### PR TITLE
[ExpressionPlaceholder] implement a Expression Pimcore Placeholder extension

### DIFF
--- a/features/placeholder/expression.feature
+++ b/features/placeholder/expression.feature
@@ -1,0 +1,21 @@
+@placeholder @placeholder_expression
+Feature: In order to extend Pimcore's placeholder
+  CoreShop adds a expression placeholder
+
+  Scenario: Test a simple arithmetic expression
+    Then the placeholder value for expression "%Expression(expression, {'expression' : '1+1'});" should be "2"
+
+  Scenario: Test a container parameter expression
+    Then the placeholder value for expression "%Expression(expression, {'expression' : 'parameter(\'kernel.environment\')'});" should be "test"
+
+  Scenario: Test a container service expression
+    Then the placeholder value for expression "%Expression(expression, {'expression' : 'service(\'coreshop.money_formatter\').format(100, \'EUR\', \'en\')'});" should be "€1.00"
+
+  Scenario: Test a coreshop expression language provider for object
+    Then the placeholder value for expression "%Expression(expression, {'expression' : 'object(1)'});" should be "/"
+
+  Scenario: Test a coreshop expression language provider for asset
+    Then the placeholder value for expression "%Expression(expression, {'expression' : 'asset(1)'});" should be "/"
+
+  Scenario: Test a coreshop expression language provider for document
+    Then the placeholder value for expression "%Expression(expression, {'expression' : 'document(1)'});" should be "/"

--- a/features/placeholder/expression.feature
+++ b/features/placeholder/expression.feature
@@ -19,3 +19,8 @@ Feature: In order to extend Pimcore's placeholder
 
   Scenario: Test a coreshop expression language provider for document
     Then the placeholder value for expression "%Expression(expression, {'expression' : 'document(1)'});" should be "/"
+
+  Scenario: Test a Pimcore object with expression language placeholder
+    Given the site operates on a store in "Austria"
+    And the site has a product "Shoe" priced at 100
+    Then the placeholder value for expression "%Expression(object, {'expression': 'value.getName()'});" for object should be "Shoe"

--- a/src/CoreShop/Behat/Context/Domain/PlaceholderContext.php
+++ b/src/CoreShop/Behat/Context/Domain/PlaceholderContext.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2017 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Behat\Context\Domain;
+
+use Behat\Behat\Context\Context;
+use CoreShop\Behat\Service\ClassStorageInterface;
+use CoreShop\Behat\Service\SharedStorageInterface;
+use Pimcore\Model\DataObject\ClassDefinition;
+use Pimcore\Model\DataObject\Fieldcollection;
+use Pimcore\Model\DataObject\Objectbrick;
+use Webmozart\Assert\Assert;
+
+final class PlaceholderContext implements Context
+{
+    /**
+     * @var SharedStorageInterface
+     */
+    private $sharedStorage;
+
+
+    /**
+     * @param SharedStorageInterface $sharedStorage
+     */
+    public function __construct(
+        SharedStorageInterface $sharedStorage
+    )
+    {
+        $this->sharedStorage = $sharedStorage;
+    }
+
+    /**
+     * @Then /^the placeholder value for expression "([^"]+)" should be "([^"]+)"$/
+     */
+    public function placeHolderValueShouldBe($expression, $value)
+    {
+        $placeholderHelper = new \Pimcore\Placeholder();
+        $data = [];
+        $executedValue = $placeholderHelper->replacePlaceholders($expression, $data);
+
+        Assert::same(
+            $executedValue,
+            $value,
+            sprintf('Expression value should be "%s" but is', $executedValue, $value)
+        );
+    }
+
+    /**
+     * @Then /^the placeholder value for expression "([^"]+)" for (object) should be "([^"]+)"$/
+     */
+    public function placeHolderValueForObjectShouldBe($expression, $object, $value)
+    {
+        $placeholderHelper = new \Pimcore\Placeholder();
+        $data = [];
+        $executedValue = $placeholderHelper->replacePlaceholders($expression, $data);
+
+        Assert::same(
+            $executedValue,
+            $value,
+            sprintf('Expression value should be "%s" but is', $executedValue, $value)
+        );
+    }
+}

--- a/src/CoreShop/Behat/Context/Domain/PlaceholderContext.php
+++ b/src/CoreShop/Behat/Context/Domain/PlaceholderContext.php
@@ -60,7 +60,9 @@ final class PlaceholderContext implements Context
     public function placeHolderValueForObjectShouldBe($expression, $object, $value)
     {
         $placeholderHelper = new \Pimcore\Placeholder();
-        $data = [];
+        $data = [
+            'object' => $object
+        ];
         $executedValue = $placeholderHelper->replacePlaceholders($expression, $data);
 
         Assert::same(

--- a/src/CoreShop/Behat/Context/Transform/SharedStorageContext.php
+++ b/src/CoreShop/Behat/Context/Transform/SharedStorageContext.php
@@ -14,6 +14,7 @@ namespace CoreShop\Behat\Context\Transform;
 
 use Behat\Behat\Context\Context;
 use CoreShop\Behat\Service\SharedStorageInterface;
+use Pimcore\Model\DataObject\Concrete;
 
 final class SharedStorageContext implements Context
 {
@@ -36,5 +37,13 @@ final class SharedStorageContext implements Context
     public function getLatestResource()
     {
         return $this->sharedStorage->getLatestResource();
+    }
+
+    /**
+     * @Transform /^(object)$/
+     */
+    public function getLatestObject()
+    {
+        return $this->getLatestResource() instanceof Concrete ? $this->getLatestResource() : null;
     }
 }

--- a/src/CoreShop/Behat/Resources/config/services/contexts/domain.yml
+++ b/src/CoreShop/Behat/Resources/config/services/contexts/domain.yml
@@ -150,3 +150,10 @@ services:
             - '@__symfony__.Pimcore\Templating\Helper\HeadMeta'
         tags:
             - { name: fob.context_service }
+
+    coreshop.behat.context.domain.placeholder:
+        class: CoreShop\Behat\Context\Domain\PlaceholderContext
+        arguments:
+            - '@coreshop.behat.shared_storage'
+        tags:
+            - { name: fob.context_service }

--- a/src/CoreShop/Behat/Resources/config/suites.yml
+++ b/src/CoreShop/Behat/Resources/config/suites.yml
@@ -10,3 +10,4 @@ imports:
     - suites/domain/pimcore.yml
     - suites/domain/order.yml
     - suites/domain/seo.yml
+    - suites/domain/placeholder.yml

--- a/src/CoreShop/Behat/Resources/config/suites/domain/placeholder.yml
+++ b/src/CoreShop/Behat/Resources/config/suites/domain/placeholder.yml
@@ -1,0 +1,15 @@
+default:
+    suites:
+        domain_placeholder:
+            contexts_services:
+                - coreshop.behat.context.hook.pimcore_setup
+                - coreshop.behat.context.hook.coreshop_setup
+
+                - coreshop.behat.context.hook.doctrine_orm
+                - coreshop.behat.context.hook.pimcore_dao
+
+                - coreshop.behat.context.transform.shared_storage
+
+                - coreshop.behat.context.domain.placeholder
+            filters:
+                tags: "@placeholder"

--- a/src/CoreShop/Behat/Resources/config/suites/domain/placeholder.yml
+++ b/src/CoreShop/Behat/Resources/config/suites/domain/placeholder.yml
@@ -10,6 +10,9 @@ default:
 
                 - coreshop.behat.context.transform.shared_storage
 
+                - coreshop.behat.context.setup.product
+                - coreshop.behat.context.setup.store
+
                 - coreshop.behat.context.domain.placeholder
             filters:
                 tags: "@placeholder"

--- a/src/CoreShop/Bundle/PimcoreBundle/CoreShopPimcoreBundle.php
+++ b/src/CoreShop/Bundle/PimcoreBundle/CoreShopPimcoreBundle.php
@@ -14,6 +14,7 @@ namespace CoreShop\Bundle\PimcoreBundle;
 
 use PackageVersions\Versions;
 use Pimcore\Extension\Bundle\AbstractPimcoreBundle;
+use Pimcore\Placeholder;
 
 final class CoreShopPimcoreBundle extends AbstractPimcoreBundle
 {
@@ -43,6 +44,16 @@ final class CoreShopPimcoreBundle extends AbstractPimcoreBundle
         }
 
         return 'coreshop/core-shop';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function boot()
+    {
+        parent::boot();
+
+        Placeholder::addPlaceholderClassPrefix('CoreShop\Component\Pimcore\Placeholder\\');
     }
 
     /**

--- a/src/CoreShop/Component/Pimcore/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/CoreShop/Component/Pimcore/ExpressionLanguage/ExpressionLanguage.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2017 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Component\Pimcore\ExpressionLanguage;
+
+use Symfony\Component\DependencyInjection\ExpressionLanguage as BaseExpressionLanguage;
+
+class ExpressionLanguage extends BaseExpressionLanguage
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct($cache = null, array $providers = array(), callable $serviceCompiler = null)
+    {
+        // prepend the default provider to let users override it easily
+        array_unshift($providers, new PimcoreLanguageProvider($serviceCompiler));
+
+        parent::__construct($cache, $providers);
+    }
+}

--- a/src/CoreShop/Component/Pimcore/ExpressionLanguage/PimcoreLanguageProvider.php
+++ b/src/CoreShop/Component/Pimcore/ExpressionLanguage/PimcoreLanguageProvider.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2017 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Component\Pimcore\ExpressionLanguage;
+
+use Pimcore\Model\Asset;
+use Pimcore\Model\DataObject;
+use Pimcore\Model\Document;
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+
+class PimcoreLanguageProvider implements ExpressionFunctionProviderInterface
+{
+    private $serviceCompiler;
+
+    public function __construct(callable $serviceCompiler = null)
+    {
+        $this->serviceCompiler = $serviceCompiler;
+    }
+
+    public function getFunctions()
+    {
+        return array(
+            new ExpressionFunction('object', $this->serviceCompiler ?: function ($arg) {
+                return sprintf('\\Pimcore\\Model\\DataObject::getById(%s)', $arg);
+            }, function (array $variables, $value) {
+                return DataObject::getById($value);
+            }),
+
+            new ExpressionFunction('asset', function ($arg) {
+                return sprintf('\\Pimcore\\Model\\Asset::getById(%s)', $arg);
+            }, function (array $variables, $value) {
+                return Asset::getById($value);
+            }),
+
+            new ExpressionFunction('document', function ($arg) {
+                return sprintf('\\Pimcore\\Model\\Document::getById(%s)', $arg);
+            }, function (array $variables, $value) {
+                return Document::getById($value);
+            }),
+        );
+    }
+}

--- a/src/CoreShop/Component/Pimcore/Placeholder/Expression.php
+++ b/src/CoreShop/Component/Pimcore/Placeholder/Expression.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2017 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Component\Pimcore\Placeholder;
+
+use CoreShop\Component\Pimcore\ExpressionLanguage\ExpressionLanguage;
+use Pimcore\Placeholder\AbstractPlaceholder;
+
+class Expression extends AbstractPlaceholder
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getTestValue()
+    {
+        return '<span class="testValue">Name of the Object</span>';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getReplacement()
+    {
+        $expr = new ExpressionLanguage();
+        $expression = $this->getPlaceholderConfig()->expression;
+
+        return $expr->evaluate($expression, [
+            'value' => $this->getValue(),
+            'key' => $this->getPlaceholderKey(),
+            'config' => $this->getPlaceholderConfig()->toArray(),
+            'container' => \Pimcore::getContainer()
+        ]);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

Allows you to use placeholders like:

```
%Expression(expression, {'expression' : 'parameter(\'kernel.environment\')'});
```

```
%Expression(expression, {'expression' : 'object(1).getProperty(\'test\')'});
```

```
%Expression(product, {'expression' : 'value.getProperty(\'test\')'});
```

```
%Expression(expression, {'expression' : 'service(\'coreshop.money_formatter\').format(100, \'EUR\', \'en\')'});
```