### PR TITLE
Deprecate CoreShopAdminBundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 2.0.0-alpha-3 to 2.0.0-alpha-4
  - **BC break** decoupled MoneyBundle from CurrencyBundle, therefore the Twig Extension for Money Conversion went to the CurrencyBundle. Therefore the name of that extension was renamed from
    **coreshop_convert_money** to **coreshop_convert_currency**. If you use it directly in your code, please rename all of them.
+ - Deprecated CoreShopAdminBundle which responsability was only handling installation and deliviering pimcore resources like JS and CSS files.
+    * Installation has been moved to CoreShopCoreBundle
+    * Delivering of resources is now handled by CoreShopResourceBundle, this also makes it easier to use CoreShop Bundles without handling resources yourself.
 
 ## 2.0.0-alpha-2 to 2.0.0-alpha-3
  - **BC break** getPrice in PurchasableInterface and ProductInterface has been removed. In favor of this a new coreShopStorePrice editable has been introduced, which stores prices for each store. This makes handling of multiple currencies way more elegant.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ CoreShop is a Bundle for [Pimcore](http://www.pimcore.org). It enhances Pimcore 
     ```
  - Run Install Command
     ```php bin/console coreshop:install```
- - Activate AdminBundle in Pimcore Extension Manager
  - Optional: Install Demo Data ```php bin/console coreshop:install:demo```
 
 # Further Information

--- a/src/CoreShop/Bundle/AdminBundle/CoreShopAdminBundle.php
+++ b/src/CoreShop/Bundle/AdminBundle/CoreShopAdminBundle.php
@@ -16,6 +16,10 @@ use CoreShop\Bundle\CoreBundle\Application\Version;
 use PackageVersions\Versions;
 use Pimcore\Extension\Bundle\AbstractPimcoreBundle;
 
+/**
+ * @deprecated Don't use anymore, Responsability of this has been moved to CoreBundle instead
+ * will be removed with beta-1
+ */
 final class CoreShopAdminBundle extends AbstractPimcoreBundle
 {
     /**

--- a/src/CoreShop/Bundle/AdminBundle/Migrations/Version20171124111923.php
+++ b/src/CoreShop/Bundle/AdminBundle/Migrations/Version20171124111923.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace CoreShop\Bundle\AdminBundle\Migrations;
+
+use CoreShop\Bundle\AdminBundle\CoreShopAdminBundle;
+use Doctrine\DBAL\Schema\Schema;
+use Pimcore\Extension\Bundle\PimcoreBundleManager;
+use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+class Version20171124111923 extends AbstractPimcoreMigration implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->container->get(PimcoreBundleManager::class)->disable(CoreShopAdminBundle::class);
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+
+    }
+}

--- a/src/CoreShop/Bundle/CoreBundle/CoreShopCoreBundle.php
+++ b/src/CoreShop/Bundle/CoreBundle/CoreShopCoreBundle.php
@@ -8,19 +8,21 @@
  *
  * @copyright  Copyright (c) 2015-2017 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
  * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
-*/
+ */
 
 namespace CoreShop\Bundle\CoreBundle;
 
-use CoreShop\Bundle\CoreBundle\DependencyInjection\Compiler\RegisterCheckoutStepPass;
+use CoreShop\Bundle\CoreBundle\Application\Version;
 use CoreShop\Bundle\CoreBundle\DependencyInjection\Compiler\RegisterProductHelperPass;
 use CoreShop\Bundle\CoreBundle\DependencyInjection\Compiler\RegisterReportsPass;
 use CoreShop\Bundle\CoreBundle\DependencyInjection\Compiler\TranslatableEntityLocalePass;
 use CoreShop\Bundle\ResourceBundle\AbstractResourceBundle;
 use CoreShop\Bundle\ResourceBundle\CoreShopResourceBundle;
+use PackageVersions\Versions;
+use Pimcore\Extension\Bundle\PimcoreBundleInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-final class CoreShopCoreBundle extends AbstractResourceBundle
+final class CoreShopCoreBundle extends AbstractResourceBundle implements PimcoreBundleInterface
 {
     /**
      * {@inheritdoc}
@@ -50,5 +52,87 @@ final class CoreShopCoreBundle extends AbstractResourceBundle
     protected function getModelNamespace()
     {
         return 'CoreShop\Component\Core\Model';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNiceName()
+    {
+        return 'CoreShop - Core';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'CoreShop - Pimcore eCommerce';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getVersion()
+    {
+        return Version::getVersion() . " (" . $this->getComposerVersion() . ")";
+    }
+
+    /**
+     * @return string
+     */
+    public function getComposerVersion()
+    {
+        $version = Versions::getVersion('coreshop/core-shop');
+
+        return $version;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInstaller()
+    {
+        return $this->container->get(Installer::class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAdminIframePath()
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getJsPaths()
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCssPaths()
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEditmodeJsPaths()
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEditmodeCssPaths()
+    {
+        return [];
     }
 }

--- a/src/CoreShop/Bundle/CoreBundle/Installer.php
+++ b/src/CoreShop/Bundle/CoreBundle/Installer.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2017 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+*/
+
+namespace CoreShop\Bundle\CoreBundle;
+
+use Doctrine\DBAL\Migrations\Version;
+use Doctrine\DBAL\Schema\Schema;
+use Pimcore\Extension\Bundle\Installer\MigrationInstaller;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+
+class Installer extends MigrationInstaller
+{
+    /**
+     *
+     */
+    protected function beforeInstallMigration()
+    {
+        $kernel = \Pimcore::getKernel();
+        $application = new Application($kernel);
+        $application->setAutoExit(false);
+        $options = ['command' => 'coreshop:install'];
+        $options = array_merge($options, ['--no-interaction' => true, '--application-name coreshop']);
+        $application->run(new ArrayInput($options));
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function migrateInstall(Schema $schema, Version $version)
+    {
+
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function migrateUninstall(Schema $schema, Version $version)
+    {
+        //TODO: Uninstalling of CoreShop eg. dropping all tables
+    }
+}

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services.yml
@@ -17,6 +17,7 @@ imports:
   - { resource: "services/settings.yml" }
   - { resource: "services/cart-processor.yml" }
   - { resource: "services/reports.yml" }
+  - { resource: "services/pimcore_installer.yml" }
 
 services:
   coreshop.core.key_transformer:

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services/pimcore_installer.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services/pimcore_installer.yml
@@ -1,0 +1,10 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  CoreShop\Bundle\CoreBundle\Installer:
+    public: true
+    arguments:
+      $bundle: "@=service('kernel').getBundle('CoreShopCoreBundle')"

--- a/src/CoreShop/Bundle/CoreBundle/composer.json
+++ b/src/CoreShop/Bundle/CoreBundle/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "coreshop/core-bundle",
-  "type": "symfony-bundle",
+  "type": "pimcore-bundle",
   "description": "CoreShop - Core Bundle (Glue Bundle)",
   "keywords": [
     "coreshop",

--- a/src/CoreShop/Bundle/ResourceBundle/CoreShopResourceBundle.php
+++ b/src/CoreShop/Bundle/ResourceBundle/CoreShopResourceBundle.php
@@ -16,11 +16,16 @@ use CoreShop\Bundle\ResourceBundle\DependencyInjection\Compiler\DoctrineTargetEn
 use CoreShop\Bundle\ResourceBundle\DependencyInjection\Compiler\RegisterInstallersPass;
 use CoreShop\Bundle\ResourceBundle\DependencyInjection\Compiler\RegisterPimcoreResourcesPass;
 use CoreShop\Bundle\ResourceBundle\DependencyInjection\Compiler\RegisterResourcesPass;
+use PackageVersions\Versions;
+use Pimcore\Extension\Bundle\AbstractPimcoreBundle;
+use Pimcore\Extension\Bundle\Traits\PackageVersionTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-final class CoreShopResourceBundle extends Bundle
+final class CoreShopResourceBundle extends AbstractPimcoreBundle
 {
+    use PackageVersionTrait;
+
     const DRIVER_DOCTRINE_ORM = 'doctrine/orm';
     const DRIVER_PIMCORE = 'pimcore';
 
@@ -39,6 +44,62 @@ final class CoreShopResourceBundle extends Bundle
         $container->addCompilerPass(new RegisterPimcoreResourcesPass());
         $container->addCompilerPass(new DoctrineTargetEntitiesResolverPass());
         $container->addCompilerPass(new RegisterInstallersPass());
+    }
+
+    /**
+     * @return string
+     */
+    public function getNiceName()
+    {
+        return 'CoreShop Resource Bundle';
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return 'CoreShop ResourceBundle is a base Bundle';
+    }
+
+    /**
+     * @return string
+     */
+    public function getComposerPackageName()
+    {
+        if (isset(Versions::VERSIONS['coreshop/resource-bundle'])) {
+            return 'coreshop/resource-bundle';
+        }
+
+        return 'coreshop/core-shop';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getJsPaths()
+    {
+        $jsFiles = [];
+
+        if ($this->container->hasParameter('coreshop.application.pimcore.admin.js')) {
+            $jsFiles = $this->container->get('coreshop.resource_loader')->loadResources($this->container->getParameter('coreshop.application.pimcore.admin.js'));
+        }
+
+        return $jsFiles;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCssPaths()
+    {
+        $cssFiles = [];
+
+        if ($this->container->hasParameter('coreshop.application.pimcore.admin.css')) {
+            $cssFiles = $this->container->get('coreshop.resource_loader')->loadResources($this->container->getParameter('coreshop.application.pimcore.admin.css'));
+        }
+
+        return $cssFiles;
     }
 
     /**

--- a/src/CoreShop/Bundle/ResourceBundle/composer.json
+++ b/src/CoreShop/Bundle/ResourceBundle/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "coreshop/resource-bundle",
-  "type": "symfony-bundle",
+  "type": "pimcore-bundle",
   "description": "CoreShop - Resource Bundle",
   "keywords": [
     "coreshop",

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -239,7 +239,7 @@ try {
 $fs = new \Symfony\Component\Filesystem\Filesystem();
 $fs->mkdir($kernel->getContainer()->getParameter('kernel.project_dir').'/public');
 
-$installer = $kernel->getContainer()->get(\CoreShop\Bundle\AdminBundle\Installer::class);
+$installer = $kernel->getContainer()->get(\CoreShop\Bundle\CoreBundle\Installer::class);
 $installer->install();
 
 \Pimcore\Cache::clearAll();


### PR DESCRIPTION
This PR deprecates the CoreShopAdminBundle and moves responsability to two different places. The AdminBundle was responsible for:
 - Pimcore Installer
 - Delivering Pimcore Admin JS Resources

This is done now by CoreShopResourceBundle and CoreShopCoreBundle.

**Pimcore Installer**
Moved to CoreShopCoreBundle, the installer only calls ```coreshop:install``` command anyway

**Admin Resources**
CoreShopResourceBundle is already responsible for registration of resource paths (CSS/JS). It now is a Pimcore-Bundle and delivers the corresponding resources. This also makes it easier to use CoreShop Bundles without the suite as the Bundle delivers the resources on its own.