### PR TITLE
SilberMa: Change active, digitalProduct, isTracked from checkbox to b…

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Migrations/Version20180615093141.php
+++ b/src/CoreShop/Bundle/CoreBundle/Migrations/Version20180615093141.php
@@ -12,34 +12,34 @@ class Version20180615093141 extends AbstractPimcoreMigration implements Containe
 {
     use ContainerAwareTrait;
 
-    private const CORE_SHOP_PRODUCT_FIELDS = [
-        [
-            'fieldName' => 'active',
-            'yesValue'  => 'active',
-            'noValue'   => 'inactive',
-        ],
-        [
-            'fieldName' => 'digitalProduct',
-            'yesValue'  => 'isDigitalProduct',
-            'noValue'   => 'noDigitalProduct',
-        ],
-        [
-            'fieldName' => 'isTracked',
-            'yesValue'  => 'isTracked',
-            'noValue'   => 'notTracked',
-        ],
-    ];
-
     /**
      * @param Schema $schema
      */
     public function up(Schema $schema)
     {
+        $coreShopProductFields = [
+            [
+                'fieldName' => 'active',
+                'yesValue'  => 'active',
+                'noValue'   => 'inactive',
+            ],
+            [
+                'fieldName' => 'digitalProduct',
+                'yesValue'  => 'isDigitalProduct',
+                'noValue'   => 'noDigitalProduct',
+            ],
+            [
+                'fieldName' => 'isTracked',
+                'yesValue'  => 'isTracked',
+                'noValue'   => 'notTracked',
+            ],
+        ];
+
         $coreShopProductClass = $this->container->getParameter('coreshop.model.product.pimcore_class_name');
 
         $classUpdater = new ClassUpdate($coreShopProductClass);
 
-        foreach (self::CORE_SHOP_PRODUCT_FIELDS as $updateField) {
+        foreach ($coreShopProductFields as $updateField) {
             if ($classUpdater->hasField($updateField['fieldName'])) {
                 $classUpdater->replaceFieldProperties(
                     $updateField['fieldName'],
@@ -73,11 +73,29 @@ class Version20180615093141 extends AbstractPimcoreMigration implements Containe
      */
     public function down(Schema $schema)
     {
+        $coreShopProductFields = [
+            [
+                'fieldName' => 'active',
+                'yesValue'  => 'active',
+                'noValue'   => 'inactive',
+            ],
+            [
+                'fieldName' => 'digitalProduct',
+                'yesValue'  => 'isDigitalProduct',
+                'noValue'   => 'noDigitalProduct',
+            ],
+            [
+                'fieldName' => 'isTracked',
+                'yesValue'  => 'isTracked',
+                'noValue'   => 'notTracked',
+            ],
+        ];
+
         $coreShopProductClass = $this->container->getParameter('coreshop.model.product.pimcore_class_name');
 
         $classUpdater = new ClassUpdate($coreShopProductClass);
 
-        foreach (self::CORE_SHOP_PRODUCT_FIELDS as $updateField) {
+        foreach ($coreShopProductFields as $updateField) {
             if ($classUpdater->hasField($updateField['fieldName'])) {
                 $classUpdater->replaceFieldProperties($updateField['fieldName'], ['fieldtype' => 'checkbox']);
             }

--- a/src/CoreShop/Bundle/CoreBundle/Migrations/Version20180615093141.php
+++ b/src/CoreShop/Bundle/CoreBundle/Migrations/Version20180615093141.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace CoreShop\Bundle\CoreBundle\Migrations;
+
+use CoreShop\Component\Pimcore\DataObject\ClassUpdate;
+use Doctrine\DBAL\Schema\Schema;
+use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+class Version20180615093141 extends AbstractPimcoreMigration implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    private const CORE_SHOP_PRODUCT_FIELDS = [
+        [
+            'fieldName' => 'active',
+            'yesValue'  => 'active',
+            'noValue'   => 'inactive',
+        ],
+        [
+            'fieldName' => 'digitalProduct',
+            'yesValue'  => 'isDigitalProduct',
+            'noValue'   => 'noDigitalProduct',
+        ],
+        [
+            'fieldName' => 'isTracked',
+            'yesValue'  => 'isTracked',
+            'noValue'   => 'notTracked',
+        ],
+    ];
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $coreShopProductClass = $this->container->getParameter('coreshop.model.product.pimcore_class_name');
+
+        $classUpdater = new ClassUpdate($coreShopProductClass);
+
+        foreach (self::CORE_SHOP_PRODUCT_FIELDS as $updateField) {
+            if ($classUpdater->hasField($updateField['fieldName'])) {
+                $classUpdater->replaceFieldProperties(
+                    $updateField['fieldName'],
+                    [
+                        'fieldtype' => 'booleanSelect',
+                        'yesLabel'  => $updateField['yesValue'],
+                        'noLabel'   => $updateField['noValue'],
+                        'options'   => [
+                            0 => [
+                                'key'   => '',
+                                'value' => 0,
+                            ],
+                            1 => [
+                                'key'   => $updateField['yesValue'],
+                                'value' => 1,
+                            ],
+                            2 => [
+                                'key'   => $updateField['noValue'],
+                                'value' => -1,
+                            ],
+                        ],
+                    ]
+                );
+            }
+        }
+        $classUpdater->save();
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $coreShopProductClass = $this->container->getParameter('coreshop.model.product.pimcore_class_name');
+
+        $classUpdater = new ClassUpdate($coreShopProductClass);
+
+        foreach (self::CORE_SHOP_PRODUCT_FIELDS as $updateField) {
+            if ($classUpdater->hasField($updateField['fieldName'])) {
+                $classUpdater->replaceFieldProperties($updateField['fieldName'], ['fieldtype' => 'checkbox']);
+            }
+        }
+        $classUpdater->save();
+    }
+}

--- a/src/CoreShop/Bundle/CoreBundle/Resources/install/pimcore/classes/CoreShopProductBundle/CoreShopProduct.json
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/install/pimcore/classes/CoreShopProductBundle/CoreShopProduct.json
@@ -216,29 +216,17 @@
                                         "emptyLabel": null,
                                         "options": [
                                             {
-                                                0: [
-                                                    {
-                                                        "key": "empty",
-                                                        "value": 0
-                                                    }
-                                                ]
+                                                "key": "empty",
+                                                "value": 0
                                             },
                                             {
-                                                1: [
-                                                    {
-                                                        "key": "isDigitalProduct",
-                                                        "value": 1
-                                                    }
-                                                ]
+                                                "key": "isDigitalProduct",
+                                                "value": 1
                                             },
                                             {
-                                                2: [
-                                                    {
-                                                        "key": "noDigitalProduct",
-                                                        "value": -1
-                                                    }
-                                                ]
-                                            },
+                                                "key": "noDigitalProduct",
+                                                "value": -1
+                                            }
                                         ],
                                         "queryColumnType": "tinyint(1)",
                                         "columnType": "tinyint(1)",
@@ -679,29 +667,17 @@
                                 "emptyLabel": null,
                                 "options": [
                                     {
-                                        0: [
-                                            {
-                                                "key": "empty",
-                                                "value": 0
-                                            }
-                                        ]
+                                        "key": "empty",
+                                        "value": 0
                                     },
                                     {
-                                        1: [
-                                            {
-                                                "key": "isTracked",
-                                                "value": 1
-                                            }
-                                        ]
+                                        "key": "isTracked",
+                                        "value": 1
                                     },
                                     {
-                                        2: [
-                                            {
-                                                "key": "notTracked",
-                                                "value": -1
-                                            }
-                                        ]
-                                    },
+                                        "key": "notTracked",
+                                        "value": -1
+                                    }
                                 ],
                                 "queryColumnType": "tinyint(1)",
                                 "columnType": "tinyint(1)",

--- a/src/CoreShop/Bundle/CoreBundle/Resources/install/pimcore/classes/CoreShopProductBundle/CoreShopProduct.json
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/install/pimcore/classes/CoreShopProductBundle/CoreShopProduct.json
@@ -210,8 +210,36 @@
                                         "visibleSearch": true
                                     },
                                     {
-                                        "fieldtype": "checkbox",
-                                        "defaultValue": 0,
+                                        "fieldtype": "booleanSelect",
+                                        "yesLabel": "isDigitalProduct",
+                                        "noLabel": "noDigitalProduct",
+                                        "emptyLabel": null,
+                                        "options": [
+                                            {
+                                                0: [
+                                                    {
+                                                        "key": "empty",
+                                                        "value": 0
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                1: [
+                                                    {
+                                                        "key": "isDigitalProduct",
+                                                        "value": 1
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                2: [
+                                                    {
+                                                        "key": "noDigitalProduct",
+                                                        "value": -1
+                                                    }
+                                                ]
+                                            },
+                                        ],
                                         "queryColumnType": "tinyint(1)",
                                         "columnType": "tinyint(1)",
                                         "phpdocType": "boolean",
@@ -645,8 +673,36 @@
                                 "visibleSearch": false
                             },
                             {
-                                "fieldtype": "checkbox",
-                                "defaultValue": 0,
+                                "fieldtype": "booleanSelect",
+                                "yesLabel": "isTracked",
+                                "noLabel": "notTracked",
+                                "emptyLabel": null,
+                                "options": [
+                                    {
+                                        0: [
+                                            {
+                                                "key": "empty",
+                                                "value": 0
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        1: [
+                                            {
+                                                "key": "isTracked",
+                                                "value": 1
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        2: [
+                                            {
+                                                "key": "notTracked",
+                                                "value": -1
+                                            }
+                                        ]
+                                    },
+                                ],
                                 "queryColumnType": "tinyint(1)",
                                 "columnType": "tinyint(1)",
                                 "phpdocType": "boolean",

--- a/src/CoreShop/Bundle/ProductBundle/Resources/install/pimcore/classes/CoreShopProduct.json
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/install/pimcore/classes/CoreShopProduct.json
@@ -193,30 +193,19 @@
                                         "noLabel": "inactive",
                                         "emptyLabel": null,
                                         "options": [
-                                          {
-                                            0: [
-                                              {
+                                            {
                                                 "key": "empty",
                                                 "value": 0
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            1: [
-                                              {
+                                            },
+                                            {
+
                                                 "key": "active",
                                                 "value": 1
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            2: [
-                                              {
+                                            },
+                                            {
                                                 "key": "inactive",
                                                 "value": -1
-                                              }
-                                            ]
-                                          },
+                                            }
                                         ],
                                         "queryColumnType": "tinyint(1)",
                                         "columnType": "tinyint(1)",

--- a/src/CoreShop/Bundle/ProductBundle/Resources/install/pimcore/classes/CoreShopProduct.json
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/install/pimcore/classes/CoreShopProduct.json
@@ -188,8 +188,36 @@
                                         "visibleSearch": true
                                     },
                                     {
-                                        "fieldtype": "checkbox",
-                                        "defaultValue": 0,
+                                        "fieldtype": "booleanSelect",
+                                        "yesLabel": "active",
+                                        "noLabel": "inactive",
+                                        "emptyLabel": null,
+                                        "options": [
+                                          {
+                                            0: [
+                                              {
+                                                "key": "empty",
+                                                "value": 0
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            1: [
+                                              {
+                                                "key": "active",
+                                                "value": 1
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            2: [
+                                              {
+                                                "key": "inactive",
+                                                "value": -1
+                                              }
+                                            ]
+                                          },
+                                        ],
                                         "queryColumnType": "tinyint(1)",
                                         "columnType": "tinyint(1)",
                                         "phpdocType": "boolean",


### PR DESCRIPTION
…ooleanselect to solve variant and inheritance issues

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

<!--
Created a migration to  change the fieldtype of "active", "digitalProduct" and "isTracked" from checkbox into booleanselect with the following values:

> private const CORE_SHOP_PRODUCT_FIELDS = [
        [
            'fieldName' => 'active',
            'yesValue'  => 'active',
            'noValue'   => 'inactive',
        ],
        [
            'fieldName' => 'digitalProduct',
            'yesValue'  => 'isDigitalProduct',
            'noValue'   => 'noDigitalProduct',
        ],
        [
            'fieldName' => 'isTracked',
            'yesValue'  => 'isTracked',
            'noValue'   => 'notTracked',
        ],
    ];

-->
