### PR TITLE
Put the categoryId between commas

### DIFF
--- a/src/CoreShop/Bundle/IndexBundle/Worker/MysqlWorker/Listing.php
+++ b/src/CoreShop/Bundle/IndexBundle/Worker/MysqlWorker/Listing.php
@@ -452,7 +452,8 @@ class Listing extends AbstractListing
         $queryBuilder->where($this->worker->renderCondition(Condition::compare('active', 1, '='), 'q'));
 
         if ($this->getCategory()) {
-            $queryBuilder->andWhere($this->worker->renderCondition(Condition::like('parentCategoryIds', $this->getCategory()->getId(), 'both'), 'q'));
+            $categoryCondition = "," . $this->getCategory()->getId() . ",";
+            $queryBuilder->andWhere($this->worker->renderCondition(Condition::like('parentCategoryIds', $categoryCondition, 'both'), 'q'));
         }
         $extensions = $this->getWorker()->getExtensions($this->getIndex());
 


### PR DESCRIPTION
Because in current method, will be search in the whole string

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
