### PR TITLE
LikeCondition parameters order

### DIFF
--- a/src/CoreShop/Bundle/FrontendBundle/Controller/CategoryController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/CategoryController.php
@@ -130,7 +130,7 @@ class CategoryController extends FrontendController
             $filteredList = $this->get('coreshop.factory.filter.list')->createList($category->getFilter(), $request->request);
             $filteredList->setLocale($request->getLocale());
             $filteredList->setVariantMode($variantMode ? $variantMode : ListingInterface::VARIANT_MODE_HIDE);
-            $filteredList->addCondition(new LikeCondition('stores', $this->getContext()->getStore()->getId(), 'both'), 'stores');
+            $filteredList->addCondition(new LikeCondition('stores', 'both', $this->getContext()->getStore()->getId()), 'stores');
             $filteredList->setCategory($category);
 
             $orderDirection = $category->getFilter()->getOrderDirection();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #446 

The order of the parameters seem to be wrong. Second should be $pattern then the $value in
