### PR TITLE
wkHtmlToPdf Improvements

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services/order.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services/order.yml
@@ -98,6 +98,7 @@ services:
     coreshop.mail.processor.order:
         class: CoreShop\Component\Core\Order\OrderMailProcessor
         arguments:
+           - '@monolog.logger.pimcore'
            - '@coreshop.money_formatter'
            - '@coreshop.repository.order_invoice'
            - '@coreshop.repository.order_shipment'

--- a/src/CoreShop/Bundle/OrderBundle/Controller/OrderInvoiceController.php
+++ b/src/CoreShop/Bundle/OrderBundle/Controller/OrderInvoiceController.php
@@ -139,14 +139,20 @@ class OrderInvoiceController extends PimcoreController
         $invoice = $this->getOrderInvoiceRepository()->find($invoiceId);
 
         if ($invoice instanceof OrderInvoiceInterface) {
-            return new Response(
-                $this->getOrderDocumentRenderer()->renderDocumentPdf($invoice),
-                200,
-                [
-                    'Content-Type' => 'application/pdf',
+
+            try {
+                $responseData = $this->getOrderDocumentRenderer()->renderDocumentPdf($invoice);
+                $header = [
+                    'Content-Type'        => 'application/pdf',
                     'Content-Disposition' => 'inline; filename="invoice-'.$invoice->getId().'.pdf"',
-                ]
-            );
+                ];
+            } catch (\Exception $e) {
+                $responseData = '<strong>'.$e->getMessage().'</strong><br>trace: '.$e->getTraceAsString();
+                $header = ['Content-Type' => 'text/html'];
+            }
+
+            return new Response($responseData, 200, $header);
+
         }
 
         throw new NotFoundHttpException(sprintf('Invoice with Id %s not found', $invoiceId));

--- a/src/CoreShop/Bundle/OrderBundle/Controller/OrderShipmentController.php
+++ b/src/CoreShop/Bundle/OrderBundle/Controller/OrderShipmentController.php
@@ -199,21 +199,24 @@ class OrderShipmentController extends PimcoreController
      */
     public function renderAction(Request $request)
     {
-        $invoiceId = $request->get('id');
-        $invoice = $this->getOrderShipmentRepository()->find($invoiceId);
+        $shipmentId = $request->get('id');
+        $shipment = $this->getOrderShipmentRepository()->find($shipmentId);
 
-        if ($invoice instanceof OrderShipmentInterface) {
-            return new Response(
-                $this->getOrderDocumentRenderer()->renderDocumentPdf($invoice),
-                200,
-                [
+        if ($shipment instanceof OrderShipmentInterface) {
+            try {
+                $responseData = $this->getOrderDocumentRenderer()->renderDocumentPdf($shipment);
+                $header = [
                     'Content-Type' => 'application/pdf',
-                    'Content-Disposition' => 'inline; filename="invoice-'.$invoice->getId().'.pdf"',
-                ]
-            );
+                    'Content-Disposition' => 'inline; filename="shipment-'.$shipment->getId().'.pdf"',
+                ];
+            } catch (\Exception $e) {
+                $responseData = '<strong>'.$e->getMessage().'</strong><br>trace: '.$e->getTraceAsString();
+                $header = ['Content-Type' => 'text/html'];
+            }
+            return new Response($responseData, 200, $header);
         }
 
-        throw new NotFoundHttpException(sprintf('Invoice with Id %s not found', $invoiceId));
+        throw new NotFoundHttpException(sprintf('Invoice with Id %s not found', $shipmentId));
     }
 
     /**

--- a/src/CoreShop/Bundle/OrderBundle/Renderer/AssetOrderDocumentPdfRenderer.php
+++ b/src/CoreShop/Bundle/OrderBundle/Renderer/AssetOrderDocumentPdfRenderer.php
@@ -38,8 +38,13 @@ class AssetOrderDocumentPdfRenderer implements OrderDocumentRendererInterface
      */
     public function renderDocumentPdf(OrderDocumentInterface $orderDocument)
     {
+        // if in dev mode, do not store document
+        if (\Pimcore::getKernel()->getEnvironment() === 'dev') {
+            return $this->decoratedService->renderDocumentPdf($orderDocument);
+        }
+
         if ($orderDocument->getRenderedAsset() instanceof Asset) {
-            //check if asset is outdated.
+            // check if asset is outdated.
             if ((int)$orderDocument->getRenderedAsset()->getCreationDate() >= (int)$orderDocument->getModificationDate()) {
                 return $orderDocument->getRenderedAsset()->getData();
             }

--- a/src/CoreShop/Bundle/OrderBundle/Renderer/AssetOrderDocumentPdfRenderer.php
+++ b/src/CoreShop/Bundle/OrderBundle/Renderer/AssetOrderDocumentPdfRenderer.php
@@ -39,7 +39,10 @@ class AssetOrderDocumentPdfRenderer implements OrderDocumentRendererInterface
     public function renderDocumentPdf(OrderDocumentInterface $orderDocument)
     {
         if ($orderDocument->getRenderedAsset() instanceof Asset) {
-            return $orderDocument->getRenderedAsset()->getData();
+            //check if asset is outdated.
+            if ((int)$orderDocument->getRenderedAsset()->getCreationDate() >= (int)$orderDocument->getModificationDate()) {
+                return $orderDocument->getRenderedAsset()->getData();
+            }
         }
 
         $pdfContent = $this->decoratedService->renderDocumentPdf($orderDocument);

--- a/src/CoreShop/Bundle/OrderBundle/Renderer/Pdf/WkHtmlToPdf.php
+++ b/src/CoreShop/Bundle/OrderBundle/Renderer/Pdf/WkHtmlToPdf.php
@@ -187,7 +187,12 @@ final class WkHtmlToPdf implements PdfRendererInterface
             $command = $wkHtmlTopPfBinary . $options;
         }
 
-        Console::exec($command.' '.$httpSource.' '.$tmpPdfFile);
+        $execCommand = $command.' '.$httpSource.' '.$tmpPdfFile;
+        Console::exec($execCommand);
+
+        if (!file_exists($tmpPdfFile)) {
+            throw new \Exception(sprintf('wkhtmltopdf pdf conversion failed. This could be a command error. Executed command was: "%s"', $execCommand));
+        }
 
         $pdfContent = file_get_contents($tmpPdfFile);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | sort of
| BC breaks?    | no
| Deprecations? | no

This PR improves several things during the pdf generation:

- Check if xvfb is installed. if so use it as xserver
- Better tmp handling. before: if wkhtmltopdf is not installed the html tmp files won't get swiped
- Better error handling in shipment / invoice pdf tab. instead of a "invalid pdf" the header returns a valid html exception string
- Better document validation: if shipment / invoice gets modified, invalidate document pdf
- Better development: Do not create rendered asset as long environment is in`dev` mode (rapid development)