### PR TITLE
Processable Items Extension

### DIFF
--- a/src/CoreShop/Bundle/OrderBundle/Controller/OrderController.php
+++ b/src/CoreShop/Bundle/OrderBundle/Controller/OrderController.php
@@ -261,7 +261,7 @@ class OrderController extends AbstractSaleDetailController
             $order['editable'] = count($this->getInvoices($sale)) > 0 ? false : true;
             $order['invoices'] = $this->getInvoices($sale);
             $order['shipments'] = $this->getShipments($sale);
-            $order['paymentCreationAllowed'] = $sale->getOrderState() !== OrderStates::STATE_CANCELLED;
+            $order['paymentCreationAllowed'] = !in_array($sale->getOrderState(), [OrderStates::STATE_CANCELLED, OrderStates::STATE_COMPLETE]);
             $order['invoiceCreationAllowed'] = $this->getInvoiceProcessableHelper()->isProcessable($sale);
             $order['shipmentCreationAllowed'] = $this->getShipmentProcessableHelper()->isProcessable($sale);
         }

--- a/src/CoreShop/Bundle/OrderBundle/Controller/OrderController.php
+++ b/src/CoreShop/Bundle/OrderBundle/Controller/OrderController.php
@@ -20,6 +20,7 @@ use CoreShop\Component\Order\Model\SaleInterface;
 use CoreShop\Component\Order\OrderInvoiceTransitions;
 use CoreShop\Component\Order\OrderPaymentTransitions;
 use CoreShop\Component\Order\OrderShipmentTransitions;
+use CoreShop\Component\Order\OrderStates;
 use CoreShop\Component\Order\OrderTransitions;
 use CoreShop\Component\Order\Processable\ProcessableInterface;
 use CoreShop\Component\Order\Repository\OrderInvoiceRepositoryInterface;
@@ -260,6 +261,7 @@ class OrderController extends AbstractSaleDetailController
             $order['editable'] = count($this->getInvoices($sale)) > 0 ? false : true;
             $order['invoices'] = $this->getInvoices($sale);
             $order['shipments'] = $this->getShipments($sale);
+            $order['paymentCreationAllowed'] = $sale->getOrderState() !== OrderStates::STATE_CANCELLED;
             $order['invoiceCreationAllowed'] = $this->getInvoiceProcessableHelper()->isProcessable($sale);
             $order['shipmentCreationAllowed'] = $this->getShipmentProcessableHelper()->isProcessable($sale);
         }

--- a/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/order/detail/blocks/invoice.js
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/order/detail/blocks/invoice.js
@@ -170,24 +170,20 @@ coreshop.order.order.detail.blocks.invoice = Class.create(coreshop.order.sale.de
 
     updateSale: function () {
         var me = this,
-            tool = me.invoiceDetails.tools.find(function(tool) { return tool.type === 'coreshop-add';});
+            tool = me.invoiceDetails.tools.find(function(tool) { return tool.type === 'coreshop-add'; });
 
         me.invoicesStore.loadRawData(me.sale.invoices);
 
         if (me.sale.invoiceCreationAllowed) {
             me.topBarButton.show();
-
             if (tool && Ext.isFunction(tool.show)) {
                 tool.show();
             }
-        }
-        else {
+        } else {
             me.topBarButton.hide();
-
             if (tool && Ext.isFunction(tool.hide)) {
                 tool.hide();
-            }
-            else {
+            } else {
                 tool.hidden = true;
             }
         }

--- a/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/order/detail/blocks/payment.js
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/order/detail/blocks/payment.js
@@ -164,9 +164,22 @@ coreshop.order.order.detail.blocks.payment = Class.create(coreshop.order.sale.de
     },
 
     updateSale: function () {
-        var me = this;
+        var me = this,
+            tool = me.paymentInfo.tools.find(function(tool) { return tool.type === 'coreshop-add'; });
 
         me.paymentsStore.loadRawData(me.sale.payments);
         me.updatePaymentInfoAlert();
+
+        if (me.sale.paymentCreationAllowed) {
+            if (tool && Ext.isFunction(tool.show)) {
+                tool.show();
+            }
+        } else {
+            if (tool && Ext.isFunction(tool.hide)) {
+                tool.hide();
+            } else {
+                tool.hidden = true;
+            }
+        }
     }
 });

--- a/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/order/detail/blocks/shipment.js
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/order/detail/blocks/shipment.js
@@ -164,24 +164,20 @@ coreshop.order.order.detail.blocks.shipment = Class.create(coreshop.order.sale.d
 
     updateSale: function () {
         var me = this,
-            tool = me.shippingInfo.tools.find(function(tool) { return tool.type === 'coreshop-add';});
+            tool = me.shippingInfo.tools.find(function(tool) { return tool.type === 'coreshop-add'; });
 
         me.shipmentsStore.loadRawData(me.sale.shipments);
 
         if (me.sale.shipmentCreationAllowed) {
             me.topBarButton.show();
-
             if (tool && Ext.isFunction(tool.show)) {
                 tool.show();
             }
-        }
-        else {
+        } else {
             me.topBarButton.hide();
-
             if (tool && Ext.isFunction(tool.hide)) {
                 tool.hide();
-            }
-            else {
+            } else {
                 tool.hidden = true;
             }
         }

--- a/src/CoreShop/Component/Order/Processable/ProcessableOrderItems.php
+++ b/src/CoreShop/Component/Order/Processable/ProcessableOrderItems.php
@@ -12,9 +12,9 @@
 
 namespace CoreShop\Component\Order\Processable;
 
+use CoreShop\Component\Order\OrderStates;
 use CoreShop\Component\Order\Model\OrderInterface;
 use CoreShop\Component\Order\Model\OrderItemInterface;
-use CoreShop\Component\Order\OrderPaymentStates;
 use CoreShop\Component\Order\Repository\OrderDocumentRepositoryInterface;
 
 class ProcessableOrderItems implements ProcessableInterface
@@ -112,6 +112,6 @@ class ProcessableOrderItems implements ProcessableInterface
      */
     public function isProcessable(OrderInterface $order)
     {
-        return !$this->isFullyProcessed($order) && $order->getPaymentState() === OrderPaymentStates::STATE_PAID;
+        return !$this->isFullyProcessed($order) && $order->getOrderState() !== OrderStates::STATE_CANCELLED;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #501

This PR fixes:
- Allow adding shipments regardless of payment state (Only disallowed if order has been cancelled)
- Allow adding invoices regardless of payment state (Only disallowed if order has been cancelled)
- Implement `paymentCreationAllowed`, to prevent payment additions after a order has been completed or cancelled