### PR TITLE
Fix issue with calling delete on array

### DIFF
--- a/src/CoreShop/Bundle/ResourceBundle/Pimcore/ObjectManager.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Pimcore/ObjectManager.php
@@ -137,13 +137,9 @@ final class ObjectManager implements \Doctrine\Common\Persistence\ObjectManager
      */
     public function flush()
     {
-        foreach ($this->modelsToRemove as $models) {
-            if (is_array($models)) {
-                foreach ($models as $model) {
-                    $model->delete();
-                }
-            } else {
-                $models->delete();
+        foreach ($this->modelsToRemove as $className => $classTypeModels) {
+            foreach ($classTypeModels as $model) {
+                $model->delete();
             }
         }
 

--- a/src/CoreShop/Bundle/ResourceBundle/Pimcore/ObjectManager.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Pimcore/ObjectManager.php
@@ -137,8 +137,14 @@ final class ObjectManager implements \Doctrine\Common\Persistence\ObjectManager
      */
     public function flush()
     {
-        foreach ($this->modelsToRemove as $model) {
-            $model->delete();
+        foreach ($this->modelsToRemove as $models) {
+            if (is_array($models)) {
+                foreach ($models as $model) {
+                    $model->delete();
+                }
+            } else {
+                $models->delete();
+            }
         }
 
         foreach ([$this->modelsToInsert, $this->modelsToUpdate] as $modelsToSave) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | /no

![image](https://user-images.githubusercontent.com/31479820/43398063-3c939f92-9407-11e8-832c-997ad578cbcf.png)
When using Process Manager or Import Definitions this error occurs when a user tries to delete some elements. 
$this->modelsToRemove returns array of array instead of array.
