### PR TITLE
[Notification] add actual workflow-name for State Transition Checker

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/EventListener/NotificationRules/OrderWorkflowListener.php
+++ b/src/CoreShop/Bundle/CoreBundle/EventListener/NotificationRules/OrderWorkflowListener.php
@@ -36,6 +36,7 @@ final class OrderWorkflowListener extends AbstractNotificationRuleListener
         }
 
         $this->rulesProcessor->applyRules('order', $order, [
+            'workflow' => $event->getWorkflowName(),
             'fromState' => $event->getMarking()->getPlaces(),
             'toState' => $event->getTransition()->getTos(),
             '_locale' => $order->getLocaleCode(),

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services/notification.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services/notification.yml
@@ -15,6 +15,7 @@ services:
         class: CoreShop\Component\Core\Notification\Rule\Condition\StateTransitionChecker
         arguments:
             - 'CoreShop\Component\Order\Model\OrderInterface'
+            - !php/const CoreShop\Component\Order\OrderInvoiceTransitions::IDENTIFIER
         tags:
             - { name: coreshop.notification_rule.condition, type: orderInvoiceTransition, notification-type: order, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Notification\Condition\StateTransitionConfigurationType }
 
@@ -32,6 +33,7 @@ services:
         class: CoreShop\Component\Core\Notification\Rule\Condition\StateTransitionChecker
         arguments:
             - 'CoreShop\Component\Order\Model\OrderInterface'
+            - !php/const CoreShop\Component\Order\OrderPaymentTransitions::IDENTIFIER
         tags:
             - { name: coreshop.notification_rule.condition, type: orderPaymentTransition, notification-type: order, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Notification\Condition\StateTransitionConfigurationType }
 
@@ -50,6 +52,7 @@ services:
         class: CoreShop\Component\Core\Notification\Rule\Condition\StateTransitionChecker
         arguments:
             - 'CoreShop\Component\Order\Model\OrderInterface'
+            - !php/const CoreShop\Component\Order\OrderShipmentTransitions::IDENTIFIER
         tags:
             - { name: coreshop.notification_rule.condition, type: orderShippingTransition, notification-type: order, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Notification\Condition\StateTransitionConfigurationType }
 
@@ -67,6 +70,7 @@ services:
         class: CoreShop\Component\Core\Notification\Rule\Condition\StateTransitionChecker
         arguments:
             - 'CoreShop\Component\Order\Model\OrderInterface'
+            - !php/const CoreShop\Component\Order\OrderTransitions::IDENTIFIER
         tags:
             - { name: coreshop.notification_rule.condition, type: orderTransition, notification-type: order, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Notification\Condition\StateTransitionConfigurationType }
 
@@ -96,6 +100,7 @@ services:
           class: CoreShop\Component\Core\Notification\Rule\Condition\StateTransitionChecker
           arguments:
               - 'CoreShop\Component\Payment\Model\PaymentInterface'
+              - !php/const CoreShop\Component\Payment\PaymentTransitions::IDENTIFIER
           tags:
             - { name: coreshop.notification_rule.condition, type: paymentTransition, notification-type: payment, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Notification\Condition\StateTransitionConfigurationType }
 
@@ -109,10 +114,11 @@ services:
           tags:
               - { name: coreshop.notification_rule.condition, type: invoiceState, notification-type: invoice, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Notification\Condition\InvoiceStateConfigurationType }
 
-    coreshop.notification_rule.condition.payment.invoice_tarnsition:
+    coreshop.notification_rule.condition.invoice.invoice_transition:
           class: CoreShop\Component\Core\Notification\Rule\Condition\StateTransitionChecker
           arguments:
               - 'CoreShop\Component\Order\Model\OrderInvoiceInterface'
+              - !php/const CoreShop\Component\Order\InvoiceTransitions::IDENTIFIER
           tags:
             - { name: coreshop.notification_rule.condition, type: invoiceTransition, notification-type: invoice, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Notification\Condition\StateTransitionConfigurationType }
 
@@ -126,10 +132,11 @@ services:
           tags:
               - { name: coreshop.notification_rule.condition, type: shipmentState, notification-type: shipment, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Notification\Condition\ShipmentStateConfigurationType }
 
-    coreshop.notification_rule.condition.payment.shipment_transition:
+    coreshop.notification_rule.condition.shipment.shipment_transition:
           class: CoreShop\Component\Core\Notification\Rule\Condition\StateTransitionChecker
           arguments:
               - 'CoreShop\Component\Order\Model\OrderShipmentInterface'
+              - !php/const CoreShop\Component\Order\ShipmentTransitions::IDENTIFIER
           tags:
             - { name: coreshop.notification_rule.condition, type: shipmentTransition, notification-type: shipment, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Notification\Condition\StateTransitionConfigurationType }
 

--- a/src/CoreShop/Component/Core/Notification/Rule/Condition/StateTransitionChecker.php
+++ b/src/CoreShop/Component/Core/Notification/Rule/Condition/StateTransitionChecker.php
@@ -23,13 +23,19 @@ final class StateTransitionChecker extends AbstractConditionChecker
      */
     private $interface;
 
+    /**
+     * @var string
+     */
+    private $workflowName;
 
     /**
      * @param string $interface
+     * @param string $workflowName
      */
-    public function __construct(string $interface)
+    public function __construct(string $interface, string $workflowName)
     {
         $this->interface = $interface;
+        $this->workflowName = $workflowName;
     }
 
     /**
@@ -38,6 +44,12 @@ final class StateTransitionChecker extends AbstractConditionChecker
     public function isNotificationRuleValid($subject, $params, array $configuration)
     {
         Assert::isInstanceOf($subject, $this->interface);
+
+        if (isset($params['workflow'])) {
+            if ($params['workflow'] !== $this->workflowName) {
+                return false;
+            }
+        }
 
         if (isset($params['transition'])) {
             return $configuration['transition'] === $params['transition'];

--- a/tests/lib/CoreShop/Test/PHPUnit/Suites/NotificationRule.php
+++ b/tests/lib/CoreShop/Test/PHPUnit/Suites/NotificationRule.php
@@ -163,7 +163,8 @@ class NotificationRule extends RuleTest
 
         $this->assertTrue($simpleStateChecker->isNotificationRuleValid($mock,
             [
-                'transition' => OrderShipmentTransitions::TRANSITION_SHIP
+                'transition' => OrderShipmentTransitions::TRANSITION_SHIP,
+                'workflow' => OrderShipmentTransitions::IDENTIFIER
             ], [
                 'transition' => OrderShipmentTransitions::TRANSITION_SHIP
             ]

--- a/tests/lib/CoreShop/Test/PHPUnit/Suites/NotificationRule.php
+++ b/tests/lib/CoreShop/Test/PHPUnit/Suites/NotificationRule.php
@@ -159,7 +159,7 @@ class NotificationRule extends RuleTest
     {
         $mock = $this->createMock(OrderShipment::class);
 
-        $simpleStateChecker = new StateTransitionChecker(get_class($mock));
+        $simpleStateChecker = new StateTransitionChecker(get_class($mock), OrderShipmentTransitions::IDENTIFIER);
 
         $this->assertTrue($simpleStateChecker->isNotificationRuleValid($mock,
             [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? |no
| Fixed tickets | #589

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->

Issue was that we have multiple "cancel" states, for order-invoice, order-shipment, order-payment and order-state and the transition checker had no idea for which workflow it should validate it.