### PR TITLE
[All] change all resource combo-boxes to load the store 'async'.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,7 @@
     "friends-of-behat/symfony-extension": "^1.2",
     "friends-of-behat/variadic-extension": "^1.1",
     "mamuz/php-dependency-analysis": "^1.3",
-    "symplify/easy-coding-standard": "^4.4.0",
+    "symplify/easy-coding-standard": "^4.3.0",
     "leanphp/behat-code-coverage": "^3.2"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,7 @@
     "friends-of-behat/symfony-extension": "^1.2",
     "friends-of-behat/variadic-extension": "^1.1",
     "mamuz/php-dependency-analysis": "^1.3",
-    "symplify/easy-coding-standard": "^4.3.0",
+    "symplify/easy-coding-standard": "^4.4.0",
     "leanphp/behat-code-coverage": "^3.2"
   },
   "autoload": {

--- a/src/CoreShop/Bundle/AddressBundle/Resources/public/pimcore/js/resource/country.js
+++ b/src/CoreShop/Bundle/AddressBundle/Resources/public/pimcore/js/resource/country.js
@@ -4,5 +4,10 @@ Ext.define('CoreShop.store.Country', {
 
     name: 'country',
     fieldLabel: t('coreshop_country'),
-    store: pimcore.globalmanager.get('coreshop_countries')
+
+    initComponent: function () {
+        this.store = pimcore.globalmanager.get('coreshop_countries');
+
+        this.callParent();
+    }
 });

--- a/src/CoreShop/Bundle/AddressBundle/Resources/public/pimcore/js/resource/state.js
+++ b/src/CoreShop/Bundle/AddressBundle/Resources/public/pimcore/js/resource/state.js
@@ -4,5 +4,10 @@ Ext.define('CoreShop.store.State', {
 
     name: 'state',
     fieldLabel: t('coreshop_state'),
-    store: pimcore.globalmanager.get('coreshop_states')
+
+    initComponent: function () {
+        this.store = pimcore.globalmanager.get('coreshop_states');
+
+        this.callParent();
+    }
 });

--- a/src/CoreShop/Bundle/AddressBundle/Resources/public/pimcore/js/resource/zone.js
+++ b/src/CoreShop/Bundle/AddressBundle/Resources/public/pimcore/js/resource/zone.js
@@ -4,5 +4,10 @@ Ext.define('CoreShop.store.Zone', {
 
     name: 'zone',
     fieldLabel: t('coreshop_zone'),
-    store: pimcore.globalmanager.get('coreshop_zones')
+
+    initComponent: function () {
+        this.store = pimcore.globalmanager.get('coreshop_zones');
+
+        this.callParent();
+    }
 });

--- a/src/CoreShop/Bundle/CurrencyBundle/Resources/public/pimcore/js/resource/currency.js
+++ b/src/CoreShop/Bundle/CurrencyBundle/Resources/public/pimcore/js/resource/currency.js
@@ -4,5 +4,10 @@ Ext.define('CoreShop.store.Currency', {
 
     name: 'currency',
     fieldLabel: t('coreshop_currency'),
-    store: pimcore.globalmanager.get('coreshop_currencies')
+
+    initComponent: function () {
+        this.store = pimcore.globalmanager.get('coreshop_currencies');
+
+        this.callParent();
+    }
 });

--- a/src/CoreShop/Bundle/StoreBundle/Resources/public/pimcore/js/resource/store.js
+++ b/src/CoreShop/Bundle/StoreBundle/Resources/public/pimcore/js/resource/store.js
@@ -4,5 +4,10 @@ Ext.define('CoreShop.store.Store', {
 
     name: 'store',
     fieldLabel: t('coreshop_store'),
-    store: pimcore.globalmanager.get('coreshop_stores')
+
+    initComponent: function () {
+        this.store = pimcore.globalmanager.get('coreshop_stores');
+
+        this.callParent();
+    }
 });

--- a/src/CoreShop/Bundle/TaxationBundle/Resources/public/pimcore/js/resource/taxRate.js
+++ b/src/CoreShop/Bundle/TaxationBundle/Resources/public/pimcore/js/resource/taxRate.js
@@ -4,5 +4,10 @@ Ext.define('CoreShop.store.TaxRate', {
 
     name: 'taxRate',
     fieldLabel: t('coreshop_tax_rate'),
-    store: pimcore.globalmanager.get('coreshop_tax_rates')
+
+    initComponent: function () {
+        this.store = pimcore.globalmanager.get('coreshop_tax_rates');
+
+        this.callParent();
+    }
 });

--- a/src/CoreShop/Bundle/TaxationBundle/Resources/public/pimcore/js/resource/taxRuleGroup.js
+++ b/src/CoreShop/Bundle/TaxationBundle/Resources/public/pimcore/js/resource/taxRuleGroup.js
@@ -3,12 +3,17 @@ Ext.define('CoreShop.store.TaxRuleGroup', {
     alias: 'widget.coreshop.taxRuleGroup',
 
     name: 'taxRule',
-    fieldLabel: t('coreshop_tax_rule_group'),
     storeId: 'coreshop_taxrulegroups',
     listeners: {
         beforerender: function () {
             if (!this.getStore().isLoaded() && !this.getStore().isLoading())
                 this.getStore().load();
         }
+    },
+
+    initComponent: function () {
+        this.store = pimcore.globalmanager.get('coreshop_tax_rule_group');
+
+        this.callParent();
     }
 });


### PR DESCRIPTION
 Reason for that: since we load resource stores differently now, they don't exist at time of loading this resource combo boxes.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
