### PR TITLE
[Order, Core] fix cart rule condition checker signature with opt param

### DIFF
--- a/src/CoreShop/Component/Core/Cart/Rule/Condition/CarriersConditionChecker.php
+++ b/src/CoreShop/Component/Core/Cart/Rule/Condition/CarriersConditionChecker.php
@@ -24,7 +24,7 @@ final class CarriersConditionChecker extends AbstractConditionChecker
     /**
      * {@inheritdoc}
      */
-    public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, CartPriceRuleVoucherCodeInterface $voucher = null, array $configuration)
+    public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, ?CartPriceRuleVoucherCodeInterface $voucher, array $configuration)
     {
         /**
          * @var $cart \CoreShop\Component\Core\Model\CartInterface

--- a/src/CoreShop/Component/Core/Cart/Rule/Condition/CategoriesConditionChecker.php
+++ b/src/CoreShop/Component/Core/Cart/Rule/Condition/CategoriesConditionChecker.php
@@ -40,7 +40,7 @@ final class CategoriesConditionChecker extends AbstractConditionChecker
     /**
      * {@inheritdoc}
      */
-    public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, CartPriceRuleVoucherCodeInterface $voucher = null, array $configuration)
+    public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, ?CartPriceRuleVoucherCodeInterface $voucher, array $configuration)
     {
         $categoryIdsToCheck = $this->getCategoriesToCheck($configuration['categories'], $configuration['recursive'] ?: false);
 

--- a/src/CoreShop/Component/Core/Cart/Rule/Condition/CountriesConditionChecker.php
+++ b/src/CoreShop/Component/Core/Cart/Rule/Condition/CountriesConditionChecker.php
@@ -25,7 +25,7 @@ final class CountriesConditionChecker extends AbstractConditionChecker
     /**
      * {@inheritdoc}
      */
-    public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, CartPriceRuleVoucherCodeInterface $voucher = null, array $configuration)
+    public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, ?CartPriceRuleVoucherCodeInterface $voucher, array $configuration)
     {
         if (!$cart->getCustomer() instanceof CustomerInterface) {
             return false;

--- a/src/CoreShop/Component/Core/Cart/Rule/Condition/CurrenciesConditionChecker.php
+++ b/src/CoreShop/Component/Core/Cart/Rule/Condition/CurrenciesConditionChecker.php
@@ -23,7 +23,7 @@ final class CurrenciesConditionChecker extends AbstractConditionChecker
     /**
      * {@inheritdoc}
      */
-    public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, CartPriceRuleVoucherCodeInterface $voucher = null, array $configuration)
+    public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, ?CartPriceRuleVoucherCodeInterface $voucher, array $configuration)
     {
         if (!$cart->getCurrency() instanceof CurrencyInterface) {
             return false;

--- a/src/CoreShop/Component/Core/Cart/Rule/Condition/CustomerGroupsConditionChecker.php
+++ b/src/CoreShop/Component/Core/Cart/Rule/Condition/CustomerGroupsConditionChecker.php
@@ -24,7 +24,7 @@ final class CustomerGroupsConditionChecker extends AbstractConditionChecker
     /**
      * {@inheritdoc}
      */
-    public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, CartPriceRuleVoucherCodeInterface $voucher = null, array $configuration)
+    public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, ?CartPriceRuleVoucherCodeInterface $voucher, array $configuration)
     {
         if (!$cart->getCustomer() instanceof CustomerInterface) {
             return false;

--- a/src/CoreShop/Component/Core/Cart/Rule/Condition/CustomersConditionChecker.php
+++ b/src/CoreShop/Component/Core/Cart/Rule/Condition/CustomersConditionChecker.php
@@ -23,7 +23,7 @@ final class CustomersConditionChecker extends AbstractConditionChecker
     /**
      * {@inheritdoc}
      */
-    public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, CartPriceRuleVoucherCodeInterface $voucher = null, array $configuration)
+    public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, ?CartPriceRuleVoucherCodeInterface $voucher, array $configuration)
     {
         if (!$cart->getCustomer() instanceof CustomerInterface) {
             return false;

--- a/src/CoreShop/Component/Core/Cart/Rule/Condition/ProductsConditionChecker.php
+++ b/src/CoreShop/Component/Core/Cart/Rule/Condition/ProductsConditionChecker.php
@@ -23,7 +23,7 @@ final class ProductsConditionChecker extends AbstractConditionChecker
     /**
      * {@inheritdoc}
      */
-    public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, CartPriceRuleVoucherCodeInterface $voucher = null, array $configuration)
+    public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, ?CartPriceRuleVoucherCodeInterface $voucher, array $configuration)
     {
         foreach ($cart->getItems() as $item) {
             $product = $item->getProduct();

--- a/src/CoreShop/Component/Core/Cart/Rule/Condition/StoresConditionChecker.php
+++ b/src/CoreShop/Component/Core/Cart/Rule/Condition/StoresConditionChecker.php
@@ -24,7 +24,7 @@ final class StoresConditionChecker extends AbstractConditionChecker
     /**
      * {@inheritdoc}
      */
-    public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, CartPriceRuleVoucherCodeInterface $voucher = null, array $configuration)
+    public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, ?CartPriceRuleVoucherCodeInterface $voucher, array $configuration)
     {
         /**
          * @var $cart \CoreShop\Component\Core\Model\CartInterface

--- a/src/CoreShop/Component/Core/Cart/Rule/Condition/ZonesConditionChecker.php
+++ b/src/CoreShop/Component/Core/Cart/Rule/Condition/ZonesConditionChecker.php
@@ -26,7 +26,7 @@ final class ZonesConditionChecker extends AbstractConditionChecker
     /**
      * {@inheritdoc}
      */
-    public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, CartPriceRuleVoucherCodeInterface $voucher = null, array $configuration)
+    public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, ?CartPriceRuleVoucherCodeInterface $voucher, array $configuration)
     {
         if (!$cart->getCustomer() instanceof CustomerInterface) {
             return false;

--- a/src/CoreShop/Component/Order/Cart/Rule/Condition/AmountConditionChecker.php
+++ b/src/CoreShop/Component/Order/Cart/Rule/Condition/AmountConditionChecker.php
@@ -21,7 +21,7 @@ class AmountConditionChecker extends AbstractConditionChecker
     /**
      * {@inheritdoc}
      */
-    public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, CartPriceRuleVoucherCodeInterface $voucher = null, array $configuration)
+    public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, ?CartPriceRuleVoucherCodeInterface $voucher, array $configuration)
     {
         if ($configuration['minAmount'] > 0) {
             $minAmount = $configuration['minAmount'];

--- a/src/CoreShop/Component/Order/Cart/Rule/Condition/CartRuleConditionCheckerInterface.php
+++ b/src/CoreShop/Component/Order/Cart/Rule/Condition/CartRuleConditionCheckerInterface.php
@@ -27,5 +27,5 @@ interface CartRuleConditionCheckerInterface extends ConditionCheckerInterface
      *
      * @return boolean
      */
-    public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, CartPriceRuleVoucherCodeInterface $voucher = null, array $configuration);
+    public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, ?CartPriceRuleVoucherCodeInterface $voucher, array $configuration);
 }

--- a/src/CoreShop/Component/Order/Cart/Rule/Condition/TimeSpanConditionChecker.php
+++ b/src/CoreShop/Component/Order/Cart/Rule/Condition/TimeSpanConditionChecker.php
@@ -22,7 +22,7 @@ class TimeSpanConditionChecker extends AbstractConditionChecker
     /**
      * {@inheritdoc}
      */
-    public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, CartPriceRuleVoucherCodeInterface $voucher = null, array $configuration)
+    public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, ?CartPriceRuleVoucherCodeInterface $voucher, array $configuration)
     {
         $dateFrom = Carbon::createFromTimestamp($configuration['dateFrom'] / 1000);
         $dateTo = Carbon::createFromTimestamp($configuration['dateTo'] / 1000);

--- a/src/CoreShop/Component/Order/Cart/Rule/Condition/VoucherConditionChecker.php
+++ b/src/CoreShop/Component/Order/Cart/Rule/Condition/VoucherConditionChecker.php
@@ -37,7 +37,7 @@ class VoucherConditionChecker extends AbstractConditionChecker
     /**
      * {@inheritdoc}
      */
-    public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, CartPriceRuleVoucherCodeInterface $voucher = null, array $configuration)
+    public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, ?CartPriceRuleVoucherCodeInterface $voucher, array $configuration)
     {
         Assert::isInstanceOf($cart, CartInterface::class);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | yes, signature change
| Deprecations? | yes

changed from

```
public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, CartPriceRuleVoucherCodeInterface $voucher = null, array $configuration)
```

to

```
public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, ?CartPriceRuleVoucherCodeInterface $voucher, array $configuration)
```