### PR TITLE
[Non-CoreShop-Sites] allow CoreShop to co-exist along none CoreShop Sites

### DIFF
--- a/src/CoreShop/Bundle/AddressBundle/Collector/CountryCollector.php
+++ b/src/CoreShop/Bundle/AddressBundle/Collector/CountryCollector.php
@@ -67,7 +67,7 @@ final class CountryCollector extends DataCollector
         try {
             $this->data['country'] = $this->countryContext->getCountry();
             $this->data['countryName'] = $this->data['country']->getName();
-        } catch (CountryNotFoundException $exception) {
+        } catch (\Exception $exception) {
             //If something went wrong, we don't have any country, which we can safely ignore
         }
     }

--- a/src/CoreShop/Bundle/AddressBundle/Resources/views/Collector/country.html.twig
+++ b/src/CoreShop/Bundle/AddressBundle/Resources/views/Collector/country.html.twig
@@ -1,11 +1,12 @@
 {% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
+    {% if country is defined %}
+        {% set icon %}
+            {{ include('@CoreShopAddress/Collector/Icon/country.svg') }}
+            <span class="sf-toolbar-value">{{ collector.country.name|default('Undefined') }}</span>
+        {% endset %}
 
-    {% set icon %}
-        {{ include('@CoreShopAddress/Collector/Icon/country.svg') }}
-        <span class="sf-toolbar-value">{{ collector.country.name|default('Undefined') }}</span>
-    {% endset %}
-
-    {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: false }) }}
+        {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: false }) }}
+    {% endif %}
 {% endblock %}

--- a/src/CoreShop/Bundle/CoreBundle/EventListener/RequestCartAvailability.php
+++ b/src/CoreShop/Bundle/CoreBundle/EventListener/RequestCartAvailability.php
@@ -13,8 +13,8 @@
 namespace CoreShop\Bundle\CoreBundle\EventListener;
 
 use CoreShop\Component\Core\Configuration\ConfigurationServiceInterface;
+use CoreShop\Component\Core\Context\ShopperContextInterface;
 use CoreShop\Component\Core\Model\CartInterface;
-use CoreShop\Component\Order\Context\CartContextInterface;
 use CoreShop\Component\Order\Manager\CartManagerInterface;
 use Pimcore\Http\RequestHelper;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -29,9 +29,9 @@ final class RequestCartAvailability
     private $cartManager;
 
     /**
-     * @var CartContextInterface
+     * @var ShopperContextInterface
      */
-    private $cartContext;
+    private $shopperContext;
 
     /**
      * @var ConfigurationServiceInterface
@@ -49,22 +49,21 @@ final class RequestCartAvailability
     private $session;
 
     /**
-     * @param CartManagerInterface $cartManager
-     * @param CartContextInterface $cartContext
+     * @param CartManagerInterface          $cartManager
+     * @param ShopperContextInterface       $shopperContext
      * @param ConfigurationServiceInterface $configurationService
-     * @param RequestHelper $pimcoreRequestHelper
-     * @param SessionInterface $session
+     * @param RequestHelper                 $pimcoreRequestHelper
+     * @param SessionInterface              $session
      */
     public function __construct(
         CartManagerInterface $cartManager,
-        CartContextInterface $cartContext,
+        ShopperContextInterface $shopperContext,
         ConfigurationServiceInterface $configurationService,
         RequestHelper $pimcoreRequestHelper,
         SessionInterface $session
-    )
-    {
+    ) {
         $this->cartManager = $cartManager;
-        $this->cartContext = $cartContext;
+        $this->shopperContext = $shopperContext;
         $this->configurationService = $configurationService;
         $this->pimcoreRequestHelper = $pimcoreRequestHelper;
         $this->session = $session;
@@ -85,8 +84,12 @@ final class RequestCartAvailability
             return;
         }
 
+        if (!$this->shopperContext->hasStore()) {
+            return;
+        }
+
         /** @var CartInterface $cart */
-        $cart = $this->cartContext->getCart();
+        $cart = $this->shopperContext->getCart();
 
         if ($cart->getId()) {
             if ($cart->getNeedsRecalculation() === true) {

--- a/src/CoreShop/Bundle/CoreBundle/EventListener/RequestCartRecalculation.php
+++ b/src/CoreShop/Bundle/CoreBundle/EventListener/RequestCartRecalculation.php
@@ -13,6 +13,7 @@
 namespace CoreShop\Bundle\CoreBundle\EventListener;
 
 use CoreShop\Component\Core\Configuration\ConfigurationServiceInterface;
+use CoreShop\Component\Core\Context\ShopperContextInterface;
 use CoreShop\Component\Order\Context\CartContextInterface;
 use CoreShop\Component\Order\Manager\CartManagerInterface;
 use Pimcore\Http\RequestHelper;
@@ -26,9 +27,9 @@ final class RequestCartRecalculation
     private $cartManager;
 
     /**
-     * @var CartContextInterface
+     * @var ShopperContextInterface
      */
-    private $cartContext;
+    private $shopperContext;
 
     /**
      * @var ConfigurationServiceInterface
@@ -42,19 +43,19 @@ final class RequestCartRecalculation
 
     /**
      * @param CartManagerInterface $cartManager
-     * @param CartContextInterface $cartContext
+     * @param ShopperContextInterface $shopperContext
      * @param ConfigurationServiceInterface $configurationService
      * @param RequestHelper $pimcoreRequestHelper
      */
     public function __construct(
         CartManagerInterface $cartManager,
-        CartContextInterface $cartContext,
+        ShopperContextInterface $shopperContext,
         ConfigurationServiceInterface $configurationService,
         RequestHelper $pimcoreRequestHelper
     )
     {
         $this->cartManager = $cartManager;
-        $this->cartContext = $cartContext;
+        $this->shopperContext = $shopperContext;
         $this->configurationService = $configurationService;
         $this->pimcoreRequestHelper = $pimcoreRequestHelper;
     }
@@ -74,7 +75,11 @@ final class RequestCartRecalculation
             return;
         }
 
-        $cart = $this->cartContext->getCart();
+        if (!$this->shopperContext->hasStore()) {
+            return;
+        }
+
+        $cart = $this->shopperContext->getCart();
 
         if ($cart->getId()) {
             if ($this->configurationService->get('SYSTEM.PRICE_RULE.UPDATE') > $cart->getModificationDate()) {

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services/listeners.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services/listeners.yml
@@ -54,7 +54,7 @@ services:
         class: CoreShop\Bundle\CoreBundle\EventListener\RequestCartRecalculation
         arguments:
            - '@coreshop.cart.manager'
-           - '@coreshop.context.cart'
+           - '@coreshop.context.shopper'
            - '@coreshop.configuration.service'
            - '@pimcore.http.request_helper'
         tags:
@@ -64,7 +64,7 @@ services:
         class: CoreShop\Bundle\CoreBundle\EventListener\RequestCartAvailability
         arguments:
            - '@coreshop.cart.manager'
-           - '@coreshop.context.cart'
+           - '@coreshop.context.shopper'
            - '@coreshop.configuration.service'
            - '@pimcore.http.request_helper'
            - '@session'

--- a/src/CoreShop/Bundle/CoreBundle/Resources/views/Collector/currency.html.twig
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/views/Collector/currency.html.twig
@@ -1,26 +1,28 @@
 {% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
-    {% set status_color = collector.currency is null ? 'red' : '' %}
+    {% if currency is defined %}
+        {% set status_color = collector.currency is null ? 'red' : '' %}
 
-    {% set icon %}
-        {{ include('@CoreShopCore/Collector/Icon/currency.svg') }}
-        <span class="sf-toolbar-value">{{ collector.currency.name|default('Undefined') }}</span>
-    {% endset %}
+        {% set icon %}
+            {{ include('@CoreShopCore/Collector/Icon/currency.svg') }}
+            <span class="sf-toolbar-value">{{ collector.currency.name|default('Undefined') }}</span>
+        {% endset %}
 
-    {% set text %}
-        <div class="sf-toolbar-info-piece">
-            <b>Currencies</b>
-            <span class="sf-toolbar-status {% if collector.currencies is empty %}sf-toolbar-status-red{% endif %}">{{ collector.currencies|length }}</span>
-        </div>
-
-        {% for currency in collector.currencies %}
+        {% set text %}
             <div class="sf-toolbar-info-piece">
-                <b>{{ currency.name }}</b>
-                <span>({{ currency.isocode }}){% if collector.isCurrencyChangeSupported %} (<a href="?_currency_id={{ currency.id }}">change</a>){% endif %}</span>
+                <b>Currencies</b>
+                <span class="sf-toolbar-status {% if collector.currencies is empty %}sf-toolbar-status-red{% endif %}">{{ collector.currencies|length }}</span>
             </div>
-        {% endfor %}
-    {% endset %}
 
-    {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: false, status: status_color }) }}
+            {% for currency in collector.currencies %}
+                <div class="sf-toolbar-info-piece">
+                    <b>{{ currency.name }}</b>
+                    <span>({{ currency.isocode }}){% if collector.isCurrencyChangeSupported %} (<a href="?_currency_id={{ currency.id }}">change</a>){% endif %}</span>
+                </div>
+            {% endfor %}
+        {% endset %}
+
+        {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: false, status: status_color }) }}
+    {% endif %}
 {% endblock %}

--- a/src/CoreShop/Bundle/OrderBundle/Collector/CartCollector.php
+++ b/src/CoreShop/Bundle/OrderBundle/Collector/CartCollector.php
@@ -15,6 +15,7 @@ namespace CoreShop\Bundle\OrderBundle\Collector;
 use CoreShop\Component\Address\Context\CountryNotFoundException;
 use CoreShop\Component\Locale\Context\LocaleContextInterface;
 use CoreShop\Component\Order\Context\CartContextInterface;
+use CoreShop\Component\Order\Context\CartNotFoundException;
 use CoreShop\Component\Order\Model\CartInterface;
 use Pimcore\Http\Request\Resolver\PimcoreContextResolver;
 use Symfony\Component\HttpFoundation\Request;
@@ -97,8 +98,8 @@ final class CartCollector extends DataCollector
         try {
             $this->data['cart'] = $this->cartContext->getCart();
             $this->data['locale'] = $this->localeContext->getLocaleCode();
-        } catch (CountryNotFoundException $exception) {
-            //If something went wrong, we don't have any country, which we can safely ignore
+        } catch (\Exception $exception) {
+            //If something went wrong, we don't have any cart, which we can safely ignore
         }
     }
 

--- a/src/CoreShop/Bundle/OrderBundle/Resources/views/Collector/cart.html.twig
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/views/Collector/cart.html.twig
@@ -1,33 +1,35 @@
 {% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
-    {% set icon %}
-        {{ include('@CoreShopOrder/Collector/Icon/cart.svg') }}
+    {% if cart is defined %}
+        {% set icon %}
+            {{ include('@CoreShopOrder/Collector/Icon/cart.svg') }}
 
-        {% if collector.admin %}
-            <span class="sf-toolbar-value">
-                -
-            </span>
-        {% else %}
-            <span class="sf-toolbar-value">
-                {{ collector.cart.total|coreshop_format_money(collector.cart.getCurrency.getIsoCode, collector.locale) }}
-            </span>
-        {% endif %}
-    {% endset %}
+            {% if collector.admin %}
+                <span class="sf-toolbar-value">
+                    -
+                </span>
+            {% else %}
+                <span class="sf-toolbar-value">
+                    {{ collector.cart.total|coreshop_format_money(collector.cart.getCurrency.getIsoCode, collector.locale) }}
+                </span>
+            {% endif %}
+        {% endset %}
 
-    {% set text %}
-        {% if collector.admin %}
-            <div class="sf-toolbar-info-piece">
-                <b>status</b>
-                <span>disabled in backend</span>
-            </div>
-        {% else %}
-            <div class="sf-toolbar-info-piece">
-                <b>Cart ID</b>
-                <span class="sf-toolbar-status">{{ collector.cart.id|default('New Cart')}}</span>
-            </div>
-        {% endif %}
-    {% endset %}
+        {% set text %}
+            {% if collector.admin %}
+                <div class="sf-toolbar-info-piece">
+                    <b>status</b>
+                    <span>disabled in backend</span>
+                </div>
+            {% else %}
+                <div class="sf-toolbar-info-piece">
+                    <b>Cart ID</b>
+                    <span class="sf-toolbar-status">{{ collector.cart.id|default('New Cart')}}</span>
+                </div>
+            {% endif %}
+        {% endset %}
 
-    {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: false }) }}
+        {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: false }) }}
+    {% endif %}
 {% endblock %}

--- a/src/CoreShop/Bundle/RuleBundle/Resources/views/Collector/rule.html.twig
+++ b/src/CoreShop/Bundle/RuleBundle/Resources/views/Collector/rule.html.twig
@@ -1,27 +1,28 @@
 {% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
+    {% if collector.getProcessedRules|length > 0 %}
+        {% set icon %}
+            {{ include('@CoreShopRule/Collector/Icon/rules.svg') }}
+            <span class="sf-toolbar-value">Processed {{ collector.getProcessedRules|length }}</span>
+        {% endset %}
 
-    {% set icon %}
-        {{ include('@CoreShopRule/Collector/Icon/rules.svg') }}
-        <span class="sf-toolbar-value">Processed {{ collector.getProcessedRules|length }}</span>
-    {% endset %}
-
-    {% set text %}
-        <div class="sf-toolbar-info-piece">
-            <b>Types</b>
-        </div>
-
-        {% for type in collector.types %}
+        {% set text %}
             <div class="sf-toolbar-info-piece">
-                <b>{{ type.name }}</b>
-                <span class="sf-toolbar-status">({{ type.count }})</span>
+                <b>Types</b>
             </div>
-        {% endfor %}
-    {% endset %}
+
+            {% for type in collector.types %}
+                <div class="sf-toolbar-info-piece">
+                    <b>{{ type.name }}</b>
+                    <span class="sf-toolbar-status">({{ type.count }})</span>
+                </div>
+            {% endfor %}
+        {% endset %}
 
 
-    {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: true }) }}
+        {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: true }) }}
+    {% endif %}
 {% endblock %}
 
 

--- a/src/CoreShop/Bundle/StoreBundle/Collector/StoreCollector.php
+++ b/src/CoreShop/Bundle/StoreBundle/Collector/StoreCollector.php
@@ -78,7 +78,7 @@ final class StoreCollector extends DataCollector
     {
         try {
             $this->data['store'] = $this->storeContext->getStore();
-        } catch (StoreNotFoundException $exception) {
+        } catch (\Exception $exception) {
             //If some goes wrong, we just ignore it
         }
     }

--- a/src/CoreShop/Bundle/StoreBundle/Resources/views/Collector/store.html.twig
+++ b/src/CoreShop/Bundle/StoreBundle/Resources/views/Collector/store.html.twig
@@ -1,26 +1,28 @@
 {% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
-    {% set status_color = collector.store is null ? 'red' : '' %}
+    {% if store is defined %}
+        {% set status_color = collector.store is null ? 'red' : '' %}
 
-    {% set icon %}
-        {{ include('@CoreShopStore/Collector/Icon/store.svg') }}
-        <span class="sf-toolbar-value">{{ collector.store.name|default('Undefined') }}</span>
-    {% endset %}
+        {% set icon %}
+            {{ include('@CoreShopStore/Collector/Icon/store.svg') }}
+            <span class="sf-toolbar-value">{{ collector.store.name|default('Undefined') }}</span>
+        {% endset %}
 
-    {% set text %}
-        <div class="sf-toolbar-info-piece">
-            <b>Stores</b>
-            <span class="sf-toolbar-status {% if collector.stores is empty %}sf-toolbar-status-red{% endif %}">{{ collector.stores|length }}</span>
-        </div>
-
-        {% for store in collector.stores %}
+        {% set text %}
             <div class="sf-toolbar-info-piece">
-                <b>{{ store.name }}</b>
-                <span>({{ store.siteId }}){% if collector.isStoreChangeSupported %} (<a href="?_store_id={{ store.id }}">change</a>){% endif %}</span>
+                <b>Stores</b>
+                <span class="sf-toolbar-status {% if collector.stores is empty %}sf-toolbar-status-red{% endif %}">{{ collector.stores|length }}</span>
             </div>
-        {% endfor %}
-    {% endset %}
 
-    {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: false, status: status_color }) }}
+            {% for store in collector.stores %}
+                <div class="sf-toolbar-info-piece">
+                    <b>{{ store.name }}</b>
+                    <span>({{ store.siteId }}){% if collector.isStoreChangeSupported %} (<a href="?_store_id={{ store.id }}">change</a>){% endif %}</span>
+                </div>
+            {% endfor %}
+        {% endset %}
+
+        {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: false, status: status_color }) }}
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #418

We decide on the store-level if it is a configured CoreShop site, if not, we don't execute any reqeust listener tasks. If you need something from the API, we still throw exceptions

