### PR TITLE
CustomerAndStoreBasedCartContext should only get applied in login route

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/EventListener/CartBlamerListener.php
+++ b/src/CoreShop/Bundle/CoreBundle/EventListener/CartBlamerListener.php
@@ -17,7 +17,6 @@ use CoreShop\Component\Customer\Model\CustomerInterface;
 use CoreShop\Component\Order\Context\CartContextInterface;
 use CoreShop\Component\Order\Manager\CartManagerInterface;
 use CoreShop\Component\Order\Model\CartInterface;
-use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 
 final class CartBlamerListener

--- a/src/CoreShop/Bundle/OrderBundle/Context/CustomerAndStoreBasedCartContext.php
+++ b/src/CoreShop/Bundle/OrderBundle/Context/CustomerAndStoreBasedCartContext.php
@@ -19,6 +19,7 @@ use CoreShop\Component\Order\Context\CartNotFoundException;
 use CoreShop\Component\Order\Repository\CartRepositoryInterface;
 use CoreShop\Component\Store\Context\StoreContextInterface;
 use CoreShop\Component\Store\Context\StoreNotFoundException;
+use Pimcore\Http\RequestHelper;
 
 final class CustomerAndStoreBasedCartContext implements CartContextInterface
 {
@@ -38,19 +39,27 @@ final class CustomerAndStoreBasedCartContext implements CartContextInterface
     private $cartRepository;
 
     /**
+     * @var RequestHelper
+     */
+    private $pimcoreRequestHelper;
+
+    /**
      * @param CustomerContextInterface $customerContext
      * @param StoreContextInterface $storeContext
      * @param CartRepositoryInterface $cartRepository
+     * @param RequestHelper $pimcoreRequestHelper
      */
     public function __construct(
         CustomerContextInterface $customerContext,
         StoreContextInterface $storeContext,
-        CartRepositoryInterface $cartRepository
+        CartRepositoryInterface $cartRepository,
+        RequestHelper $pimcoreRequestHelper
     )
     {
         $this->customerContext = $customerContext;
         $this->storeContext = $storeContext;
         $this->cartRepository = $cartRepository;
+        $this->pimcoreRequestHelper = $pimcoreRequestHelper;
     }
 
     /**
@@ -58,6 +67,14 @@ final class CustomerAndStoreBasedCartContext implements CartContextInterface
      */
     public function getCart()
     {
+        if(!$this->pimcoreRequestHelper->hasMasterRequest()) {
+            throw new CartNotFoundException('CustomerAndStoreBasedCartContext needs a valid master request.');
+        }
+
+        if($this->pimcoreRequestHelper->getMasterRequest()->get('_route') !== 'coreshop_login_check') {
+            throw new CartNotFoundException('CustomerAndStoreBasedCartContext can only be applied in coreshop_login_check route.');
+        }
+
         try {
             $store = $this->storeContext->getStore();
         } catch (StoreNotFoundException $exception) {

--- a/src/CoreShop/Bundle/OrderBundle/Context/CustomerAndStoreBasedCartContext.php
+++ b/src/CoreShop/Bundle/OrderBundle/Context/CustomerAndStoreBasedCartContext.php
@@ -67,12 +67,10 @@ final class CustomerAndStoreBasedCartContext implements CartContextInterface
      */
     public function getCart()
     {
-        if(!$this->pimcoreRequestHelper->hasMasterRequest()) {
-            throw new CartNotFoundException('CustomerAndStoreBasedCartContext needs a valid master request.');
-        }
-
-        if($this->pimcoreRequestHelper->getMasterRequest()->get('_route') !== 'coreshop_login_check') {
-            throw new CartNotFoundException('CustomerAndStoreBasedCartContext can only be applied in coreshop_login_check route.');
+        if($this->pimcoreRequestHelper->hasMasterRequest()) {
+            if($this->pimcoreRequestHelper->getMasterRequest()->get('_route') !== 'coreshop_login_check') {
+                throw new CartNotFoundException('CustomerAndStoreBasedCartContext can only be applied in coreshop_login_check route.');
+            }
         }
 
         try {

--- a/src/CoreShop/Bundle/OrderBundle/Resources/config/services/context.yml
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/config/services/context.yml
@@ -10,6 +10,7 @@ services:
             - '@coreshop.context.customer'
             - '@coreshop.context.store'
             - '@coreshop.repository.cart'
+            - '@pimcore.http.request_helper'
         tags:
             - { name: coreshop.context.cart, priority: -777 }
 


### PR DESCRIPTION
This PR will untangle the cart context behaviour. After a order has been placed, `CustomerAndStoreBasedCartContext` will search again for a cart, based on the current user. If a User comes back from a unfinished order for example, a older cart gets applied to user, even if the customer is still in a order process.

With those changes, `CustomerAndStoreBasedCartContext` only tries to find a mapping cart after a user successfully logged in.