### PR TITLE
[All] refine constraints for certain conditions/actions

### DIFF
--- a/features/shipping/default_carrier_customer.feature
+++ b/features/shipping/default_carrier_customer.feature
@@ -49,7 +49,7 @@ Feature: In Order to make checkout easier
     Then the cart shipping should be "2000" excluding tax
 
   Scenario: When I change my cart, It should automatically invalidate the carrier and resolve a new default carrier
-    Given the shipping rule "post" has a condition amount from "0" to "150"
+    Given the shipping rule "post" has a condition amount from "1" to "150"
     And the site has another carrier "DPD"
     And adding a shipping rule named "DPD"
     And the shipping rule is active

--- a/src/CoreShop/Bundle/OrderBundle/Form/Type/Action/DiscountAmountConfigurationType.php
+++ b/src/CoreShop/Bundle/OrderBundle/Form/Type/Action/DiscountAmountConfigurationType.php
@@ -20,6 +20,7 @@ use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\GreaterThan;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Type;
 
@@ -35,6 +36,7 @@ final class DiscountAmountConfigurationType extends AbstractType
                 'constraints' => [
                     new NotBlank(['groups' => ['coreshop']]),
                     new Type(['type' => 'numeric', 'groups' => ['coreshop']]),
+                    new GreaterThan(['value' => 0, 'groups' => ['coreshop']]),
                 ],
             ])
             ->add('gross', CheckboxType::class, [

--- a/src/CoreShop/Bundle/OrderBundle/Form/Type/Action/DiscountPercentConfigurationType.php
+++ b/src/CoreShop/Bundle/OrderBundle/Form/Type/Action/DiscountPercentConfigurationType.php
@@ -32,7 +32,7 @@ final class DiscountPercentConfigurationType extends AbstractType
                 'constraints' => [
                     new NotBlank(['groups' => ['coreshop']]),
                     new Type(['type' => 'numeric', 'groups' => ['coreshop']]),
-                    new Range(['min' => 0, 'max' => 100]),
+                    new Range(['min' => 0, 'max' => 100, 'groups' => ['coreshop']]),
                 ],
             ])
             ->add('applyOn', ChoiceType::class, [

--- a/src/CoreShop/Bundle/OrderBundle/Form/Type/Condition/AmountConfigurationType.php
+++ b/src/CoreShop/Bundle/OrderBundle/Form/Type/Condition/AmountConfigurationType.php
@@ -15,6 +15,9 @@ namespace CoreShop\Bundle\OrderBundle\Form\Type\Rule\Condition;
 use CoreShop\Bundle\MoneyBundle\Form\Type\MoneyType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Type;
 
 final class AmountConfigurationType extends AbstractType
 {
@@ -24,8 +27,20 @@ final class AmountConfigurationType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('minAmount', MoneyType::class)
-            ->add('maxAmount', MoneyType::class);
+            ->add('minAmount', MoneyType::class, [
+                'constraints' => [
+                    new NotBlank(['groups' => ['coreshop']]),
+                    new Type(['type' => 'numeric', 'groups' => ['coreshop']]),
+                    new GreaterThan(['value' => 0, 'groups' => ['coreshop']]),
+                ],
+            ])
+            ->add('maxAmount', MoneyType::class, [
+                'constraints' => [
+                    new NotBlank(['groups' => ['coreshop']]),
+                    new Type(['type' => 'numeric', 'groups' => ['coreshop']]),
+                    new GreaterThan(['value' => 0, 'groups' => ['coreshop']]),
+                ],
+            ]);
     }
 
     /**

--- a/src/CoreShop/Bundle/ProductBundle/Form/Type/Rule/Action/DiscountAmountConfigurationType.php
+++ b/src/CoreShop/Bundle/ProductBundle/Form/Type/Rule/Action/DiscountAmountConfigurationType.php
@@ -18,6 +18,7 @@ use CoreShop\Component\Currency\Model\CurrencyInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\GreaterThan;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Type;
 
@@ -33,6 +34,7 @@ final class DiscountAmountConfigurationType extends AbstractType
                 'constraints' => [
                     new NotBlank(['groups' => ['coreshop']]),
                     new Type(['type' => 'numeric', 'groups' => ['coreshop']]),
+                    new GreaterThan(['value' => 0, 'groups' => ['coreshop']]),
                 ],
             ])
             ->add('currency', CurrencyChoiceType::class, [

--- a/src/CoreShop/Bundle/ProductBundle/Form/Type/Rule/Action/DiscountPercentConfigurationType.php
+++ b/src/CoreShop/Bundle/ProductBundle/Form/Type/Rule/Action/DiscountPercentConfigurationType.php
@@ -31,7 +31,7 @@ final class DiscountPercentConfigurationType extends AbstractType
                 'constraints' => [
                     new NotBlank(['groups' => ['coreshop']]),
                     new Type(['type' => 'numeric', 'groups' => ['coreshop']]),
-                    new Range(['min' => 0, 'max' => 100]),
+                    new Range(['min' => 0, 'max' => 100, 'groups' => ['coreshop']]),
                 ],
             ]);
     }

--- a/src/CoreShop/Bundle/ShippingBundle/Form/Type/Rule/Action/AdditionAmountActionConfigurationType.php
+++ b/src/CoreShop/Bundle/ShippingBundle/Form/Type/Rule/Action/AdditionAmountActionConfigurationType.php
@@ -18,7 +18,9 @@ use CoreShop\Component\Currency\Model\CurrencyInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\GreaterThan;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Type;
 
 class AdditionAmountActionConfigurationType extends AbstractType
 {
@@ -31,6 +33,8 @@ class AdditionAmountActionConfigurationType extends AbstractType
             ->add('amount', MoneyType::class, [
                 'constraints' => [
                     new NotBlank(['groups' => ['coreshop']]),
+                    new Type(['type' => 'numeric', 'groups' => ['coreshop']]),
+                    new GreaterThan(['value' => 0, 'groups' => ['coreshop']]),
                 ],
             ])
             ->add('currency', CurrencyChoiceType::class, [

--- a/src/CoreShop/Bundle/ShippingBundle/Form/Type/Rule/Action/AdditionPercentActionConfigurationType.php
+++ b/src/CoreShop/Bundle/ShippingBundle/Form/Type/Rule/Action/AdditionPercentActionConfigurationType.php
@@ -16,6 +16,8 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Range;
+use Symfony\Component\Validator\Constraints\Type;
 
 class AdditionPercentActionConfigurationType extends AbstractType
 {
@@ -28,6 +30,8 @@ class AdditionPercentActionConfigurationType extends AbstractType
             ->add('percent', IntegerType::class, [
                 'constraints' => [
                     new NotBlank(['groups' => ['coreshop']]),
+                    new Type(['type' => 'numeric', 'groups' => ['coreshop']]),
+                    new Range(['min' => 0, 'max' => 100, 'groups' => ['coreshop']]),
                 ],
             ]);
     }

--- a/src/CoreShop/Bundle/ShippingBundle/Form/Type/Rule/Action/DiscountAmountActionConfigurationType.php
+++ b/src/CoreShop/Bundle/ShippingBundle/Form/Type/Rule/Action/DiscountAmountActionConfigurationType.php
@@ -18,7 +18,9 @@ use CoreShop\Component\Currency\Model\CurrencyInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\GreaterThan;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Type;
 
 class DiscountAmountActionConfigurationType extends AbstractType
 {
@@ -31,6 +33,8 @@ class DiscountAmountActionConfigurationType extends AbstractType
             ->add('amount', MoneyType::class, [
                 'constraints' => [
                     new NotBlank(['groups' => ['coreshop']]),
+                    new Type(['type' => 'numeric', 'groups' => ['coreshop']]),
+                    new GreaterThan(['value' => 0, 'groups' => ['coreshop']]),
                 ],
             ])
             ->add('currency', CurrencyChoiceType::class, [

--- a/src/CoreShop/Bundle/ShippingBundle/Form/Type/Rule/Action/DiscountPercentActionConfigurationType.php
+++ b/src/CoreShop/Bundle/ShippingBundle/Form/Type/Rule/Action/DiscountPercentActionConfigurationType.php
@@ -16,6 +16,8 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Range;
+use Symfony\Component\Validator\Constraints\Type;
 
 class DiscountPercentActionConfigurationType extends AbstractType
 {
@@ -28,6 +30,8 @@ class DiscountPercentActionConfigurationType extends AbstractType
             ->add('percent', IntegerType::class, [
                 'constraints' => [
                     new NotBlank(['groups' => ['coreshop']]),
+                    new Type(['type' => 'numeric', 'groups' => ['coreshop']]),
+                    new Range(['min' => 0, 'max' => 100, 'groups' => ['coreshop']]),
                 ],
             ]);
     }

--- a/src/CoreShop/Bundle/ShippingBundle/Form/Type/Rule/Condition/AmountConfigurationType.php
+++ b/src/CoreShop/Bundle/ShippingBundle/Form/Type/Rule/Condition/AmountConfigurationType.php
@@ -15,6 +15,7 @@ namespace CoreShop\Bundle\ShippingBundle\Form\Type\Rule\Condition;
 use CoreShop\Bundle\MoneyBundle\Form\Type\MoneyType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\GreaterThan;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Type;
 
@@ -30,6 +31,7 @@ final class AmountConfigurationType extends AbstractType
                 'constraints' => [
                     new NotBlank(['groups' => ['coreshop']]),
                     new Type(['type' => 'numeric', 'groups' => ['coreshop']]),
+                    new GreaterThan(['value' => 0, 'groups' => ['coreshop']]),
                 ],
             ])
             ->add('maxAmount', MoneyType::class, [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Currently it is possible to set percent values that are higher than 100 percent and amount values that are lower than 0