### PR TITLE
[Rules] Fix action join column name

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Migrations/Version20180616104008.php
+++ b/src/CoreShop/Bundle/CoreBundle/Migrations/Version20180616104008.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace CoreShop\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
+
+class Version20180616104008 extends AbstractPimcoreMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE coreshop_cart_price_rule_action DROP FOREIGN KEY FK_830435D887793B6;');
+        $this->addSql('DROP INDEX IDX_830435D887793B6 ON coreshop_cart_price_rule_action;');
+        $this->addSql('ALTER TABLE coreshop_cart_price_rule_action DROP PRIMARY KEY;');
+        $this->addSql('ALTER TABLE coreshop_cart_price_rule_action CHANGE condition_id action_id INT NOT NULL;');
+        $this->addSql('ALTER TABLE coreshop_cart_price_rule_action ADD CONSTRAINT FK_830435D9D32F035 FOREIGN KEY (action_id) REFERENCES coreshop_rule_action (id) ON DELETE CASCADE;');
+        $this->addSql('CREATE INDEX IDX_830435D9D32F035 ON coreshop_cart_price_rule_action (action_id);');
+        $this->addSql('ALTER TABLE coreshop_cart_price_rule_action ADD PRIMARY KEY (price_rule_id, action_id);');
+        $this->addSql('ALTER TABLE coreshop_product_price_rule_action DROP FOREIGN KEY FK_47E36FB8887793B6;');
+        $this->addSql('DROP INDEX IDX_47E36FB8887793B6 ON coreshop_product_price_rule_action;');
+        $this->addSql('ALTER TABLE coreshop_product_price_rule_action DROP PRIMARY KEY;');
+        $this->addSql('ALTER TABLE coreshop_product_price_rule_action CHANGE condition_id action_id INT NOT NULL;');
+        $this->addSql('ALTER TABLE coreshop_product_price_rule_action ADD CONSTRAINT FK_47E36FB89D32F035 FOREIGN KEY (action_id) REFERENCES coreshop_rule_action (id) ON DELETE CASCADE;');
+        $this->addSql('CREATE INDEX IDX_47E36FB89D32F035 ON coreshop_product_price_rule_action (action_id);');
+        $this->addSql('ALTER TABLE coreshop_product_price_rule_action ADD PRIMARY KEY (price_rule_id, action_id);');
+        $this->addSql('ALTER TABLE coreshop_product_specific_price_rule_action DROP FOREIGN KEY FK_B89BEDCE887793B6;');
+        $this->addSql('DROP INDEX IDX_B89BEDCE887793B6 ON coreshop_product_specific_price_rule_action;');
+        $this->addSql('ALTER TABLE coreshop_product_specific_price_rule_action DROP PRIMARY KEY;');
+        $this->addSql('ALTER TABLE coreshop_product_specific_price_rule_action CHANGE condition_id action_id INT NOT NULL;');
+        $this->addSql('ALTER TABLE coreshop_product_specific_price_rule_action ADD CONSTRAINT FK_B89BEDCE9D32F035 FOREIGN KEY (action_id) REFERENCES coreshop_rule_action (id) ON DELETE CASCADE;');
+        $this->addSql('CREATE INDEX IDX_B89BEDCE9D32F035 ON coreshop_product_specific_price_rule_action (action_id);');
+        $this->addSql('ALTER TABLE coreshop_product_specific_price_rule_action ADD PRIMARY KEY (price_rule_id, action_id);');
+        $this->addSql('ALTER TABLE coreshop_exchange_rate CHANGE exchangeRate exchangeRate NUMERIC(10, 5) NOT NULL;');
+        $this->addSql('ALTER TABLE coreshop_notification_rule_action DROP FOREIGN KEY FK_D2282E7B887793B6;');
+        $this->addSql('DROP INDEX IDX_D2282E7B887793B6 ON coreshop_notification_rule_action;');
+        $this->addSql('ALTER TABLE coreshop_notification_rule_action DROP PRIMARY KEY;');
+        $this->addSql('ALTER TABLE coreshop_notification_rule_action CHANGE condition_id action_id INT NOT NULL;');
+        $this->addSql('ALTER TABLE coreshop_notification_rule_action ADD CONSTRAINT FK_D2282E7B9D32F035 FOREIGN KEY (action_id) REFERENCES coreshop_rule_action (id) ON DELETE CASCADE;');
+        $this->addSql('CREATE INDEX IDX_D2282E7B9D32F035 ON coreshop_notification_rule_action (action_id);');
+        $this->addSql('ALTER TABLE coreshop_notification_rule_action ADD PRIMARY KEY (notification_id, action_id);');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+
+    }
+}

--- a/src/CoreShop/Bundle/CoreBundle/Migrations/Version20180616104008.php
+++ b/src/CoreShop/Bundle/CoreBundle/Migrations/Version20180616104008.php
@@ -4,9 +4,13 @@ namespace CoreShop\Bundle\CoreBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-class Version20180616104008 extends AbstractPimcoreMigration
+class Version20180616104008 extends AbstractPimcoreMigration implements ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     /**
      * @param Schema $schema
      */
@@ -41,6 +45,8 @@ class Version20180616104008 extends AbstractPimcoreMigration
         $this->addSql('ALTER TABLE coreshop_notification_rule_action ADD CONSTRAINT FK_D2282E7B9D32F035 FOREIGN KEY (action_id) REFERENCES coreshop_rule_action (id) ON DELETE CASCADE;');
         $this->addSql('CREATE INDEX IDX_D2282E7B9D32F035 ON coreshop_notification_rule_action (action_id);');
         $this->addSql('ALTER TABLE coreshop_notification_rule_action ADD PRIMARY KEY (notification_id, action_id);');
+
+        $this->container->get('pimcore.cache.core.handler')->clearTag('doctrine_pimcore_cache');
     }
 
     /**

--- a/src/CoreShop/Bundle/NotificationBundle/Resources/config/doctrine/model/NotificationRule.orm.yml
+++ b/src/CoreShop/Bundle/NotificationBundle/Resources/config/doctrine/model/NotificationRule.orm.yml
@@ -62,7 +62,7 @@ CoreShop\Component\Notification\Model\NotificationRule:
                         nullable: false
                         onDelete: CASCADE
                 inverseJoinColumns:
-                    condition_id:
+                    action_id:
                         referencedColumnName: id
                         nullable: false
                         onDelete: CASCADE

--- a/src/CoreShop/Bundle/OrderBundle/Resources/config/doctrine/model/CartPriceRule.orm.yml
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/config/doctrine/model/CartPriceRule.orm.yml
@@ -69,7 +69,7 @@ CoreShop\Component\Order\Model\CartPriceRule:
                         nullable: false
                         onDelete: CASCADE
                 inverseJoinColumns:
-                    condition_id:
+                    action_id:
                         referencedColumnName: id
                         nullable: false
                         onDelete: CASCADE

--- a/src/CoreShop/Bundle/ProductBundle/Resources/config/doctrine/model/ProductPriceRule.orm.yml
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/config/doctrine/model/ProductPriceRule.orm.yml
@@ -59,7 +59,7 @@ CoreShop\Component\Product\Model\ProductPriceRule:
                         nullable: false
                         onDelete: CASCADE
                 inverseJoinColumns:
-                    condition_id:
+                    action_id:
                         referencedColumnName: id
                         nullable: false
                         onDelete: CASCADE

--- a/src/CoreShop/Bundle/ProductBundle/Resources/config/doctrine/model/ProductSpecificPriceRule.orm.yml
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/config/doctrine/model/ProductSpecificPriceRule.orm.yml
@@ -65,7 +65,7 @@ CoreShop\Component\Product\Model\ProductSpecificPriceRule:
                         nullable: false
                         onDelete: CASCADE
                 inverseJoinColumns:
-                    condition_id:
+                    action_id:
                         referencedColumnName: id
                         nullable: false
                         onDelete: CASCADE


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

For action classes the join column was named "condition_id" due to a copy-paste error on my side. This fixes that.
