### PR TITLE
Refactor parameter

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Command/InstallCommand.php
+++ b/src/CoreShop/Bundle/CoreBundle/Command/InstallCommand.php
@@ -93,6 +93,8 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $output->setVerbosity(OutputInterface::VERBOSITY_NORMAL);
+
         $outputStyle = new SymfonyStyle($input, $output);
         $outputStyle->writeln('<info>Installing CoreShop...</info>');
         $outputStyle->writeln($this->getCoreShopLogo());

--- a/src/CoreShop/Bundle/CoreBundle/DependencyInjection/Compiler/RegisterProductHelperPass.php
+++ b/src/CoreShop/Bundle/CoreBundle/DependencyInjection/Compiler/RegisterProductHelperPass.php
@@ -16,7 +16,7 @@ class RegisterProductHelperPass implements CompilerPassInterface
             return;
         }
 
-        $implementationId = 'coreshop.implementations.coreshop.product';
+        $implementationId = 'coreshop.implementations.product.pimcore_class_names';
         $definitionId = 'coreshop.index.class_helper.product';
 
         if ($container->hasParameter($implementationId)) {
@@ -25,9 +25,6 @@ class RegisterProductHelperPass implements CompilerPassInterface
             $implementations = $container->getParameter($implementationId);
 
             foreach ($implementations as $class) {
-                $class = str_replace('Pimcore\\Model\\DataObject\\', '', $class);
-                $class = str_replace('\\', '', $class);
-
                 $container->setDefinition($definitionId, new Definition(ProductClassHelper::class));
                 $registry->addMethodCall('register', [$class, new Reference($definitionId)]);
             }

--- a/src/CoreShop/Bundle/CoreBundle/Report/ProductsReport.php
+++ b/src/CoreShop/Bundle/CoreBundle/Report/ProductsReport.php
@@ -57,7 +57,7 @@ class ProductsReport implements ReportInterface
     /**
      * @var array
      */
-    private $productImplementations;
+    private $productImplementationsIds;
 
     /**
      * @param RepositoryInterface $storeRepository
@@ -65,7 +65,7 @@ class ProductsReport implements ReportInterface
      * @param MoneyFormatterInterface $moneyFormatter
      * @param LocaleContextInterface $localeContext
      * @param array $pimcoreClasses
-     * @param array $productImplementations
+     * @param array $productImplementationsIds
      */
     public function __construct(
         RepositoryInterface $storeRepository,
@@ -73,7 +73,7 @@ class ProductsReport implements ReportInterface
         MoneyFormatterInterface $moneyFormatter,
         LocaleContextInterface $localeContext,
         array $pimcoreClasses,
-        array $productImplementations
+        array $productImplementationsIds
     )
     {
         $this->storeRepository = $storeRepository;
@@ -81,7 +81,7 @@ class ProductsReport implements ReportInterface
         $this->moneyFormatter = $moneyFormatter;
         $this->localeContext = $localeContext;
         $this->pimcoreClasses = $pimcoreClasses;
-        $this->productImplementations = $productImplementations;
+        $this->productImplementationsIds = $productImplementationsIds;
     }
 
     /**
@@ -117,15 +117,8 @@ class ProductsReport implements ReportInterface
         }
 
         if ($objectTypeFilter === 'container') {
-
-            $objectClassArray = [];
-            foreach ($this->productImplementations as $productClass) {
-                $obj = new $productClass();
-                $objectClassArray[] = $obj->getClassId();
-            }
-
             $unionData = [];
-            foreach ($objectClassArray as $id) {
+            foreach ($this->productImplementationsIds as $id) {
                 $unionData[] = 'SELECT `o_id`, `name`, `o_type` FROM object_localized_' . $id . '_' . $locale;
             }
 

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services/reports.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services/reports.yml
@@ -18,8 +18,8 @@ services:
             - '@doctrine.dbal.default_connection'
             - '@coreshop.money_formatter'
             - '@coreshop.context.locale'
-            - '%coreshop.pimcore_class_ids%'
-            - '%coreshop.implementations.coreshop.product%'
+            - '%coreshop.pimcore_classes.ids%'
+            - '%coreshop.implementations.product.pimcore_class_ids%'
         tags:
             - { name: coreshop.report, type: products }
 
@@ -30,7 +30,7 @@ services:
             - '@doctrine.dbal.default_connection'
             - '@coreshop.money_formatter'
             - '@coreshop.context.locale'
-            - '%coreshop.pimcore_class_ids%'
+            - '%coreshop.pimcore_classes.ids%'
         tags:
             - { name: coreshop.report, type: categories }
 
@@ -40,7 +40,7 @@ services:
             - '@doctrine.dbal.default_connection'
             - '@coreshop.money_formatter'
             - '@coreshop.context.locale'
-            - '%coreshop.pimcore_class_ids%'
+            - '%coreshop.pimcore_classes.ids%'
         tags:
             - { name: coreshop.report, type: customers }
 
@@ -49,7 +49,7 @@ services:
         arguments:
             - '@coreshop.repository.store'
             - '@doctrine.dbal.default_connection'
-            - '%coreshop.pimcore_class_ids%'
+            - '%coreshop.pimcore_classes.ids%'
         tags:
             - { name: coreshop.report, type: carts }
             - { name: coreshop.portlet, type: order_cart }
@@ -59,7 +59,7 @@ services:
         arguments:
             - '@coreshop.repository.store'
             - '@doctrine.dbal.default_connection'
-            - '%coreshop.pimcore_class_ids%'
+            - '%coreshop.pimcore_classes.ids%'
         tags:
             - { name: coreshop.report, type: carts_abandoned }
 
@@ -70,7 +70,7 @@ services:
             - '@doctrine.dbal.default_connection'
             - '@coreshop.money_formatter'
             - '@coreshop.context.locale'
-            - '%coreshop.pimcore_class_ids%'
+            - '%coreshop.pimcore_classes.ids%'
         tags:
             - { name: coreshop.report, type: sales }
             - { name: coreshop.portlet, type: sales }
@@ -81,7 +81,7 @@ services:
             - '@coreshop.repository.store'
             - '@doctrine.dbal.default_connection'
             - '@coreshop.repository.carrier'
-            - '%coreshop.pimcore_class_ids%'
+            - '%coreshop.pimcore_classes.ids%'
         tags:
             - { name: coreshop.report, type: carriers }
 
@@ -91,7 +91,7 @@ services:
             - '@coreshop.repository.store'
             - '@doctrine.dbal.default_connection'
             - '@coreshop.repository.payment_provider'
-            - '%coreshop.pimcore_class_ids%'
+            - '%coreshop.pimcore_classes.ids%'
         tags:
             - { name: coreshop.report, type: payment_providers }
 
@@ -102,6 +102,6 @@ services:
             - '@doctrine.dbal.default_connection'
             - '@coreshop.money_formatter'
             - '@coreshop.context.locale'
-            - '%coreshop.pimcore_class_ids%'
+            - '%coreshop.pimcore_classes.ids%'
         tags:
             - { name: coreshop.report, type: vouchers }

--- a/src/CoreShop/Bundle/CoreBundle/Resources/public/pimcore/js/cart/pricerules/actions/giftProduct.js
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/public/pimcore/js/cart/pricerules/actions/giftProduct.js
@@ -18,11 +18,11 @@ coreshop.cart.pricerules.actions.giftProduct = Class.create(coreshop.rules.actio
         this.product = new coreshop.object.elementHref({
             id: this.data ? this.data.product : null,
             type: 'object',
-            subtype: coreshop.class_map.product
+            subtype: coreshop.class_map['coreshop.product']
         }, {
             objectsAllowed: true,
             classes: [{
-                classes: coreshop.class_map.product
+                classes: coreshop.class_map['coreshop.product']
             }],
             name: 'product',
             title: t('coreshop_action_giftProduct')

--- a/src/CoreShop/Bundle/CoreBundle/Resources/public/pimcore/js/cart/pricerules/actions/giftProduct.js
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/public/pimcore/js/cart/pricerules/actions/giftProduct.js
@@ -18,11 +18,11 @@ coreshop.cart.pricerules.actions.giftProduct = Class.create(coreshop.rules.actio
         this.product = new coreshop.object.elementHref({
             id: this.data ? this.data.product : null,
             type: 'object',
-            subtype: coreshop.class_map['coreshop.product']
+            subtype: coreshop.class_map.coreshop.product
         }, {
             objectsAllowed: true,
             classes: [{
-                classes: coreshop.class_map['coreshop.product']
+                classes: coreshop.class_map.coreshop.product
             }],
             name: 'product',
             title: t('coreshop_action_giftProduct')

--- a/src/CoreShop/Bundle/CoreBundle/Resources/public/pimcore/js/coreshop.js
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/public/pimcore/js/coreshop.js
@@ -255,7 +255,7 @@ coreshop.plugin = Class.create(pimcore.plugin.admin, {
 
         var productsMenu = [];
 
-        if (user.classes.indexOf(coreshop.class_map['coreshop.product']) >= 0) {
+        if (user.classes.indexOf(coreshop.class_map.coreshop.product) >= 0) {
             productsMenu.push({
                 text: t('coreshop_product_list'),
                 iconCls: 'coreshop_icon_product_list',
@@ -483,7 +483,7 @@ coreshop.plugin = Class.create(pimcore.plugin.admin, {
     },
 
     postOpenObject: function (tab, type) {
-        if (tab.data.general.o_className === coreshop.class_map['coreshop.cart']) {
+        if (tab.data.general.o_className === coreshop.class_map.coreshop.cart) {
             tab.toolbar.insert(tab.toolbar.items.length,
                 '-'
             );
@@ -497,9 +497,9 @@ coreshop.plugin = Class.create(pimcore.plugin.admin, {
                     }
                 }
             );*/
-        } else if (tab.data.general.o_className === coreshop.class_map['coreshop.product']) {
+        } else if (tab.data.general.o_className === coreshop.class_map.coreshop.product) {
             
-        } else if (tab.data.general.o_className === coreshop.class_map['.coreshop.order']) {
+        } else if (tab.data.general.o_className === coreshop.class_map.coreshop.order) {
             var orderMoreButtons = [];
 
             orderMoreButtons.push(
@@ -549,7 +549,7 @@ coreshop.plugin = Class.create(pimcore.plugin.admin, {
                     }
                 );
             }
-        } else if (tab.data.general.o_className === coreshop.class_map['coreshop.order_invoice']) {
+        } else if (tab.data.general.o_className === coreshop.class_map.coreshop.order_invoice) {
             var resetChangesFunction = tab.resetChanges;
 
             var renderTab = new coreshop.invoice.render(tab);
@@ -561,7 +561,7 @@ coreshop.plugin = Class.create(pimcore.plugin.admin, {
 
                 renderTab.reload();
             };
-        } else if (tab.data.general.o_className === coreshop.class_map['coreshop.order_shipment']) {
+        } else if (tab.data.general.o_className === coreshop.class_map.coreshop.order_shipment) {
             var resetChangesFunction = tab.resetChanges;
 
             var renderTab = new coreshop.shipment.render(tab);

--- a/src/CoreShop/Bundle/CoreBundle/Resources/public/pimcore/js/coreshop.js
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/public/pimcore/js/coreshop.js
@@ -255,7 +255,7 @@ coreshop.plugin = Class.create(pimcore.plugin.admin, {
 
         var productsMenu = [];
 
-        if (user.classes.indexOf(coreshop.class_map.product) >= 0) {
+        if (user.classes.indexOf(coreshop.class_map['coreshop.product']) >= 0) {
             productsMenu.push({
                 text: t('coreshop_product_list'),
                 iconCls: 'coreshop_icon_product_list',
@@ -483,7 +483,7 @@ coreshop.plugin = Class.create(pimcore.plugin.admin, {
     },
 
     postOpenObject: function (tab, type) {
-        if (tab.data.general.o_className === coreshop.class_map.cart) {
+        if (tab.data.general.o_className === coreshop.class_map['coreshop.cart']) {
             tab.toolbar.insert(tab.toolbar.items.length,
                 '-'
             );
@@ -497,9 +497,9 @@ coreshop.plugin = Class.create(pimcore.plugin.admin, {
                     }
                 }
             );*/
-        } else if (tab.data.general.o_className === coreshop.class_map.product) {
+        } else if (tab.data.general.o_className === coreshop.class_map['coreshop.product']) {
             
-        } else if (tab.data.general.o_className === coreshop.class_map.order) {
+        } else if (tab.data.general.o_className === coreshop.class_map['.coreshop.order']) {
             var orderMoreButtons = [];
 
             orderMoreButtons.push(
@@ -549,7 +549,7 @@ coreshop.plugin = Class.create(pimcore.plugin.admin, {
                     }
                 );
             }
-        } else if (tab.data.general.o_className === coreshop.class_map.order_invoice) {
+        } else if (tab.data.general.o_className === coreshop.class_map['coreshop.order_invoice']) {
             var resetChangesFunction = tab.resetChanges;
 
             var renderTab = new coreshop.invoice.render(tab);
@@ -561,7 +561,7 @@ coreshop.plugin = Class.create(pimcore.plugin.admin, {
 
                 renderTab.reload();
             };
-        } else if (tab.data.general.o_className === coreshop.class_map.order_shipment) {
+        } else if (tab.data.general.o_className === coreshop.class_map['coreshop.order_shipment']) {
             var resetChangesFunction = tab.resetChanges;
 
             var renderTab = new coreshop.shipment.render(tab);

--- a/src/CoreShop/Bundle/CoreBundle/Resources/public/pimcore/js/helpers.js
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/public/pimcore/js/helpers.js
@@ -34,7 +34,7 @@ coreshop.helpers.createOrder = function () {
                 object: ['object']
             },
             specific: {
-                classes: [coreshop.class_map.customer]
+                classes: [coreshop.class_map['coreshop.customer']]
             }
         }
     );

--- a/src/CoreShop/Bundle/CoreBundle/Resources/public/pimcore/js/helpers.js
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/public/pimcore/js/helpers.js
@@ -34,7 +34,7 @@ coreshop.helpers.createOrder = function () {
                 object: ['object']
             },
             specific: {
-                classes: [coreshop.class_map['coreshop.customer']]
+                classes: [coreshop.class_map.coreshop.customer]
             }
         }
     );

--- a/src/CoreShop/Bundle/CoreBundle/Resources/public/pimcore/js/shipping/rules/conditions/categories.js
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/public/pimcore/js/shipping/rules/conditions/categories.js
@@ -18,7 +18,7 @@ coreshop.shippingrule.conditions.categories = Class.create(coreshop.rules.condit
 
     getForm: function () {
         this.categories = new coreshop.object.objectMultihref(this.data ? this.data.categories : [], {
-            classes: this.getFormattedImplementationsClasses(coreshop.implementations['coreshop.category']),
+            classes: this.getFormattedImplementationsClasses(coreshop.implementations.coreshop.category),
             name: 'categories',
             title: '',
             height: 200,

--- a/src/CoreShop/Bundle/CoreBundle/Resources/public/pimcore/js/shipping/rules/conditions/customerGroups.js
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/public/pimcore/js/shipping/rules/conditions/customerGroups.js
@@ -18,7 +18,7 @@ coreshop.shippingrule.conditions.customerGroups = Class.create(coreshop.rules.co
 
     getForm: function () {
         this.customerGroups = new coreshop.object.objectMultihref(this.data ? this.data.customerGroups : [], {
-            classes: this.getFormattedImplementationsClasses(coreshop.implementations['coreshop.customer_group']),
+            classes: this.getFormattedImplementationsClasses(coreshop.implementations-coreshop.customer_group),
             name: 'customerGroups',
             title: '',
             height: 200,

--- a/src/CoreShop/Bundle/CoreBundle/Resources/public/pimcore/js/shipping/rules/conditions/customerGroups.js
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/public/pimcore/js/shipping/rules/conditions/customerGroups.js
@@ -18,7 +18,7 @@ coreshop.shippingrule.conditions.customerGroups = Class.create(coreshop.rules.co
 
     getForm: function () {
         this.customerGroups = new coreshop.object.objectMultihref(this.data ? this.data.customerGroups : [], {
-            classes: this.getFormattedImplementationsClasses(coreshop.implementations-coreshop.customer_group),
+            classes: this.getFormattedImplementationsClasses(coreshop.implementations.coreshop.customer_group),
             name: 'customerGroups',
             title: '',
             height: 200,

--- a/src/CoreShop/Bundle/CoreBundle/Resources/public/pimcore/js/shipping/rules/conditions/customers.js
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/public/pimcore/js/shipping/rules/conditions/customers.js
@@ -18,7 +18,7 @@ coreshop.shippingrule.conditions.customers = Class.create(coreshop.rules.conditi
 
     getForm: function () {
         this.customers = new coreshop.object.objectMultihref(this.data ? this.data.customers : [], {
-            classes: this.getFormattedImplementationsClasses(coreshop.implementations['coreshop.customer']),
+            classes: this.getFormattedImplementationsClasses(coreshop.implementations.coreshop.customer),
             name: 'customers',
             title: '',
             height: 200,

--- a/src/CoreShop/Bundle/CoreBundle/Resources/public/pimcore/js/shipping/rules/conditions/products.js
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/public/pimcore/js/shipping/rules/conditions/products.js
@@ -18,7 +18,7 @@ coreshop.shippingrule.conditions.products = Class.create(coreshop.rules.conditio
 
     getForm: function () {
         this.products = new coreshop.object.objectMultihref(this.data ? this.data.products : [], {
-            classes: this.getFormattedImplementationsClasses(coreshop.implementations['coreshop.product']),
+            classes: this.getFormattedImplementationsClasses(coreshop.implementations.coreshop.product),
             name: 'products',
             title: '',
             height: 200,

--- a/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/order/list.js
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/order/list.js
@@ -19,7 +19,7 @@ coreshop.order.order.list = Class.create(coreshop.order.sale.list, {
             function (id) {
                 this.open(id);
             }.bind(this),
-            [coreshop.class_map['order']]
+            [coreshop.class_map['coreshop.order']]
         );
     },
 

--- a/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/order/list.js
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/order/list.js
@@ -19,7 +19,7 @@ coreshop.order.order.list = Class.create(coreshop.order.sale.list, {
             function (id) {
                 this.open(id);
             }.bind(this),
-            [coreshop.class_map['coreshop.order']]
+            [coreshop.class_map.coreshop.order]
         );
     },
 

--- a/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/quote/list.js
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/quote/list.js
@@ -19,7 +19,7 @@ coreshop.order.quote.list = Class.create(coreshop.order.sale.list, {
             function (id) {
                 this.open(id);
             }.bind(this),
-            [coreshop.class_map['quote']]
+            [coreshop.class_map['coreshop.quote']]
         );
     },
 

--- a/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/quote/list.js
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/quote/list.js
@@ -19,7 +19,7 @@ coreshop.order.quote.list = Class.create(coreshop.order.sale.list, {
             function (id) {
                 this.open(id);
             }.bind(this),
-            [coreshop.class_map['coreshop.quote']]
+            [coreshop.class_map.coreshop.quote]
         );
     },
 

--- a/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/sale/create/panel.js
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/sale/create/panel.js
@@ -53,7 +53,7 @@ coreshop.order.sale.create.panel = Class.create({
                     object: ['object']
                 },
                 specific: {
-                    classes: coreshop.implementations['coreshop.customer']
+                    classes: coreshop.implementations.coreshop.customer
                 }
             }
         );

--- a/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/sale/create/step/products.js
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/sale/create/step/products.js
@@ -209,7 +209,7 @@ coreshop.order.sale.create.step.products = Class.create(coreshop.order.sale.crea
                                 object: ['object', 'variant']
                             },
                             specific: {
-                                classes: coreshop.implementations['coreshop.product']
+                                classes: coreshop.implementations.coreshop.product
                             }
                         }
                     );

--- a/src/CoreShop/Bundle/ProductBundle/Resources/public/pimcore/js/product/pricerule/conditions/categories.js
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/public/pimcore/js/product/pricerule/conditions/categories.js
@@ -18,7 +18,7 @@ coreshop.product.pricerule.conditions.categories = Class.create(coreshop.rules.c
 
     getForm: function () {
         this.categories = new coreshop.object.objectMultihref(this.data ? this.data.categories : [], {
-            classes: this.getFormattedImplementationsClasses(coreshop.implementations['coreshop.category']),
+            classes: this.getFormattedImplementationsClasses(coreshop.implementations.coreshop.category),
             name: 'categories',
             title: '',
             height: 200,

--- a/src/CoreShop/Bundle/ProductBundle/Resources/public/pimcore/js/product/pricerule/conditions/products.js
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/public/pimcore/js/product/pricerule/conditions/products.js
@@ -18,7 +18,7 @@ coreshop.product.pricerule.conditions.products = Class.create(coreshop.rules.con
 
     getForm: function () {
         this.products = new coreshop.object.objectMultihref(this.data ? this.data.products : [], {
-            classes: this.getFormattedImplementationsClasses(coreshop.implementations['coreshop.product']),
+            classes: this.getFormattedImplementationsClasses(coreshop.implementations.coreshop.product),
             name: 'products',
             title: '',
             height: 200,

--- a/src/CoreShop/Bundle/ResourceBundle/Controller/ResourceSettingsController.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Controller/ResourceSettingsController.php
@@ -48,28 +48,28 @@ class ResourceSettingsController extends AdminController
             'implementations' => []
         ];
 
-        if ($this->container->hasParameter('coreshop.pimcore.classes')) {
-            $classes = $this->getParameter('coreshop.pimcore.classes');
+        if ($this->container->hasParameter('coreshop.all.pimcore_classes')) {
+            $classes = $this->getParameter('coreshop.all.pimcore_classes');
 
             foreach ($classes as $key => $definition) {
                 $alias = explode('.', $key);
+                $application = $alias[0];
                 $alias = $alias[1];
 
                 $class = str_replace('Pimcore\\Model\\DataObject\\', '', $definition['classes']['model']);
                 $class = str_replace('\\', '', $class);
 
-                $config['classMap'][$alias] = $class;
+                $config['classMap'][$application][$alias] = $class;
             }
 
-            $implementations = $this->container->getParameter('coreshop.implementations.classes');
+            $implementations = $this->container->getParameter('coreshop.all.implementations.pimcore_class_names');
 
-            foreach ($implementations as $implementationKey => $classes) {
-                foreach ($classes as $class) {
-                    $class = str_replace('Pimcore\\Model\\DataObject\\', '', $class);
-                    $class = str_replace('\\', '', $class);
+            foreach ($implementations as $key => $impl) {
+                $alias = explode('.', $key);
+                $application = $alias[0];
+                $alias = $alias[1];
 
-                    $config['implementations'][$implementationKey][] = $class;
-                }
+                $config['implementations'][$application][$alias] = $impl;
             }
         }
 

--- a/src/CoreShop/Bundle/ResourceBundle/CoreShopResourceBundle.php
+++ b/src/CoreShop/Bundle/ResourceBundle/CoreShopResourceBundle.php
@@ -82,8 +82,8 @@ final class CoreShopResourceBundle extends AbstractPimcoreBundle
     {
         $jsFiles = [];
 
-        if ($this->container->hasParameter('resources.admin.js')) {
-            $jsFiles = $this->container->get('coreshop.resource_loader')->loadResources($this->container->getParameter('resources.admin.js'));
+        if ($this->container->hasParameter('coreshop.all.pimcore.admin.js')) {
+            $jsFiles = $this->container->get('coreshop.resource_loader')->loadResources($this->container->getParameter('coreshop.all.pimcore.admin.js'));
         }
 
         return $jsFiles;
@@ -96,8 +96,8 @@ final class CoreShopResourceBundle extends AbstractPimcoreBundle
     {
         $cssFiles = [];
 
-        if ($this->container->hasParameter('resources.admin.css')) {
-            $cssFiles = $this->container->get('coreshop.resource_loader')->loadResources($this->container->getParameter('resources.admin.css'));
+        if ($this->container->hasParameter('coreshop.all.pimcore.admin.css')) {
+            $cssFiles = $this->container->get('coreshop.resource_loader')->loadResources($this->container->getParameter('coreshop.all.pimcore.admin.css'));
         }
 
         return $cssFiles;

--- a/src/CoreShop/Bundle/ResourceBundle/DependencyInjection/Compiler/RegisterPimcoreResourcesPass.php
+++ b/src/CoreShop/Bundle/ResourceBundle/DependencyInjection/Compiler/RegisterPimcoreResourcesPass.php
@@ -25,7 +25,7 @@ final class RegisterPimcoreResourcesPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         try {
-            $resources = $container->getParameter('coreshop.pimcore');
+            $resources = $container->getParameter('coreshop.all.pimcore_classes');
             $registry = $container->findDefinition('coreshop.resource_registry');
         } catch (InvalidArgumentException $exception) {
             return;
@@ -62,10 +62,10 @@ final class RegisterPimcoreResourcesPass implements CompilerPassInterface
         }
 
         foreach ($applicationClasses as $applicationName => $values) {
-            $container->setParameter(sprintf('%s.pimcore_class_ids', $applicationName), $values);
+            $container->setParameter(sprintf('%s.pimcore_classes.ids', $applicationName), $values);
         }
 
-        $container->setParameter('coreshop.resource.pimcore_class_ids', $pimcoreClasses);
+        $container->setParameter('coreshop.all.pimcore_classes.ids', $pimcoreClasses);
     }
 
     /**

--- a/src/CoreShop/Bundle/ResourceBundle/DependencyInjection/CoreShopResourceExtension.php
+++ b/src/CoreShop/Bundle/ResourceBundle/DependencyInjection/CoreShopResourceExtension.php
@@ -47,8 +47,8 @@ final class CoreShopResourceExtension extends AbstractModelExtension implements 
             $container->setParameter('coreshop.state_machine.colors', $config['state_machine']['colors']);
         }
 
-        if (!$container->hasParameter('coreshop.pimcore')) {
-            $container->setParameter('coreshop.pimcore', []);
+        if (!$container->hasParameter('coreshop.all.pimcore_classes')) {
+            $container->setParameter('coreshop.all.pimcore_classes', []);
         }
 
         if (!$container->hasParameter('coreshop.state_machine.callbacks')) {

--- a/src/CoreShop/Bundle/ResourceBundle/DependencyInjection/Extension/AbstractModelExtension.php
+++ b/src/CoreShop/Bundle/ResourceBundle/DependencyInjection/Extension/AbstractModelExtension.php
@@ -136,7 +136,7 @@ abstract class AbstractModelExtension extends Extension
             $applicationPermissions = [];
             $applicationParameter = sprintf('%s.permissions', $applicationName);
             $resourcePermissions = [];
-            $globalParameter = sprintf('coreshop.resource.permissions', $applicationName);
+            $globalParameter = sprintf('coreshop.all.permissions', $applicationName);
 
             if ($container->hasParameter($applicationParameter)) {
                 $applicationPermissions = $container->getParameter($applicationParameter);

--- a/src/CoreShop/Bundle/ResourceBundle/DependencyInjection/Extension/AbstractModelExtension.php
+++ b/src/CoreShop/Bundle/ResourceBundle/DependencyInjection/Extension/AbstractModelExtension.php
@@ -71,7 +71,7 @@ abstract class AbstractModelExtension extends Extension
             $alias = $applicationName . '.' . $modelName;
             $modelConfig = array_merge(['driver' => 'pimcore', 'alias' => $this->getAlias()], $modelConfig);
 
-            foreach (['coreshop.pimcore', sprintf('%s.pimcore.classes', $applicationName)] as $parameter) {
+            foreach (['coreshop.all.pimcore_classes', sprintf('%s.pimcore_classes', $applicationName)] as $parameter) {
                 $models = $container->hasParameter($parameter) ? $container->getParameter($parameter) : [];
                 $models = array_merge($models, [$alias => $modelConfig]);
                 $container->setParameter($parameter, $models);
@@ -94,12 +94,12 @@ abstract class AbstractModelExtension extends Extension
 
         foreach ($resourceTypes as $resourceType) {
             if (array_key_exists($resourceType, $bundleResources)) {
-                $applicationParameter = sprintf('%s.application.pimcore.admin.%s', $applicationName, $resourceType);
-                $aliasParameter = sprintf('%s.pimcore.admin.%s', $this->getAlias(), $resourceType);
-                $globalParameter = sprintf('resources.admin.%s', $resourceType);
+                $applicationParameter = sprintf('%s.pimcore.admin.%s', $applicationName, $resourceType);
+                //$aliasParameter = sprintf('%s.pimcore.admin.%s', $this->getAlias(), $resourceType);
+                $globalParameter = sprintf('coreshop.all.pimcore.admin.%s', $resourceType);
 
                 $parameters = [
-                    $applicationParameter, $aliasParameter, $globalParameter
+                    $applicationParameter, $globalParameter
                 ];
 
                 foreach ($parameters as $containerParameter) {
@@ -116,11 +116,11 @@ abstract class AbstractModelExtension extends Extension
 
         if (array_key_exists('install', $bundleResources)) {
             foreach ($bundleResources['install'] as $type => $value) {
-                $applicationParameter = sprintf('%s.application.pimcore.admin.install.%s', $applicationName, $type);
-                $aliasParameter = sprintf('%s.pimcore.admin.install.%s', $this->getAlias(), $type);
-                $globalParameter = sprintf('resources.admin.install.%s', $type);
+                $applicationParameter = sprintf('%s.pimcore.admin.install.%s', $applicationName, $type);
+                //$aliasParameter = sprintf('%s.pimcore.admin.install.%s', $this->getAlias(), $type);
+                $globalParameter = sprintf('coreshop.all.pimcore.admin.install.%s', $type);
 
-                foreach ([$applicationParameter, $aliasParameter, $globalParameter] as $containerParameter) {
+                foreach ([$applicationParameter, $globalParameter] as $containerParameter) {
                     $resources = [];
 
                     if ($container->hasParameter($containerParameter)) {
@@ -167,8 +167,8 @@ abstract class AbstractModelExtension extends Extension
      */
     public function registerImplementations($applicationName, $implementations, ContainerBuilder $container)
     {
-        $appParameterName = sprintf('%s.coreshop.application.implementations', $applicationName);
-        $globalParameterName = 'coreshop.implementations';
+        $appParameterName = sprintf('%s.implementations', $applicationName);
+        $globalParameterName = 'coreshop.all.implementations';
 
         foreach ([$appParameterName, $globalParameterName] as $parameterName) {
             $implementationsConfig = $container->hasParameter($parameterName) ? $container->getParameter($parameterName) : [];

--- a/src/CoreShop/Bundle/ResourceBundle/Installer/PimcoreAdminTranslationsInstaller.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Installer/PimcoreAdminTranslationsInstaller.php
@@ -19,6 +19,6 @@ final class PimcoreAdminTranslationsInstaller extends AbstractTranslationInstall
      */
     protected function getIdentifier($applicationName = null)
     {
-        return $applicationName ? sprintf('%s.application.pimcore.admin.install.admin_translations', $applicationName) : 'resources.admin.install.admin_translations';
+        return $applicationName ? sprintf('%s.pimcore.admin.install.admin_translations', $applicationName) : 'coreshop.all.pimcore.admin.install.admin_translations';
     }
 }

--- a/src/CoreShop/Bundle/ResourceBundle/Installer/PimcoreClassInstaller.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Installer/PimcoreClassInstaller.php
@@ -48,7 +48,7 @@ final class PimcoreClassInstaller implements ResourceInstallerInterface
      */
     public function installResources(OutputInterface $output, $applicationName = null)
     {
-        $parameter = $applicationName ? sprintf('%s.pimcore.classes', $applicationName) : 'coreshop.pimcore';
+        $parameter = $applicationName ? sprintf('%s.pimcore_classes', $applicationName) : 'coreshop.all.pimcore_classes';
 
         if ($this->kernel->getContainer()->hasParameter($parameter)) {
             $pimcoreClasses = $this->kernel->getContainer()->getParameter($parameter);

--- a/src/CoreShop/Bundle/ResourceBundle/Installer/PimcoreDocumentsInstaller.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Installer/PimcoreDocumentsInstaller.php
@@ -41,7 +41,7 @@ final class PimcoreDocumentsInstaller implements ResourceInstallerInterface
      */
     public function installResources(OutputInterface $output, $applicationName = null)
     {
-        $parameter = $applicationName ? sprintf('%s.application.pimcore.admin.install.documents', $applicationName) : 'resources.admin.install.documents';
+        $parameter = $applicationName ? sprintf('%s.pimcore.admin.install.documents', $applicationName) : 'coreshop.all.pimcore.admin.install.documents';
 
         if ($this->kernel->getContainer()->hasParameter($parameter)) {
             $documentFilesToInstall = $this->kernel->getContainer()->getParameter($parameter);

--- a/src/CoreShop/Bundle/ResourceBundle/Installer/PimcoreGridConfigInstaller.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Installer/PimcoreGridConfigInstaller.php
@@ -58,7 +58,7 @@ final class PimcoreGridConfigInstaller implements ResourceInstallerInterface
      */
     public function installResources(OutputInterface $output, $applicationName = null)
     {
-        $parameter = $applicationName ? sprintf('%s.application.pimcore.admin.install.grid_config', $applicationName) : 'resources.admin.install.grid_config';
+        $parameter = $applicationName ? sprintf('%s.pimcore.admin.install.grid_config', $applicationName) : 'coreshop.all.pimcore.admin.install.grid_config';
 
         if ($this->kernel->getContainer()->hasParameter($parameter)) {
             $routeFilesToInstall = $this->kernel->getContainer()->getParameter($parameter);

--- a/src/CoreShop/Bundle/ResourceBundle/Installer/PimcoreImageThumbnailsInstaller.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Installer/PimcoreImageThumbnailsInstaller.php
@@ -40,7 +40,7 @@ final class PimcoreImageThumbnailsInstaller implements ResourceInstallerInterfac
      */
     public function installResources(OutputInterface $output, $applicationName = null)
     {
-        $parameter = $applicationName ? sprintf('%s.application.pimcore.admin.install.image_thumbnails', $applicationName) : 'resources.admin.install.image_thumbnails';
+        $parameter = $applicationName ? sprintf('%s.pimcore.admin.install.image_thumbnails', $applicationName) : 'coreshop.all.pimcore.admin.install.image_thumbnails';
 
         if ($this->kernel->getContainer()->hasParameter($parameter)) {
             $thumbnailFilesToInstall = $this->kernel->getContainer()->getParameter($parameter);

--- a/src/CoreShop/Bundle/ResourceBundle/Installer/PimcorePermissionInstaller.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Installer/PimcorePermissionInstaller.php
@@ -37,7 +37,7 @@ final class PimcorePermissionInstaller implements ResourceInstallerInterface
      */
     public function installResources(OutputInterface $output, $applicationName = null)
     {
-        $parameter = $applicationName ? sprintf('%s.permissions', $applicationName) : 'coreshop.resource.permissions';
+        $parameter = $applicationName ? sprintf('%s.permissions', $applicationName) : 'coreshop.all.permissions';
 
         if ($this->kernel->getContainer()->hasParameter($parameter)) {
             $permissions = $this->kernel->getContainer()->getParameter($parameter);

--- a/src/CoreShop/Bundle/ResourceBundle/Installer/PimcoreRoutesInstaller.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Installer/PimcoreRoutesInstaller.php
@@ -40,7 +40,7 @@ final class PimcoreRoutesInstaller implements ResourceInstallerInterface
      */
     public function installResources(OutputInterface $output, $applicationName = null)
     {
-        $parameter = $applicationName ? sprintf('%s.application.pimcore.admin.install.routes', $applicationName) : 'resources.admin.install.routes';
+        $parameter = $applicationName ? sprintf('%s.pimcore.admin.install.routes', $applicationName) : 'coreshop.all.pimcore.admin.install.routes';
 
         if ($this->kernel->getContainer()->hasParameter($parameter)) {
             $routeFilesToInstall = $this->kernel->getContainer()->getParameter($parameter);

--- a/src/CoreShop/Bundle/ResourceBundle/Installer/PimcoreSharedTranslationsInstaller.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Installer/PimcoreSharedTranslationsInstaller.php
@@ -19,6 +19,6 @@ final class PimcoreSharedTranslationsInstaller extends AbstractTranslationInstal
      */
     protected function getIdentifier($applicationName = null)
     {
-        return $applicationName ? sprintf('%s.application.pimcore.admin.install.translations', $applicationName) : 'resources.admin.install.translations';
+        return $applicationName ? sprintf('%s.pimcore.admin.install.translations', $applicationName) : 'coreshop.all.pimcore.admin.install.translations';
     }
 }

--- a/src/CoreShop/Bundle/ResourceBundle/Installer/SqlInstaller.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Installer/SqlInstaller.php
@@ -37,7 +37,7 @@ final class SqlInstaller implements ResourceInstallerInterface
      */
     public function installResources(OutputInterface $output, $applicationName = null)
     {
-        $parameter = $applicationName ? sprintf('%s.application.pimcore.admin.install.sql', $applicationName) : 'resources.admin.install.sql';
+        $parameter = $applicationName ? sprintf('%s.pimcore.admin.install.sql', $applicationName) : 'coreshop.all.pimcore.admin.install.sql';
 
         if ($this->kernel->getContainer()->hasParameter($parameter)) {
             $sqlFilesToExecute = $this->kernel->getContainer()->getParameter($parameter);

--- a/src/CoreShop/Bundle/ResourceBundle/Resources/config/services/commands.yml
+++ b/src/CoreShop/Bundle/ResourceBundle/Resources/config/services/commands.yml
@@ -3,7 +3,7 @@ services:
         class: CoreShop\Bundle\ResourceBundle\Command\CreateObjectClassCommand
         arguments:
             - '@kernel'
-            - '%coreshop.pimcore%'
+            - '%coreshop.all.pimcore_classes%'
         tags:
             - { name: console.command, command: 'coreshop:generate:class' }
 

--- a/src/CoreShop/Bundle/ResourceBundle/Resources/config/services/installer.yml
+++ b/src/CoreShop/Bundle/ResourceBundle/Resources/config/services/installer.yml
@@ -68,7 +68,7 @@ services:
         class: CoreShop\Bundle\ResourceBundle\Installer\PimcoreGridConfigInstaller
         arguments:
             - '@kernel'
-            - '%coreshop.resource.pimcore_class_ids%'
+            - '%coreshop.all.pimcore_classes.ids%'
             - '@coreshop.grid_config_installer'
         tags:
             - { name: 'coreshop.resource.installer', type: 'grid_config', priority: 200}


### PR DESCRIPTION
This is a internal refactor and changes the naming of parameters.

all application specific parameters now start with the application name ```%applicationName%.implementations``` there is one parameter where all 'implementations' can be found ```coreshop.all.implementations```. This is also valid for:
 - Installable Resource like routes/permissions/layouts (```%applicationName%.pimcore.admin.install.%type%```, ```coreshop.all.pimcore.admin.install.%type%```)
 - JS/CSS Resources (```%applicationName%.pimcore.admin.%type%```, ```coreshop.all.pimcore.admin.%type%```)
 - Implementations
 - Classes (```coreshop.all.pimcore_classes```, ```%applicationName.pimcore_classes```
 - Class Ids (```coreshop.all.pimcore_classes.ids```, ```%applicationName%.pimcore_classes.ids```)