### PR TITLE
Added isFloat

### DIFF
--- a/lib/CoreShop/Model/Product/Filter/Condition/Range.php
+++ b/lib/CoreShop/Model/Product/Filter/Condition/Range.php
@@ -85,13 +85,20 @@ class Range extends AbstractCondition
         $rawValues = $list->getGroupByValues($this->getField(), true);
         $script = $this->getViewScript($filter, $list, $currentFilter);
 
+        $product = [];
+        foreach (['value'] as $value) {
+            $product[$value] = array_product(array_column($rawValues, $value));
+        }
+
         $minValue = count($rawValues) > 0 ? $rawValues[0]['value'] : 0;
         $maxValue = count($rawValues) > 0 ? $rawValues[count($rawValues)-1]['value'] : 0;
+        $isFloat = count($rawValues) > 0 ? is_float($product['value']) : 0;
 
         return $this->getView()->partial($script, array(
             'label' => $this->getLabel(),
             'minValue' => $minValue,
             'maxValue' => $maxValue,
+            'isFloat' => $isFloat,
             'currentValueMin' => $currentFilter[$this->getField().'-min'] ? $currentFilter[$this->getField().'-min'] : $minValue,
             'currentValueMax' => $currentFilter[$this->getField().'-max'] ? $currentFilter[$this->getField().'-max'] : $maxValue,
             'values' => array_values($rawValues),


### PR DESCRIPTION
Adds the ability to receive the number type provided easily. Like this you can adjust your number slider's step amount, which you are using as a filter.

Sometimes you receive decimal numbers from your Pimcore object and sometimes you receive integers. Therefore you need the ability to adjust your step amount of your number slider accordingly. See code below:

```php
<input title="<?= $this->translate($this->label); ?>"
                  type="text"
                  name="<?= $this->fieldname; ?>"
                  class="range-slider span2"
                  value=""
                  id="<?= $this->fieldname; ?>Slider"
                  data-slider-id="<?= $this->fieldname; ?>Slider"
                  data-slider-min="<?= $this->minValue; ?>"
                  data-slider-max="<?= $this->maxValue; ?>"
                  data-slider-step="<?= $this->isFloat ? '0.1' : '1'; ?>"
                  data-slider-value="[<?= $this->currentValueMin; ?>, <?= $this->currentValueMax; ?>]">
```