### PR TITLE
[FrontendBundle] Template Configurator 

### DIFF
--- a/src/CoreShop/Bundle/FrontendBundle/Controller/CartController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/CartController.php
@@ -36,7 +36,7 @@ class CartController extends FrontendController
      */
     public function widgetAction(Request $request)
     {
-        return $this->renderTemplate('CoreShopFrontendBundle:Cart:_widget.html.twig', [
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Cart/_widget.html'), [
             'cart' => $this->getCart(),
         ]);
     }
@@ -60,7 +60,7 @@ class CartController extends FrontendController
 
                 if (!$voucherCode instanceof CartPriceRuleVoucherCodeInterface) {
                     $this->addFlash('error', 'coreshop.ui.error.voucher.not_found');
-                    return $this->renderTemplate('CoreShopFrontendBundle:Cart:summary.html.twig', [
+                    return $this->renderTemplate($this->templateConfigurator->findTemplate('Cart/summary.html'), [
                         'cart' => $this->getCart(),
                         'form' => $form->createView()
                     ]);
@@ -74,7 +74,7 @@ class CartController extends FrontendController
 
                     if ($rule->getId() === $voucherCode->getCartPriceRule()->getId()) {
                         $this->addFlash('error', 'coreshop.ui.error.voucher.invalid');
-                        return $this->renderTemplate('CoreShopFrontendBundle:Cart:summary.html.twig', [
+                        return $this->renderTemplate($this->templateConfigurator->findTemplate('Cart/summary.html'), [
                             'cart' => $this->getCart(),
                             'form' => $form->createView()
                         ]);
@@ -101,7 +101,7 @@ class CartController extends FrontendController
             }
         }
 
-        return $this->renderTemplate('CoreShopFrontendBundle:Cart:summary.html.twig', [
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Cart/summary.html'), [
             'cart' => $cart,
             'form' => $form->createView()
         ]);

--- a/src/CoreShop/Bundle/FrontendBundle/Controller/CategoryController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/CategoryController.php
@@ -59,7 +59,7 @@ class CategoryController extends FrontendController
     {
         $categories = $this->getRepository()->findForStore($this->getContext()->getStore());
 
-        return $this->renderTemplate('CoreShopFrontendBundle:Category:_menu.html.twig', [
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Category/_menu.html'), [
             'categories' => $categories,
         ]);
     }
@@ -79,7 +79,7 @@ class CategoryController extends FrontendController
             $activeSubCategories = $this->getRepository()->findChildCategoriesForStore($activeCategory, $this->getContext()->getStore());
         }
 
-        return $this->renderTemplate('CoreShopFrontendBundle:Category:_menu-left.html.twig', [
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Category/_menu-left.html'), [
             'categories' => $firstLevelCategories,
             'activeCategory' => $activeCategory,
             'activeSubCategories' => $activeSubCategories
@@ -202,7 +202,7 @@ class CategoryController extends FrontendController
             $this->get('coreshop.tracking.manager')->trackPurchasableImpression($product);
         }
 
-        return $this->renderTemplate('CoreShopFrontendBundle:Category:index.html.twig', $viewParameters);
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Category/index.html'), $viewParameters);
     }
 
     /**

--- a/src/CoreShop/Bundle/FrontendBundle/Controller/CheckoutController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/CheckoutController.php
@@ -127,7 +127,9 @@ class CheckoutController extends FrontendController
      */
     protected function renderResponseForCheckoutStep(Request $request, CheckoutStepInterface $step, $stepIdentifier, $dataForStep)
     {
-        return $this->renderTemplate(sprintf('@CoreShopFrontend/Checkout/steps/%s.html.twig', $stepIdentifier), $dataForStep);
+        $template = $this->templateConfigurator->findTemplate(sprintf('Checkout/steps/%s.html', $stepIdentifier));
+
+        return $this->renderTemplate($template, $dataForStep);
     }
 
     /**
@@ -210,7 +212,7 @@ class CheckoutController extends FrontendController
         $payments = $this->get('coreshop.repository.payment')->findForOrder($order);
         $lastPayment = is_array($payments) ? $payments[count($payments) - 1] : null;
 
-        return $this->renderTemplate('@CoreShopFrontend/Checkout/error.html.twig', [
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Checkout/error.html'), [
             'order' => $order,
             'payments' => $payments,
             'lastPayment' => $lastPayment
@@ -242,7 +244,7 @@ class CheckoutController extends FrontendController
             $this->get('security.token_storage')->setToken(null);
         }
 
-        return $this->renderTemplate('@CoreShopFrontend/Checkout/thank-you.html.twig', [
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Checkout/thank-you.html'), [
             'order' => $order,
         ]);
     }

--- a/src/CoreShop/Bundle/FrontendBundle/Controller/CurrencyController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/CurrencyController.php
@@ -27,7 +27,7 @@ class CurrencyController extends FrontendController
     {
         $currencies = $this->get('coreshop.repository.currency')->findActiveForStore($this->get('coreshop.context.shopper')->getStore());
 
-        return $this->renderTemplate('CoreShopFrontendBundle:Currency:_widget.html.twig', [
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Currency/_widget.html'), [
             'currencies' => $currencies,
         ]);
     }

--- a/src/CoreShop/Bundle/FrontendBundle/Controller/CustomerController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/CustomerController.php
@@ -24,7 +24,7 @@ class CustomerController extends FrontendController
 {
     public function headerAction(Request $request)
     {
-        return $this->renderTemplate('CoreShopFrontendBundle:Customer:_header.html.twig', [
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Customer/_header.html'), [
             'catalogMode' => false,
             'customer' => $this->getCustomer(),
         ]);
@@ -32,7 +32,7 @@ class CustomerController extends FrontendController
 
     public function footerAction()
     {
-        return $this->renderTemplate('CoreShopFrontendBundle:Customer:_footer.html.twig', [
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Customer/_footer.html'), [
             'catalogMode' => false,
             'customer' => $this->getCustomer(),
         ]);
@@ -46,7 +46,7 @@ class CustomerController extends FrontendController
             return $this->redirectToRoute('coreshop_index');
         }
 
-        return $this->renderTemplate('CoreShopFrontendBundle:Customer:profile.html.twig', [
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Customer/profile.html'), [
             'customer' => $customer,
         ]);
     }
@@ -59,7 +59,7 @@ class CustomerController extends FrontendController
             return $this->redirectToRoute('coreshop_index');
         }
 
-        return $this->renderTemplate('CoreShopFrontendBundle:Customer:orders.html.twig', [
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Customer/orders.html'), [
             'customer' => $customer,
             'orders' => $this->get('coreshop.repository.order')->findByCustomer($this->getCustomer())
         ]);
@@ -84,7 +84,7 @@ class CustomerController extends FrontendController
             return $this->redirectToRoute('coreshop_customer_orders');
         }
 
-        return $this->renderTemplate('CoreShopFrontendBundle:Customer:order_detail.html.twig', [
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Customer/order_detail.html'), [
             'customer' => $customer,
             'order' => $order
         ]);
@@ -98,7 +98,7 @@ class CustomerController extends FrontendController
             return $this->redirectToRoute('coreshop_index');
         }
 
-        return $this->renderTemplate('CoreShopFrontendBundle:Customer:addresses.html.twig', [
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Customer/addresses.html'), [
             'customer' => $customer,
         ]);
     }
@@ -154,7 +154,7 @@ class CustomerController extends FrontendController
             }
         }
 
-        return $this->renderTemplate('CoreShopFrontendBundle:Customer:address.html.twig', [
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Customer/address.html'), [
             'address' => $address,
             'customer' => $customer,
             'form' => $form->createView()
@@ -223,7 +223,7 @@ class CustomerController extends FrontendController
             }
         }
 
-        return $this->renderTemplate('CoreShopFrontendBundle:Customer:settings.html.twig', [
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Customer/settings.html'), [
             'customer' => $customer,
             'form' => $form->createView()
         ]);

--- a/src/CoreShop/Bundle/FrontendBundle/Controller/FrontendController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/FrontendController.php
@@ -12,7 +12,20 @@
 
 namespace CoreShop\Bundle\FrontendBundle\Controller;
 
+use CoreShop\Bundle\FrontendBundle\TemplateConfigurator\TemplateConfiguratorInterface;
+
 class FrontendController extends \Pimcore\Controller\FrontendController
 {
-
+    /**
+     * @var TemplateConfiguratorInterface
+     */
+    protected $templateConfigurator;
+    
+    /**
+     * @param TemplateConfiguratorInterface $templateConfigurator
+     */
+    public function setTemplateConfigurator(TemplateConfiguratorInterface $templateConfigurator)
+    {
+        $this->templateConfigurator = $templateConfigurator;
+    }
 }

--- a/src/CoreShop/Bundle/FrontendBundle/Controller/IndexController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/IndexController.php
@@ -18,6 +18,6 @@ class IndexController extends FrontendController
 {
     public function indexAction(Request $request)
     {
-        return $this->renderTemplate('CoreShopFrontendBundle:Index:index.html.twig');
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Index/index.html'));
     }
 }

--- a/src/CoreShop/Bundle/FrontendBundle/Controller/MailController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/MailController.php
@@ -23,7 +23,7 @@ class MailController extends FrontendController
      */
     public function mailAction(Request $request)
     {
-        return $this->renderTemplate('CoreShopFrontendBundle:Mail:mail.html.twig');
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Mail/mail.html'));
     }
 
     /**
@@ -39,6 +39,6 @@ class MailController extends FrontendController
             $viewParameters['order'] = $order;
         }
 
-        return $this->renderTemplate('CoreShopFrontendBundle:Mail:order-confirmation.html.twig', $viewParameters);
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Mail/order-confirmation.html'), $viewParameters);
     }
 }

--- a/src/CoreShop/Bundle/FrontendBundle/Controller/OrderController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/OrderController.php
@@ -90,7 +90,7 @@ class OrderController extends FrontendController
             'form' => $form->createView()
         ];
 
-        return $this->renderTemplate('CoreShopFrontendBundle:Order:revise.html.twig', $args);
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Order/revise.html'), $args);
     }
 
     /**

--- a/src/CoreShop/Bundle/FrontendBundle/Controller/ProductController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/ProductController.php
@@ -27,7 +27,7 @@ class ProductController extends FrontendController
     {
         $productRepository = $this->get('coreshop.repository.product');
 
-        return $this->renderTemplate('CoreShopFrontendBundle:Product:_latest.html.twig', [
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Product/_latest.html'), [
             'products' => $productRepository->findLatestByStore($this->get('coreshop.context.store')->getStore()),
         ]);
     }
@@ -50,7 +50,7 @@ class ProductController extends FrontendController
 
         $this->get('coreshop.tracking.manager')->trackPurchasableView($product);
 
-        return $this->renderTemplate('CoreShopFrontendBundle:Product:detail.html.twig', [
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Product/detail.html'), [
             'product' => $product,
         ]);
     }

--- a/src/CoreShop/Bundle/FrontendBundle/Controller/QuoteController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/QuoteController.php
@@ -41,7 +41,7 @@ class QuoteController extends FrontendController
             return $this->redirectToRoute('coreshop_index');
         }
 
-        return $this->renderTemplate('CoreShopFrontendBundle:Quote:show.html.twig', [
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Quote/show.html'), [
             'quote' => $quote,
         ]);
     }

--- a/src/CoreShop/Bundle/FrontendBundle/Controller/RegisterController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/RegisterController.php
@@ -53,7 +53,7 @@ class RegisterController extends FrontendController
                 if (!$customer instanceof \CoreShop\Component\Core\Model\CustomerInterface ||
                     !$address instanceof AddressInterface
                 ) {
-                    return $this->renderTemplate('CoreShopFrontendBundle:Register:register.html.twig', [
+                    return $this->renderTemplate($this->templateConfigurator->findTemplate('Register/register.html'), [
                         'form' => $form->createView()
                     ]);
                 }
@@ -63,7 +63,7 @@ class RegisterController extends FrontendController
                 try {
                     $registrationService->registerCustomer($customer, $address, $formData, false);
                 } catch (CustomerAlreadyExistsException $e) {
-                    return $this->renderTemplate('CoreShopFrontendBundle:Register:register.html.twig', [
+                    return $this->renderTemplate($this->templateConfigurator->findTemplate('Register/register.html'), [
                         'form' => $form->createView()
                     ]);
                 }
@@ -72,7 +72,7 @@ class RegisterController extends FrontendController
             }
         }
 
-        return $this->renderTemplate('CoreShopFrontendBundle:Register:register.html.twig', [
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Register/register.html'), [
             'form' => $form->createView()
         ]);
     }
@@ -111,7 +111,7 @@ class RegisterController extends FrontendController
             }
         }
 
-        return $this->renderTemplate('CoreShopFrontendBundle:Register:password-reset-request.html.twig', [
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Register/password-reset-request.html'), [
             'form' => $form->createView()
         ]);
     }
@@ -143,7 +143,7 @@ class RegisterController extends FrontendController
                 }
             }
 
-            return $this->renderTemplate('CoreShopFrontendBundle:Register:password-reset.html.twig', [
+            return $this->renderTemplate($this->templateConfigurator->findTemplate('Register/password-reset.html'), [
                 'form' => $form->createView()
             ]);
         }

--- a/src/CoreShop/Bundle/FrontendBundle/Controller/SearchController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/SearchController.php
@@ -22,7 +22,7 @@ class SearchController extends FrontendController
     {
         $form = $this->createSearchForm();
 
-        return $this->renderTemplate('CoreShopFrontendBundle:Search:_widget.html.twig', [
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Search/_widget.html'), [
             'form' => $form->createView()
         ]);
     }
@@ -58,7 +58,7 @@ class SearchController extends FrontendController
             $paginator->setCurrentPageNumber($page);
             $paginator->setItemCountPerPage($itemsPerPage);
 
-            return $this->renderTemplate('CoreShopFrontendBundle:Search:search.html.twig', [
+            return $this->renderTemplate($this->templateConfigurator->findTemplate('Search/search.html'), [
                 'paginator' => $paginator,
                 'searchText' => $text
             ]);

--- a/src/CoreShop/Bundle/FrontendBundle/Controller/SecurityController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/SecurityController.php
@@ -71,7 +71,10 @@ class SecurityController extends FrontendController
 
         $renderLayout = $request->get('renderLayout', true);
 
-        return $this->renderTemplate($renderLayout ? '@CoreShopFrontend/Security/login.html.twig' : '@CoreShopFrontend/Security/_login-form.html.twig', [
+        $viewWithLayout = $this->templateConfigurator->findTemplate('Security/login.html');
+        $viewWithoutLayout = $this->templateConfigurator->findTemplate('Security/_login-form.html');
+
+        return $this->renderTemplate($renderLayout ? $viewWithLayout : $viewWithoutLayout, [
             'form' => $form->createView(),
             'last_username' => $lastUsername,
             'last_error' => $lastError,

--- a/src/CoreShop/Bundle/FrontendBundle/Controller/WishlistController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/WishlistController.php
@@ -73,7 +73,7 @@ class WishlistController extends FrontendController
      */
     public function summaryAction(Request $request)
     {
-        return $this->renderTemplate('CoreShopFrontendBundle:Wishlist:summary.html.twig', [
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Wishlist:summary.html'), [
             'wishlist' => $this->getWishlist()
         ]);
     }

--- a/src/CoreShop/Bundle/FrontendBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/FrontendBundle/DependencyInjection/Configuration.php
@@ -41,34 +41,45 @@ final class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('coreshop_frontend');
 
+        $rootNode
+            ->children()
+                ->scalarNode('view_suffix')->defaultValue('twig')->end()
+                ->scalarNode('view_bundle')->defaultValue('CoreShopFrontend')->end()
+            ->end()
+        ;
+
         $this->addPimcoreResourcesSection($rootNode);
         $this->addControllerSection($rootNode);
 
         return $treeBuilder;
     }
 
-    private function addControllerSection(ArrayNodeDefinition $node) {
+    /**
+     * @param ArrayNodeDefinition $node
+     */
+    private function addControllerSection(ArrayNodeDefinition $node)
+    {
         $node->children()
-                ->arrayNode('controllers')
-                    ->addDefaultsIfNotSet()
-                    ->children()
-                        ->scalarNode('index')->defaultValue(IndexController::class)->end()
-                        ->scalarNode('register')->defaultValue(RegisterController::class)->end()
-                        ->scalarNode('customer')->defaultValue(CustomerController::class)->end()
-                        ->scalarNode('currency')->defaultValue(CurrencyController::class)->end()
-                        ->scalarNode('language')->defaultValue(LanguageController::class)->end()
-                        ->scalarNode('search')->defaultValue(SearchController::class)->end()
-                        ->scalarNode('cart')->defaultValue(CartController::class)->end()
-                        ->scalarNode('checkout')->defaultValue(CheckoutController::class)->end()
-                        ->scalarNode('order')->defaultValue(OrderController::class)->end()
-                        ->scalarNode('category')->defaultValue(CategoryController::class)->end()
-                        ->scalarNode('product')->defaultValue(ProductController::class)->end()
-                        ->scalarNode('quote')->defaultValue(QuoteController::class)->end()
-                        ->scalarNode('security')->defaultValue(SecurityController::class)->end()
-                        ->scalarNode('payment')->defaultValue(PaymentController::class)->end()
-                        ->scalarNode('wishlist')->defaultValue(WishlistController::class)->end()
-                    ->end()
-                ->end();
+            ->arrayNode('controllers')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->scalarNode('index')->defaultValue(IndexController::class)->end()
+                    ->scalarNode('register')->defaultValue(RegisterController::class)->end()
+                    ->scalarNode('customer')->defaultValue(CustomerController::class)->end()
+                    ->scalarNode('currency')->defaultValue(CurrencyController::class)->end()
+                    ->scalarNode('language')->defaultValue(LanguageController::class)->end()
+                    ->scalarNode('search')->defaultValue(SearchController::class)->end()
+                    ->scalarNode('cart')->defaultValue(CartController::class)->end()
+                    ->scalarNode('checkout')->defaultValue(CheckoutController::class)->end()
+                    ->scalarNode('order')->defaultValue(OrderController::class)->end()
+                    ->scalarNode('category')->defaultValue(CategoryController::class)->end()
+                    ->scalarNode('product')->defaultValue(ProductController::class)->end()
+                    ->scalarNode('quote')->defaultValue(QuoteController::class)->end()
+                    ->scalarNode('security')->defaultValue(SecurityController::class)->end()
+                    ->scalarNode('payment')->defaultValue(PaymentController::class)->end()
+                    ->scalarNode('wishlist')->defaultValue(WishlistController::class)->end()
+                ->end()
+            ->end();
     }
 
     /**

--- a/src/CoreShop/Bundle/FrontendBundle/DependencyInjection/CoreShopFrontendExtension.php
+++ b/src/CoreShop/Bundle/FrontendBundle/DependencyInjection/CoreShopFrontendExtension.php
@@ -36,6 +36,9 @@ final class CoreShopFrontendExtension extends AbstractModelExtension
             }
         }
 
+        $container->setParameter('coreshop.frontend.view_bundle', $config['view_bundle']);
+        $container->setParameter('coreshop.frontend.view_suffix', $config['view_suffix']);
+
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
     }

--- a/src/CoreShop/Bundle/FrontendBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/config/services.yml
@@ -2,79 +2,62 @@ imports:
     - { resource: "services/wishlist.yml" }
 
 services:
-    coreshop.frontend.controller.index:
-        class: '%coreshop.frontend.controller.index%'
+    coreshop.frontend.controller.abstract:
+        class: CoreShop\Bundle\FrontendBundle\Controller\FrontendController
+        abstract: true
         calls:
             - [setContainer, ['@service_container']]
             - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
+
+    coreshop.frontend.controller.index:
+        class: '%coreshop.frontend.controller.index%'
+        parent: coreshop.frontend.controller.abstract
 
     coreshop.frontend.controller.register:
         class: '%coreshop.frontend.controller.register%'
-        calls:
-            - [setContainer, ['@service_container']]
-            - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
+        parent: coreshop.frontend.controller.abstract
 
     coreshop.frontend.controller.customer:
         class: '%coreshop.frontend.controller.customer%'
-        calls:
-            - [setContainer, ['@service_container']]
-            - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
+        parent: coreshop.frontend.controller.abstract
 
     coreshop.frontend.controller.currency:
         class: '%coreshop.frontend.controller.currency%'
-        calls:
-            - [setContainer, ['@service_container']]
-            - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
+        parent: coreshop.frontend.controller.abstract
 
     coreshop.frontend.controller.language:
         class: '%coreshop.frontend.controller.language%'
-        calls:
-            - [setContainer, ['@service_container']]
-            - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
+        parent: coreshop.frontend.controller.abstract
 
     coreshop.frontend.controller.search:
         class: '%coreshop.frontend.controller.search%'
-        calls:
-            - [setContainer, ['@service_container']]
-            - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
+        parent: coreshop.frontend.controller.abstract
 
     coreshop.frontend.controller.cart:
         class: '%coreshop.frontend.controller.cart%'
-        calls:
-            - [setContainer, ['@service_container']]
-            - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
+        parent: coreshop.frontend.controller.abstract
 
     coreshop.frontend.controller.checkout:
         class: '%coreshop.frontend.controller.checkout%'
         arguments:
             - '@coreshop.checkout_manager.factory'
-        calls:
-            - [setContainer, ['@service_container']]
-            - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
+        parent: coreshop.frontend.controller.abstract
 
     coreshop.frontend.controller.order:
         class: '%coreshop.frontend.controller.order%'
-        calls:
-            - [setContainer, ['@service_container']]
-            - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
+        parent: coreshop.frontend.controller.abstract
 
     coreshop.frontend.controller.category:
         class: '%coreshop.frontend.controller.category%'
-        calls:
-            - [setContainer, ['@service_container']]
-            - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
+        parent: coreshop.frontend.controller.abstract
 
     coreshop.frontend.controller.product:
         class: '%coreshop.frontend.controller.product%'
-        calls:
-            - [setContainer, ['@service_container']]
-            - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
+        parent: coreshop.frontend.controller.abstract
 
     coreshop.frontend.controller.quote:
         class: '%coreshop.frontend.controller.quote%'
-        calls:
-            - [setContainer, ['@service_container']]
-            - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
+        parent: coreshop.frontend.controller.abstract
 
     coreshop.frontend.controller.security:
         class: '%coreshop.frontend.controller.security%'
@@ -82,9 +65,11 @@ services:
             - '@security.authentication_utils'
             - '@form.factory'
             - '@coreshop.context.shopper'
-        calls:
-            - [setContainer, ['@service_container']]
-            - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
+        parent: coreshop.frontend.controller.abstract
+
+    coreshop.frontend.controller.wishlist:
+        class: '%coreshop.frontend.controller.wishlist%'
+        parent: coreshop.frontend.controller.abstract
 
     coreshop.frontend.controller.payment:
         class: '%coreshop.frontend.controller.payment%'
@@ -96,12 +81,6 @@ services:
             - '@doctrine.orm.entity_manager'
         calls:
             - [setContainer, ['@service_container']]
-
-    coreshop.frontend.controller.wishlist:
-        class: '%coreshop.frontend.controller.wishlist%'
-        calls:
-            - [setContainer, ['@service_container']]
-            - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
 
     coreshop.frontend.template_configurator:
         class: CoreShop\Bundle\FrontendBundle\TemplateConfigurator\TemplateConfigurator

--- a/src/CoreShop/Bundle/FrontendBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/config/services.yml
@@ -6,36 +6,43 @@ services:
         class: '%coreshop.frontend.controller.index%'
         calls:
             - [setContainer, ['@service_container']]
+            - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
 
     coreshop.frontend.controller.register:
         class: '%coreshop.frontend.controller.register%'
         calls:
             - [setContainer, ['@service_container']]
+            - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
 
     coreshop.frontend.controller.customer:
         class: '%coreshop.frontend.controller.customer%'
         calls:
             - [setContainer, ['@service_container']]
+            - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
 
     coreshop.frontend.controller.currency:
         class: '%coreshop.frontend.controller.currency%'
         calls:
             - [setContainer, ['@service_container']]
+            - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
 
     coreshop.frontend.controller.language:
         class: '%coreshop.frontend.controller.language%'
         calls:
             - [setContainer, ['@service_container']]
+            - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
 
     coreshop.frontend.controller.search:
         class: '%coreshop.frontend.controller.search%'
         calls:
             - [setContainer, ['@service_container']]
+            - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
 
     coreshop.frontend.controller.cart:
         class: '%coreshop.frontend.controller.cart%'
         calls:
             - [setContainer, ['@service_container']]
+            - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
 
     coreshop.frontend.controller.checkout:
         class: '%coreshop.frontend.controller.checkout%'
@@ -43,26 +50,31 @@ services:
             - '@coreshop.checkout_manager.factory'
         calls:
             - [setContainer, ['@service_container']]
+            - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
 
     coreshop.frontend.controller.order:
         class: '%coreshop.frontend.controller.order%'
         calls:
             - [setContainer, ['@service_container']]
+            - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
 
     coreshop.frontend.controller.category:
         class: '%coreshop.frontend.controller.category%'
         calls:
             - [setContainer, ['@service_container']]
+            - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
 
     coreshop.frontend.controller.product:
         class: '%coreshop.frontend.controller.product%'
         calls:
             - [setContainer, ['@service_container']]
+            - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
 
     coreshop.frontend.controller.quote:
         class: '%coreshop.frontend.controller.quote%'
         calls:
             - [setContainer, ['@service_container']]
+            - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
 
     coreshop.frontend.controller.security:
         class: '%coreshop.frontend.controller.security%'
@@ -72,6 +84,7 @@ services:
             - '@coreshop.context.shopper'
         calls:
             - [setContainer, ['@service_container']]
+            - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
 
     coreshop.frontend.controller.payment:
         class: '%coreshop.frontend.controller.payment%'
@@ -88,3 +101,10 @@ services:
         class: '%coreshop.frontend.controller.wishlist%'
         calls:
             - [setContainer, ['@service_container']]
+            - [setTemplateConfigurator, ['@coreshop.frontend.template_configurator']]
+
+    coreshop.frontend.template_configurator:
+        class: CoreShop\Bundle\FrontendBundle\TemplateConfigurator\TemplateConfigurator
+        arguments:
+            - '%coreshop.frontend.view_bundle%'
+            - '%coreshop.frontend.view_suffix%'

--- a/src/CoreShop/Bundle/FrontendBundle/TemplateConfigurator/TemplateConfigurator.php
+++ b/src/CoreShop/Bundle/FrontendBundle/TemplateConfigurator/TemplateConfigurator.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2017 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\FrontendBundle\TemplateConfigurator;
+
+class TemplateConfigurator implements TemplateConfiguratorInterface
+{
+    /**
+     * @var string
+     */
+    private $bundleName;
+
+    /**
+     * @var string
+     */
+    private $templateSuffix;
+
+    /**
+     * @param string $bundleName
+     * @param string $templateSuffix
+     */
+    public function __construct(string $bundleName, string $templateSuffix)
+    {
+        $this->bundleName = $bundleName;
+        $this->templateSuffix = $templateSuffix;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findTemplate($templateName)
+    {
+        return sprintf('@%s/%s.%s', $this->bundleName, $templateName, $this->templateSuffix);
+    }
+}

--- a/src/CoreShop/Bundle/FrontendBundle/TemplateConfigurator/TemplateConfiguratorInterface.php
+++ b/src/CoreShop/Bundle/FrontendBundle/TemplateConfigurator/TemplateConfiguratorInterface.php
@@ -10,16 +10,13 @@
  * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
  */
 
-namespace CoreShop\Bundle\FrontendBundle\Controller;
+namespace CoreShop\Bundle\FrontendBundle\TemplateConfigurator;
 
-use Symfony\Component\HttpFoundation\Request;
-
-class LanguageController extends FrontendController
+interface TemplateConfiguratorInterface
 {
-    public function widgetAction(Request $request)
-    {
-        return $this->renderTemplate($this->templateConfigurator->findTemplate('Language/_widget.html'), [
-            'languages' => ['de', 'en'], //$this->get('pimcore.locale')->getLocaleList()
-        ]);
-    }
+    /**
+     * @param $templateName
+     * @return string
+     */
+    public function findTemplate($templateName);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #178

implement TemplateConfigurator to allow views to be loaded from different locations and in different engines. This allows CoreShop to be used with the PHP Engine as well. You can now configure following things:

```
core_shop_frontend:
    view_bundle: 'App'
    view_suffix: 'php'
```

This changes the template location path to @App and the suffix to php, so for the Cart Summary that would be: '@App/Cart/summary.html.php'
