### PR TITLE
Carrier Calculation in Cart

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Migrations/Version20180323141834.php
+++ b/src/CoreShop/Bundle/CoreBundle/Migrations/Version20180323141834.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace CoreShop\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+class Version20180323141834 extends AbstractPimcoreMigration implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        //update translations
+        $this->container->get('coreshop.resource.installer.shared_translations')->installResources(new NullOutput(), 'coreshop');
+
+        //update static routes (check shipment in cart route added)
+        $options = ['allowed' => ['coreshop_cart_check_shipment']];
+        $this->container->get('coreshop.resource.installer.routes')->installResources(new NullOutput(), 'coreshop', $options);
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+    }
+}

--- a/src/CoreShop/Bundle/FrontendBundle/Controller/CartController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/CartController.php
@@ -141,7 +141,7 @@ class CartController extends FrontendController
                 $price = $carrierPriceCalculator->getPrice($carrier, $cart, $virtualAddress);
                 $priceWithoutTax = $carrierPriceCalculator->getPrice($carrier, $cart, $virtualAddress, false);
                 $availableCarriers[] = [
-                    'name'            => $carrier->getName(),
+                    'name'            => $carrier->getLabel(),
                     'isFreeShipping'  => $price === 0,
                     'price'           => $price,
                     'priceWithoutTax' => $priceWithoutTax,

--- a/src/CoreShop/Bundle/FrontendBundle/Controller/CartController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/CartController.php
@@ -13,6 +13,8 @@
 namespace CoreShop\Bundle\FrontendBundle\Controller;
 
 use CoreShop\Bundle\OrderBundle\Form\Type\CartType;
+use CoreShop\Bundle\OrderBundle\Form\Type\ShippingCalculatorType;
+use CoreShop\Component\Address\Model\AddressInterface;
 use CoreShop\Component\Inventory\Model\StockableInterface;
 use CoreShop\Component\Order\Cart\Rule\CartPriceRuleProcessorInterface;
 use CoreShop\Component\Order\Cart\Rule\CartPriceRuleUnProcessorInterface;
@@ -104,6 +106,57 @@ class CartController extends FrontendController
         return $this->renderTemplate($this->templateConfigurator->findTemplate('Cart/summary.html'), [
             'cart' => $cart,
             'form' => $form->createView()
+        ]);
+    }
+
+    /**
+     * @param Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function shipmentCalculationAction(Request $request)
+    {
+        $cart = $this->getCart();
+        $form = $this->createForm(ShippingCalculatorType::class, null, [
+                'action' => $this->generateUrl('coreshop_cart_check_shipment')
+            ]
+        );
+
+        $availableCarriers = [];
+        $form->handleRequest($request);
+
+        //check if there is a shipping calculation request
+        if (in_array($request->getMethod(), ['POST', 'PUT', 'PATCH']) && $form->isValid()) {
+
+            $shippingCalculatorFormData = $form->getData();
+            $carrierPriceCalculator = $this->get('coreshop.carrier.price_calculator.taxed');
+            $carriersResolver = $this->get('coreshop.carrier.resolver');
+
+            /** @var AddressInterface $virtualAddress */
+            $virtualAddress = $this->get('coreshop.factory.address')->createNew();
+            $virtualAddress->setCountry($shippingCalculatorFormData['country']);
+            $virtualAddress->setPostcode($shippingCalculatorFormData['zip']);
+
+            $carriers = $carriersResolver->resolveCarriers($cart, $virtualAddress);
+            foreach ($carriers as $carrier) {
+                $price = $carrierPriceCalculator->getPrice($carrier, $cart, $virtualAddress);
+                $priceWithoutTax = $carrierPriceCalculator->getPrice($carrier, $cart, $virtualAddress, false);
+                $availableCarriers[] = [
+                    'name'            => $carrier->getName(),
+                    'isFreeShipping'  => $price === 0,
+                    'price'           => $price,
+                    'priceWithoutTax' => $priceWithoutTax,
+                    'data'            => $carrier
+                ];
+            }
+            uasort($availableCarriers, function ($a, $b) {
+                return ($a['price'] > $b['price']);
+            });
+        }
+
+        return $this->renderTemplate($this->templateConfigurator->findTemplate('Cart/ShipmentCalculator/_widget.html'), [
+            'cart' => $cart,
+            'form' => $form->createView(),
+            'availableCarriers' => $availableCarriers
         ]);
     }
 

--- a/src/CoreShop/Bundle/FrontendBundle/Resources/install/pimcore/staticroutes.yml
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/install/pimcore/staticroutes.yml
@@ -62,6 +62,15 @@ routes:
     variables: _locale
     priority: 3
 
+  coreshop_cart_check_shipment:
+    pattern: "/(\\w+)\\/shop\\/cart\\/shipment-calculation/"
+    reverse: "/%_locale/shop/cart/shipment-calculation"
+    module: FrontendBundle
+    controller: "@coreshop.frontend.controller.cart"
+    action: shipmentCalculation
+    variables: _locale
+    priority: 3
+
   coreshop_login:
     pattern: "/(\\w+)\\/shop\\/login/"
     reverse: "/%_locale/shop/login"

--- a/src/CoreShop/Bundle/FrontendBundle/Resources/install/pimcore/translations.yml
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/install/pimcore/translations.yml
@@ -233,6 +233,30 @@ translations:
           en: 'Update Cart'
           de: 'Warenkorb aktualisieren'
 
+  coreshop.ui.cart.shipment.available_carriers:
+      languages:
+          de_CH: 'Verfügbare Versanddienste'
+          en: 'Available Carriers'
+          de: 'Verfügbare Versanddienste'
+
+  coreshop.ui.cart.shipment.is_free_shipping:
+      languages:
+          de_CH: 'Kostenlose Lieferung'
+          en: 'Free Shipping'
+          de: 'Kostenlose Lieferung'
+
+  coreshop.ui.cart.shipment.no_valid_carrier_found:
+      languages:
+          de_CH: 'Es wurden keine Versanddienste gefunden'
+          en: 'No valid carrier found'
+          de: 'Es wurden keine Versanddienste gefunden'
+
+  coreshop.ui.cart.shipment.search_for_carrier:
+      languages:
+          de_CH: 'Passenden Versanddienst finden'
+          en: 'Search for Carrier'
+          de: 'Passenden Versanddienst finden'
+
   coreshop.ui.items:
       languages:
           de_CH: 'Produkte'
@@ -1060,6 +1084,24 @@ translations:
           de_CH: 'Bezahlung erneut durchführen'
           en: 'Process payment'
           de: 'Bezahlung erneut durchführen'
+
+  coreshop.form.cart.carrier.country:
+      languages:
+          de_CH: 'Land'
+          en: 'Country'
+          de: 'Land'
+
+  coreshop.form.cart.carrier.zip:
+      languages:
+          de_CH: 'PLZ'
+          en: 'Post Code'
+          de: 'PLZ'
+
+  coreshop.form.cart.carrier.submit:
+      languages:
+          de_CH: 'Suchen'
+          en: 'Search'
+          de: 'Suchen'
 
   coreshop.global_error.cart_has_changed:
       languages:

--- a/src/CoreShop/Bundle/FrontendBundle/Resources/public/static/js/shop.js
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/public/static/js/shop.js
@@ -8,12 +8,34 @@ $(document).ready(function () {
 
     shop.init = function () {
         shop.initChangeAddress();
+        shop.initCartShipmentCalculator();
 
         $('#paymentProvider').handlePrototypes({
             'prototypePrefix': 'paymentProvider',
             'containerSelector': '.paymentSettings',
             'selectorAttr': 'data-factory'
         });
+    };
+
+    shop.initCartShipmentCalculator = function () {
+
+        $(document).on('submit', 'form[name="coreshop_shipping_calculator"]', function (ev) {
+            ev.preventDefault();
+            var $form = $(this);
+            $form.addClass('loading');
+            $form.find('button[type="submit"]').attr('disabled', 'disabled');
+            $form.closest('.cart-shipment-calculation-box').find('.cart-shipment-available-carriers').css('opacity', .2);
+            $.ajax({
+                url: $form.attr('action'),
+                method: 'POST',
+                data: $form.serialize(),
+                success: function(res) {
+                    $form.removeClass('loading');
+                    $form.closest('.cart-shipment-calculation-box').replaceWith($(res));
+                }
+            });
+        });
+
     };
 
     shop.initChangeAddress = function () {

--- a/src/CoreShop/Bundle/FrontendBundle/Resources/views/Cart/ShipmentCalculator/_widget.html.twig
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/views/Cart/ShipmentCalculator/_widget.html.twig
@@ -1,0 +1,37 @@
+{% import "@CoreShopFrontend/Common/Macro/currency.html.twig" as currency %}
+{% form_theme form 'bootstrap_4_layout.html.twig' %}
+
+<div class="cart-shipment-calculation-box">
+    <div class="row">
+        <div class="col-12 col-sm-6 offset-sm-6">
+
+            {% if availableCarriers|length > 0 %}
+                <div class="cart-shipment-available-carriers">
+                    <h3>{{ 'coreshop.ui.cart.shipment.available_carriers'|trans }}</h3>
+                    <table class="table table-bordered">
+                        {% for carrier in availableCarriers %}
+                            <tr>
+                                <td><strong>{{ carrier.name }}</strong></td>
+                                <td>{{ currency.convertAndFormat(carrier.price) }} {% if carrier.isFreeShipping %}<span class="badge badge-pill badge-success">{{ 'coreshop.ui.cart.shipment.is_free_shipping'|trans }}</span>{% endif %}</td>
+                                {# <td>{{ currency.convertAndFormat(carrier.priceWithoutTax) }}</td> #}
+                            </tr>
+                        {% endfor %}
+                    </table>
+                </div>
+            {% else %}
+                {% if app.request.method == 'POST' %}
+                    <div class="alert alert-warning no-carrier-found">{{ 'coreshop.ui.cart.shipment.no_valid_carrier_found'|trans }}</div>
+                {% endif %}
+            {% endif %}
+
+            <h3>{{ 'coreshop.ui.cart.shipment.search_for_carrier'|trans }}</h3>
+            <table class="table table-bordered">
+                <tr>
+                    <td colspan="2">
+                        {{ form(form, {'method': 'POST'}) }}
+                    </td>
+                </tr>
+            </table>
+        </div>
+    </div>
+</div>

--- a/src/CoreShop/Bundle/FrontendBundle/Resources/views/Cart/Summary/_items.html.twig
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/views/Cart/Summary/_items.html.twig
@@ -43,4 +43,9 @@
 
         {{ form_row(form._token) }}
     {{ form_end(form, {'render_rest': false}) }}
+
 </div>
+
+{% if cart.getShipping(false) is null %}
+    {{ render(controller('coreshop.frontend.controller.cart:shipmentCalculationAction')) }}
+{% endif %}

--- a/src/CoreShop/Bundle/FrontendBundle/Resources/views/Product/detail.html.twig
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/views/Product/detail.html.twig
@@ -26,7 +26,7 @@
             {% if product.getImages|length > 0 %}
                 <div class="row">
                     {% for image in product.getImages %}
-                        <div class="col-xs-12 col-sm-6">
+                        <div class="col-12 col-sm-6">
                             {{ image.getThumbnail("coreshop_productDetailThumbnail").getHtml({"class": "img-responsive thumbnail"})|raw }}
                         </div>
                     {% endfor %}

--- a/src/CoreShop/Bundle/OrderBundle/Form/Type/ShippingCalculatorType.php
+++ b/src/CoreShop/Bundle/OrderBundle/Form/Type/ShippingCalculatorType.php
@@ -27,7 +27,7 @@ final class ShippingCalculatorType extends AbstractType
     {
         $builder
             ->add('country', CountryChoiceType::class, [
-                'active' => null,
+                'active' => true,
                 'label' => 'coreshop.form.cart.carrier.country',
             ])
             ->add('zip', TextType::class, [

--- a/src/CoreShop/Bundle/OrderBundle/Form/Type/ShippingCalculatorType.php
+++ b/src/CoreShop/Bundle/OrderBundle/Form/Type/ShippingCalculatorType.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2017 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\OrderBundle\Form\Type;
+
+use CoreShop\Bundle\AddressBundle\Form\Type\CountryChoiceType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class ShippingCalculatorType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('country', CountryChoiceType::class, [
+                'active' => null,
+                'label' => 'coreshop.form.cart.carrier.country',
+            ])
+            ->add('zip', TextType::class, [
+                'label' => 'coreshop.form.cart.carrier.zip'
+            ])
+            ->add('submit', SubmitType::class, [
+                'label' => 'coreshop.form.cart.carrier.submit'
+            ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'coreshop_shipping_calculator';
+    }
+}

--- a/src/CoreShop/Component/Core/Order/Processor/CartShippingProcessor.php
+++ b/src/CoreShop/Component/Core/Order/Processor/CartShippingProcessor.php
@@ -12,15 +12,9 @@
 
 namespace CoreShop\Component\Core\Order\Processor;
 
-use CoreShop\Component\Core\Model\Carrier;
-use CoreShop\Component\Core\Model\TaxRuleGroup;
 use CoreShop\Component\Core\Shipping\Calculator\TaxedShippingCalculatorInterface;
-use CoreShop\Component\Core\Taxation\TaxCalculatorFactoryInterface;
 use CoreShop\Component\Order\Model\CartInterface;
 use CoreShop\Component\Order\Processor\CartProcessorInterface;
-use CoreShop\Component\Taxation\Calculator\TaxCalculatorInterface;
-use CoreShop\Component\Taxation\Collector\TaxCollectorInterface;
-use Pimcore\Model\DataObject\Fieldcollection;
 
 final class CartShippingProcessor implements CartProcessorInterface
 {
@@ -32,10 +26,7 @@ final class CartShippingProcessor implements CartProcessorInterface
     /**
      * @param TaxedShippingCalculatorInterface $carrierPriceCalculator
      */
-    public function __construct(
-        TaxedShippingCalculatorInterface $carrierPriceCalculator
-
-    )
+    public function __construct(TaxedShippingCalculatorInterface $carrierPriceCalculator)
     {
         $this->carrierPriceCalculator = $carrierPriceCalculator;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #370 

This PR adds some UX improvements in cart to get available carriers by adding a new form (`ShippingCalculatorType`).

See it in action here: http://recordit.co/hskjM1mGKE

## Statements
- If a cart already has some calculated shipment values (happens if customer already has chosen a shipment address and a carrier in the carrier checkout step), the form will **no longer** show up. Otherwise it's quite confusing if there are shipment prices in the cart overview and also a optional carrier selection form

## Questions
- @dpfaffenbauer as already discussed, there is still some work to do: If a user checks the available carriers within this new form, he should be able to select the available carrier. add the carrier to the cart should be enough? are there other ways to provide the cheapest carrier on the fly? Please fill free to add the necessary adoptions to this PR  