### PR TITLE
[FrontendBundle] make reset password url absolute

### DIFF
--- a/src/CoreShop/Bundle/FrontendBundle/Controller/RegisterController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/RegisterController.php
@@ -21,6 +21,7 @@ use CoreShop\Component\Address\Model\AddressInterface;
 use CoreShop\Component\Customer\Model\CustomerInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class RegisterController extends FrontendController
 {
@@ -97,7 +98,7 @@ class RegisterController extends FrontendController
                 $customer->setPasswordResetHash(hash('md5', $customer->getId() . $customer->getEmail() . mt_rand() . time()));
                 $customer->save();
 
-                $resetLink = $this->generateUrl('coreshop_customer_password_reset', ['token' => $customer->getPasswordResetHash()]);
+                $resetLink = $this->generateUrl('coreshop_customer_password_reset', ['token' => $customer->getPasswordResetHash()], UrlGeneratorInterface::ABSOLUTE_URL);
 
                 $dispatcher = $this->container->get('event_dispatcher');
                 $dispatcher->dispatch('coreshop.customer.request_password_reset', new RequestPasswordChangeEvent($customer, $resetLink));


### PR DESCRIPTION
The default parameter for generateUrl is UrlGeneratorInterface::ABSOLUTE_PATH, not ABSOLUTE_URL