### PR TITLE
[Index] rename getName/getEnabled to getIndexableName/getIndexableEnabled in IndexableInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
     - Before adding a new Shipment / Invoice you need to dispatch a request state to your order. Read more about it [here](./docs/03_Development/06_Order/05_Invoice/01_Invoice_Creation.md) and [here](./docs/03_Development/06_Order/06_Shipment/01_Shipment_Creation.md).
 
  - **BC break** getName in ```CoreShop\Component\Index\Model\IndexableInterface``` has been changed to `getIndexableName` as `getName` could eventually conflict with a non localized Pimcore Field
+ - **BC break** getEnabled in ```CoreShop\Component\Index\Model\IndexableInterface``` has been changed to `getIndexableEnabled` as `getEnabled` could eventually conflict with a localized Pimcore Field
+
 
 ## 2.0.0-beta.1 to 2.0.0-beta.2
  - Link Generator implemented. If you want to use nice urls, you need to add the link generator service:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
  - **BC break** Shipment / Invoice Creation via API changed
     - Before adding a new Shipment / Invoice you need to dispatch a request state to your order. Read more about it [here](./docs/03_Development/06_Order/05_Invoice/01_Invoice_Creation.md) and [here](./docs/03_Development/06_Order/06_Shipment/01_Shipment_Creation.md).
 
+ - **BC break** getName in ```CoreShop\Component\Index\Model\IndexableInterface``` has been changed to `getIndexableName` as `getName` could eventually conflict with a non localized Pimcore Field
+
 ## 2.0.0-beta.1 to 2.0.0-beta.2
  - Link Generator implemented. If you want to use nice urls, you need to add the link generator service:
     - CoreShopProduct: add `@coreshop.object.link_generator.product` as Link Provider

--- a/src/CoreShop/Behat/Model/Index/TestEnableIndex.php
+++ b/src/CoreShop/Behat/Model/Index/TestEnableIndex.php
@@ -41,4 +41,12 @@ class TestEnableIndex extends AbstractPimcoreModel implements IndexableInterface
     {
         return new ImplementedByPimcoreException(__CLASS__, __METHOD__);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIndexableName($language)
+    {
+        return $this->getName($language);
+    }
 }

--- a/src/CoreShop/Behat/Model/Index/TestEnableIndex.php
+++ b/src/CoreShop/Behat/Model/Index/TestEnableIndex.php
@@ -31,6 +31,14 @@ class TestEnableIndex extends AbstractPimcoreModel implements IndexableInterface
      */
     public function getIndexableEnabled()
     {
+        return $this->getEnabled();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEnabled()
+    {
         return new ImplementedByPimcoreException(__CLASS__, __METHOD__);
     }
 

--- a/src/CoreShop/Behat/Model/Index/TestEnableIndex.php
+++ b/src/CoreShop/Behat/Model/Index/TestEnableIndex.php
@@ -23,13 +23,13 @@ class TestEnableIndex extends AbstractPimcoreModel implements IndexableInterface
      */
     public function getIndexable()
     {
-        return $this->getEnabled() && $this->getPublished();
+        return $this->getIndexableEnabled() && $this->getPublished();
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getEnabled()
+    public function getIndexableEnabled()
     {
         return new ImplementedByPimcoreException(__CLASS__, __METHOD__);
     }

--- a/src/CoreShop/Behat/Model/Index/TestIndex.php
+++ b/src/CoreShop/Behat/Model/Index/TestIndex.php
@@ -29,6 +29,14 @@ class TestIndex extends AbstractPimcoreModel implements IndexableInterface
     /**
      * {@inheritdoc}
      */
+    public function getIndexableEnabled()
+    {
+        return $this->getEnabled();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getEnabled()
     {
         return new ImplementedByPimcoreException(__CLASS__, __METHOD__);

--- a/src/CoreShop/Behat/Model/Index/TestIndex.php
+++ b/src/CoreShop/Behat/Model/Index/TestIndex.php
@@ -41,4 +41,12 @@ class TestIndex extends AbstractPimcoreModel implements IndexableInterface
     {
         return new ImplementedByPimcoreException(__CLASS__, __METHOD__);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIndexableName($language)
+    {
+        return $this->getName($language);
+    }
 }

--- a/src/CoreShop/Bundle/IndexBundle/Worker/AbstractWorker.php
+++ b/src/CoreShop/Bundle/IndexBundle/Worker/AbstractWorker.php
@@ -108,7 +108,7 @@ abstract class AbstractWorker implements WorkerInterface
             $extensions = $this->getExtensions($index);
 
             $virtualObjectId = $object->getId();
-            $virtualObjectActive = $object->getEnabled();
+            $virtualObjectActive = $object->getIndexableEnabled();
 
             if ($object->getType() === Concrete::OBJECT_TYPE_VARIANT) {
                 $parent = $object->getParent();
@@ -118,7 +118,7 @@ abstract class AbstractWorker implements WorkerInterface
                 }
 
                 $virtualObjectId = $parent->getId();
-                $virtualObjectActive = $object->getEnabled();
+                $virtualObjectActive = $object->getIndexableEnabled();
             }
 
             $validLanguages = Tool::getValidLanguages();
@@ -139,7 +139,7 @@ abstract class AbstractWorker implements WorkerInterface
                 }
             }
 
-            $data['active'] = $object->getEnabled();
+            $data['active'] = $object->getIndexableEnabled();
 
             if (!is_bool($data['active'])) {
                 $data['active'] = false;

--- a/src/CoreShop/Bundle/IndexBundle/Worker/AbstractWorker.php
+++ b/src/CoreShop/Bundle/IndexBundle/Worker/AbstractWorker.php
@@ -151,7 +151,7 @@ abstract class AbstractWorker implements WorkerInterface
             ];
 
             foreach ($validLanguages as $language) {
-                $localizedData['values'][$language]['name'] = $object->getName($language);
+                $localizedData['values'][$language]['name'] = $object->getIndexableName($language);
             }
 
             $relationData = [];

--- a/src/CoreShop/Bundle/OrderBundle/Controller/AbstractSaleController.php
+++ b/src/CoreShop/Bundle/OrderBundle/Controller/AbstractSaleController.php
@@ -19,11 +19,12 @@ use Pimcore\Model\DataObject;
 abstract class AbstractSaleController extends PimcoreController
 {
     /**
-     * @param mixed $data
+     * @param DataObject\Concrete $data
+     * @param array $loadedObjects
      *
      * @return array
      */
-    protected function getDataForObject($data)
+    protected function getDataForObject(DataObject\Concrete $data, $loadedObjects = [])
     {
         if (!$data instanceof DataObject\AbstractObject) {
             return [];
@@ -43,14 +44,18 @@ abstract class AbstractSaleController extends PimcoreController
 
             if ($def instanceof DataObject\ClassDefinition\Data\Href) {
                 if ($fieldData instanceof DataObject\Concrete) {
-                    $objectData[$key] = $this->getDataForObject($fieldData);
+                    if (!in_array($fieldData->getId(), $loadedObjects)) {
+                        $objectData[$key] = $this->getDataForObject($fieldData, $loadedObjects);
+                    }
                 }
             } elseif ($def instanceof DataObject\ClassDefinition\Data\Multihref) {
                 $objectData[$key] = [];
 
                 foreach ($fieldData as $object) {
                     if ($object instanceof DataObject\Concrete) {
-                        $objectData[$key][] = $this->getDataForObject($object);
+                        if (!in_array($object->getId(), $loadedObjects)) {
+                            $objectData[$key][] = $this->getDataForObject($object, $loadedObjects);
+                        }
                     }
                 }
             } elseif ($def instanceof DataObject\ClassDefinition\Data) {
@@ -65,6 +70,8 @@ abstract class AbstractSaleController extends PimcoreController
                 $objectData[$key] = null;
             }
         }
+
+        $loadedObjects[] = $data->getId();
 
         $objectData['o_id'] = $data->getId();
         $objectData['o_creationDate'] = $data->getCreationDate();

--- a/src/CoreShop/Component/Core/Model/Product.php
+++ b/src/CoreShop/Component/Core/Model/Product.php
@@ -222,4 +222,12 @@ class Product extends BaseProduct implements ProductInterface
     {
         return $this->getEnabled();
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIndexableName($language)
+    {
+        return $this->getName($language);
+    }
 }

--- a/src/CoreShop/Component/Core/Model/Product.php
+++ b/src/CoreShop/Component/Core/Model/Product.php
@@ -210,7 +210,7 @@ class Product extends BaseProduct implements ProductInterface
     /**
      * {@inheritdoc}
      */
-    public function getEnabled()
+    public function getIndexableEnabled()
     {
         return $this->getActive() && $this->getPublished();
     }
@@ -220,7 +220,7 @@ class Product extends BaseProduct implements ProductInterface
      */
     public function getIndexable()
     {
-        return $this->getEnabled();
+        return $this->getIndexableEnabled();
     }
 
     /**

--- a/src/CoreShop/Component/Index/Model/IndexableInterface.php
+++ b/src/CoreShop/Component/Index/Model/IndexableInterface.php
@@ -22,7 +22,7 @@ interface IndexableInterface
     /**
      * @return boolean
      */
-    public function getEnabled();
+    public function getIndexableEnabled();
 
     /**
      * @return boolean

--- a/src/CoreShop/Component/Index/Model/IndexableInterface.php
+++ b/src/CoreShop/Component/Index/Model/IndexableInterface.php
@@ -53,7 +53,7 @@ interface IndexableInterface
      * @param $language
      * @return string
      */
-    public function getName($language);
+    public function getIndexableName($language);
 
     /**
      * @return static|null


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no

getName could eventually conflict with a Pimcore non-localized name field, therefore we rename ours to getIndexableName to provide support for that. This is a hard BC Break cause there is no possibility to mark it deprecated. 

Also does the same for getEnabled -> getIndexableEnabled