### PR TITLE
[PriceRules] refactor the way product price-rules are calculated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@
  - **BC break**: All occurrences of parameters `coreshop.all.stack.pimcore_class_ids`, `"application".model."class".pimcore_class_id`, `coreshop.all.pimcore_classes.ids` have been removed. Inject the corresponding Repository and use `classId` function instead
  - **Pimcore**: CoreShop now requires at least Pimcore 5.4.0. You need to update Pimcore to the at least 5.4.0 in order to use/update CoreShop.
 
+### Product Price Calculation
+In order to allow custom price calculation on API Level, we changed the way CoreShop calculates product prices by introducing a new parameter to every PriceCalculation Interface. Price Calculator Conditions are not anymore using a Live context, instead it gets passed via API.
+
+Following interfaces have changed:
+
+ - ```CoreShop\Component\Core\Product\TaxedProductPriceCalculatorInterface```
+ - ```CoreShop\Component\Order\Calculator\PurchasableDiscountCalculatorInterface```
+ - ```CoreShop\Component\Order\Calculator\PurchasableDiscountPriceCalculatorInterface```
+ - ```CoreShop\Component\Order\Calculator\PurchasablePriceCalculatorInterface```
+ - ```CoreShop\Component\Order\Calculator\PurchasableRetailPriceCalculatorInterface```
+ - ```CoreShop\Component\Product\Calculator\ProductDiscountCalculatorInterface```
+ - ```CoreShop\Component\Product\Calculator\ProductDiscountPriceCalculatorInterface```
+ - ```CoreShop\Component\Product\Calculator\ProductPriceCalculatorInterface```
+ - ```CoreShop\Component\Product\Calculator\ProductRetailPriceCalculatorInterface```
+ - ```CoreShop\Component\Product\Rule\Action\ProductDiscountActionProcessorInterface```
+ - ```CoreShop\Component\Product\Rule\Action\ProductDiscountPriceActionProcessorInterface```
+ - ```CoreShop\Component\Product\Rule\Action\ProductDiscountPriceActionProcessorInterface```
+ - ```CoreShop\Component\Product\Rule\Action\ProductPriceActionProcessorInterface```
+ - ```CoreShop\Component\Product\Rule\Fetcher\ValidRulesFetcherInterface```
+
+ If you have anything customized with those classes, please change them accordingly.
+
 ### Adjustments
 > **BC break / New Feature**
 

--- a/src/CoreShop/Behat/Context/Domain/ProductPriceRuleContext.php
+++ b/src/CoreShop/Behat/Context/Domain/ProductPriceRuleContext.php
@@ -14,6 +14,7 @@ namespace CoreShop\Behat\Context\Domain;
 
 use Behat\Behat\Context\Context;
 use CoreShop\Behat\Service\SharedStorageInterface;
+use CoreShop\Component\Core\Context\ShopperContextInterface;
 use CoreShop\Component\Core\Model\ProductInterface;
 use CoreShop\Component\Product\Model\ProductPriceRuleInterface;
 use CoreShop\Component\Rule\Condition\RuleValidationProcessorInterface;
@@ -27,20 +28,28 @@ final class ProductPriceRuleContext implements Context
     private $sharedStorage;
 
     /**
+     * @var ShopperContextInterface
+     */
+    private $shopperContext;
+
+    /**
      * @var RuleValidationProcessorInterface
      */
     private $ruleValidationProcessor;
 
     /**
      * @param SharedStorageInterface $sharedStorage
+     * @param ShopperContextInterface $shopperContext
      * @param RuleValidationProcessorInterface $ruleValidationProcessor
      */
     public function __construct(
         SharedStorageInterface $sharedStorage,
+        ShopperContextInterface $shopperContext,
         RuleValidationProcessorInterface $ruleValidationProcessor
     )
     {
         $this->sharedStorage = $sharedStorage;
+        $this->shopperContext = $shopperContext;
         $this->ruleValidationProcessor = $ruleValidationProcessor;
     }
 
@@ -50,7 +59,7 @@ final class ProductPriceRuleContext implements Context
      */
     public function theSpecificPriceRuleForProductShouldBeValid(ProductPriceRuleInterface $productPriceRule, ProductInterface $product)
     {
-        Assert::true($this->ruleValidationProcessor->isValid($product, $productPriceRule, []));
+        Assert::true($this->ruleValidationProcessor->isValid($product, $productPriceRule, $this->getContext()));
     }
 
     /**
@@ -59,6 +68,20 @@ final class ProductPriceRuleContext implements Context
      */
     public function theSpecificPriceRuleForProductShouldBeInvalid(ProductPriceRuleInterface $productPriceRule, ProductInterface $product)
     {
-        Assert::false($this->ruleValidationProcessor->isValid($product, $productPriceRule, []));
+        Assert::false($this->ruleValidationProcessor->isValid($product, $productPriceRule, $this->getContext()));
+    }
+
+    /**
+     * @return array
+     */
+    protected function getContext()
+    {
+        return [
+            'store' => $this->shopperContext->getStore(),
+            'customer' => $this->shopperContext->hasCustomer() ? $this->shopperContext->getCustomer() : null,
+            'currency' => $this->shopperContext->getCurrency(),
+            'country' => $this->shopperContext->getCountry(),
+            'cart' => $this->shopperContext->getCart()
+        ];
     }
 }

--- a/src/CoreShop/Behat/Context/Domain/ProductSpecificPriceRuleContext.php
+++ b/src/CoreShop/Behat/Context/Domain/ProductSpecificPriceRuleContext.php
@@ -14,6 +14,7 @@ namespace CoreShop\Behat\Context\Domain;
 
 use Behat\Behat\Context\Context;
 use CoreShop\Behat\Service\SharedStorageInterface;
+use CoreShop\Component\Core\Context\ShopperContextInterface;
 use CoreShop\Component\Core\Model\ProductInterface;
 use CoreShop\Component\Product\Model\ProductSpecificPriceRuleInterface;
 use CoreShop\Component\Rule\Condition\RuleValidationProcessorInterface;
@@ -27,20 +28,28 @@ final class ProductSpecificPriceRuleContext implements Context
     private $sharedStorage;
 
     /**
+     * @var ShopperContextInterface
+     */
+    private $shopperContext;
+
+    /**
      * @var RuleValidationProcessorInterface
      */
     private $ruleValidationProcessor;
 
     /**
      * @param SharedStorageInterface $sharedStorage
+     * @param ShopperContextInterface $shopperContext
      * @param RuleValidationProcessorInterface $ruleValidationProcessor
      */
     public function __construct(
         SharedStorageInterface $sharedStorage,
+        ShopperContextInterface $shopperContext,
         RuleValidationProcessorInterface $ruleValidationProcessor
     )
     {
         $this->sharedStorage = $sharedStorage;
+        $this->shopperContext = $shopperContext;
         $this->ruleValidationProcessor = $ruleValidationProcessor;
     }
 
@@ -50,7 +59,7 @@ final class ProductSpecificPriceRuleContext implements Context
      */
     public function theSpecificPriceRuleForProductShouldBeValid(ProductSpecificPriceRuleInterface $productSpecificPriceRule, ProductInterface $product)
     {
-        Assert::true($this->ruleValidationProcessor->isValid($product, $productSpecificPriceRule, []));
+        Assert::true($this->ruleValidationProcessor->isValid($product, $productSpecificPriceRule, $this->getContext()));
     }
 
     /**
@@ -59,6 +68,20 @@ final class ProductSpecificPriceRuleContext implements Context
      */
     public function theSpecificPriceRuleForProductShouldBeInvalid(ProductSpecificPriceRuleInterface $productSpecificPriceRule, ProductInterface $product)
     {
-        Assert::false($this->ruleValidationProcessor->isValid($product, $productSpecificPriceRule, []));
+        Assert::false($this->ruleValidationProcessor->isValid($product, $productSpecificPriceRule, $this->getContext()));
+    }
+
+    /**
+     * @return array
+     */
+    protected function getContext()
+    {
+        return [
+            'store' => $this->shopperContext->getStore(),
+            'customer' => $this->shopperContext->hasCustomer() ? $this->shopperContext->getCustomer() : null,
+            'currency' => $this->shopperContext->getCurrency(),
+            'country' => $this->shopperContext->getCountry(),
+            'cart' => $this->shopperContext->getCart()
+        ];
     }
 }

--- a/src/CoreShop/Behat/Resources/config/services/contexts/domain.yml
+++ b/src/CoreShop/Behat/Resources/config/services/contexts/domain.yml
@@ -3,6 +3,7 @@ services:
         class: CoreShop\Behat\Context\Domain\ProductContext
         arguments:
             - '@coreshop.behat.shared_storage'
+            - '@__symfony__.coreshop.context.shopper'
             - '@__symfony__.coreshop.repository.product'
             - '@__symfony__.coreshop.product.price_calculator'
             - '@__symfony__.coreshop.product.taxed_price_calculator'
@@ -13,6 +14,7 @@ services:
         class: CoreShop\Behat\Context\Domain\ProductSpecificPriceRuleContext
         arguments:
             - '@coreshop.behat.shared_storage'
+            - '@__symfony__.coreshop.context.shopper'
             - '@__symfony__.coreshop.product_specific_price_rule.processor'
         tags:
             - { name: fob.context_service }
@@ -21,6 +23,7 @@ services:
         class: CoreShop\Behat\Context\Domain\ProductPriceRuleContext
         arguments:
             - '@coreshop.behat.shared_storage'
+            - '@__symfony__.coreshop.context.shopper'
             - '@__symfony__.coreshop.product_price_rule.processor'
         tags:
             - { name: fob.context_service }

--- a/src/CoreShop/Bundle/CoreBundle/Controller/CoreSaleCreationTrait.php
+++ b/src/CoreShop/Bundle/CoreBundle/Controller/CoreSaleCreationTrait.php
@@ -67,16 +67,11 @@ trait CoreSaleCreationTrait
             return $this->viewHandler->handle(['success' => false, 'message' => "Store with ID '$storeId' not found"]);
         }
 
-        $this->get('coreshop.context.store.fixed')->setStore($store);
-        $this->get('coreshop.context.currency.fixed')->setCurrency($currency);
-        $this->get('coreshop.context.customer.fixed')->setCustomer($customer);
-        $this->get('coreshop.context.country.fixed')->setCountry($shippingAddress->getCountry());
-
         /**
          * @var $cart \CoreShop\Component\Core\Model\CartInterface
          */
-        $cart = InheritanceHelper::useInheritedValues(function() use($customer, $shippingAddress, $invoiceAddress, $currency, $language, $productIds, $request, $store) {
-            $cart = $this->createTempCart($customer, $shippingAddress, $invoiceAddress, $currency, $language, $productIds);
+        $cart = InheritanceHelper::useInheritedValues(function() use($customer, $store, $shippingAddress, $invoiceAddress, $currency, $language, $productIds, $request) {
+            $cart = $this->createTempCart($customer, $store, $shippingAddress, $invoiceAddress, $currency, $language, $productIds);
             $this->get('coreshop.cart_processor')->process($cart);
 
             return $cart;

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services/product.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services/product.yml
@@ -23,13 +23,14 @@ services:
         class: CoreShop\Bundle\CoreBundle\Templating\Helper\ProductPriceHelper
         arguments:
             - '@coreshop.product.taxed_price_calculator'
+            - '@coreshop.context.shopper'
         tags:
             - { name: templating.helper, alias: coreshop_product_price }
 
     coreshop.templating.helper.tax:
         class: CoreShop\Bundle\CoreBundle\Templating\Helper\ProductTaxHelper
         arguments:
-            - '@coreshop.product.taxed_price_calculator'
+            - '@coreshop.templating.helper.price'
             - '@coreshop.product.tax_factory'
         tags:
             - { name: templating.helper, alias: coreshop_product_tax }
@@ -65,8 +66,6 @@ services:
     coreshop.core.product.price_calculator.store_price:
         class: CoreShop\Component\Core\Product\Calculator\StoreProductPriceCalculator
         decorates: 'coreshop.product.price_calculator.property_price'
-        arguments:
-            - '@coreshop.context.store'
 
     coreshop.order.purchasable.price_calculator.product:
         class: CoreShop\Component\Core\Order\Calculator\PurchasableProductPriceCalculator

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services/rules.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services/rules.yml
@@ -4,53 +4,37 @@ services:
 
     coreshop.rule.condition.customers:
         class: CoreShop\Component\Core\Product\Rule\Condition\CustomersConditionChecker
-        arguments:
-            - '@coreshop.context.customer'
         tags:
-            - { name: coreshop.shipping_rule.condition, type: customers, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Rule\Condition\CustomersConfigurationType }
             - { name: coreshop.product_price_rule.condition, type: customers, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Rule\Condition\CustomersConfigurationType }
             - { name: coreshop.product_specific_price_rule.condition, type: customers, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Rule\Condition\CustomersConfigurationType }
 
     coreshop.rule.condition.customer_groups:
         class: CoreShop\Component\Core\Product\Rule\Condition\CustomerGroupsConditionChecker
-        arguments:
-            - '@coreshop.context.customer'
         tags:
-            - { name: coreshop.shipping_rule.condition, type: customerGroups, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Rule\Condition\CustomerGroupsConfigurationType }
             - { name: coreshop.product_price_rule.condition, type: customerGroups, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Rule\Condition\CustomerGroupsConfigurationType }
             - { name: coreshop.product_specific_price_rule.condition, type: customerGroups, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Rule\Condition\CustomerGroupsConfigurationType }
 
     coreshop.rule.condition.countries:
         class: CoreShop\Component\Core\Product\Rule\Condition\CountriesConditionChecker
-        arguments:
-            - '@coreshop.context.country'
         tags:
             - { name: coreshop.product_price_rule.condition, type: countries, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Rule\Condition\CountriesConfigurationType }
             - { name: coreshop.product_specific_price_rule.condition, type: countries, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Rule\Condition\CountriesConfigurationType }
 
     coreshop.rule.condition.zones:
         class: CoreShop\Component\Core\Product\Rule\Condition\ZonesConditionChecker
-        arguments:
-            - '@coreshop.context.country'
         tags:
             - { name: coreshop.product_price_rule.condition, type: zones, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Rule\Condition\ZonesConfigurationType }
             - { name: coreshop.product_specific_price_rule.condition, type: zones, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Rule\Condition\ZonesConfigurationType }
 
     coreshop.rule.condition.stores:
         class: CoreShop\Component\Core\Product\Rule\Condition\StoresConditionChecker
-        arguments:
-            - '@coreshop.context.store'
         tags:
-            - { name: coreshop.shipping_rule.condition, type: stores, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Rule\Condition\StoresConfigurationType }
             - { name: coreshop.product_price_rule.condition, type: stores, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Rule\Condition\StoresConfigurationType }
             - { name: coreshop.product_specific_price_rule.condition, type: stores, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Rule\Condition\StoresConfigurationType }
 
     coreshop.rule.condition.currencies:
         class: CoreShop\Component\Core\Product\Rule\Condition\CurrenciesConditionChecker
-        arguments:
-            - '@coreshop.context.currency'
         tags:
-            - { name: coreshop.shipping_rule.condition, type: currencies, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Rule\Condition\CurrenciesConfigurationType }
             - { name: coreshop.product_price_rule.condition, type: currencies, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Rule\Condition\CurrenciesConfigurationType }
             - { name: coreshop.product_specific_price_rule.condition, type: currencies, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Rule\Condition\CurrenciesConfigurationType }
 
@@ -58,14 +42,11 @@ services:
         class: CoreShop\Component\Core\Product\Rule\Condition\CategoriesConditionChecker
         arguments:
             - '@coreshop.repository.category'
-            - '@coreshop.context.store'
         tags:
             - { name: coreshop.product_price_rule.condition, type: categories, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Rule\Condition\CategoriesConfigurationType }
 
     coreshop.product_price_rule.condition.quantity:
         class: CoreShop\Component\Core\Product\Rule\Condition\QuantityConditionChecker
-        arguments:
-            - '@coreshop.context.cart'
         tags:
             - { name: coreshop.product_price_rule.condition, type: quantity, form-type: CoreShop\Bundle\CoreBundle\Form\Type\ProductPriceRule\Condition\QuantityConfigurationType }
 
@@ -74,7 +55,6 @@ services:
         class: CoreShop\Component\Core\Cart\Rule\Condition\CategoriesConditionChecker
         arguments:
             - '@coreshop.repository.category'
-            - '@coreshop.context.store'
         tags:
             - { name: coreshop.cart_price_rule.condition, type: categories, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Rule\Condition\CategoriesConfigurationType }
 

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services/shipping.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services/shipping.yml
@@ -30,6 +30,26 @@ services:
         tags:
             - { name: coreshop.shipping_rule.condition, type: zones, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Rule\Condition\ZonesConfigurationType }
 
+    coreshop.shipping_rule.condition.customers:
+        class: CoreShop\Component\Core\Shipping\Rule\Condition\CustomersConditionChecker
+        tags:
+            - { name: coreshop.shipping_rule.condition, type: customers, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Rule\Condition\CustomersConfigurationType }
+
+    coreshop.shipping_rule.condition.customer_groups:
+        class: CoreShop\Component\Core\Shipping\Rule\Condition\CustomerGroupsConditionChecker
+        tags:
+            - { name: coreshop.shipping_rule.condition, type: customerGroups, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Rule\Condition\CustomerGroupsConfigurationType }
+
+    coreshop.shipping_rule.condition.stores:
+        class: CoreShop\Component\Core\Shipping\Rule\Condition\StoresConditionChecker
+        tags:
+            - { name: coreshop.shipping_rule.condition, type: stores, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Rule\Condition\StoresConfigurationType }
+
+    coreshop.shipping_rule.condition.currencies:
+        class: CoreShop\Component\Core\Shipping\Rule\Condition\CurrenciesConditionChecker
+        tags:
+            - { name: coreshop.shipping_rule.condition, type: currencies, form-type: CoreShop\Bundle\CoreBundle\Form\Type\Rule\Condition\CurrenciesConfigurationType }
+
     coreshop.carrier.price_calculator.taxed:
         class: CoreShop\Component\Core\Shipping\Calculator\TaxedCarrierPriceRuleCalculator
         arguments:

--- a/src/CoreShop/Bundle/CoreBundle/Templating/Helper/ProductPriceHelper.php
+++ b/src/CoreShop/Bundle/CoreBundle/Templating/Helper/ProductPriceHelper.php
@@ -12,6 +12,7 @@
 
 namespace CoreShop\Bundle\CoreBundle\Templating\Helper;
 
+use CoreShop\Component\Core\Context\ShopperContextInterface;
 use CoreShop\Component\Core\Product\TaxedProductPriceCalculatorInterface;
 use CoreShop\Component\Order\Model\PurchasableInterface;
 use Symfony\Component\Templating\Helper\Helper;
@@ -24,11 +25,20 @@ class ProductPriceHelper extends Helper implements ProductPriceHelperInterface
     private $productPriceCalculator;
 
     /**
-     * @param TaxedProductPriceCalculatorInterface $productPriceCalculator
+     * @var ShopperContextInterface
      */
-    public function __construct(TaxedProductPriceCalculatorInterface $productPriceCalculator)
-    {
+    private $shopperContext;
+
+    /**
+     * @param TaxedProductPriceCalculatorInterface $productPriceCalculator
+     * @param ShopperContextInterface              $shopperContext
+     */
+    public function __construct(
+        TaxedProductPriceCalculatorInterface $productPriceCalculator,
+        ShopperContextInterface $shopperContext
+    ) {
         $this->productPriceCalculator = $productPriceCalculator;
+        $this->shopperContext = $shopperContext;
     }
 
     /**
@@ -36,7 +46,7 @@ class ProductPriceHelper extends Helper implements ProductPriceHelperInterface
      */
     public function getPrice(PurchasableInterface $product, $withTax = true)
     {
-        return $this->productPriceCalculator->getPrice($product, $withTax);
+        return $this->productPriceCalculator->getPrice($product, $this->getContext(), $withTax);
     }
 
     /**
@@ -44,7 +54,7 @@ class ProductPriceHelper extends Helper implements ProductPriceHelperInterface
      */
     public function getDiscountPrice(PurchasableInterface $product, $withTax = true)
     {
-        return $this->productPriceCalculator->getDiscountPrice($product, $withTax);
+        return $this->productPriceCalculator->getDiscountPrice($product, $this->getContext(), $withTax);
     }
 
     /**
@@ -52,7 +62,7 @@ class ProductPriceHelper extends Helper implements ProductPriceHelperInterface
      */
     public function getRetailPrice(PurchasableInterface $product, $withTax = true)
     {
-        return $this->productPriceCalculator->getRetailPrice($product, $withTax);
+        return $this->productPriceCalculator->getRetailPrice($product, $this->getContext(), $withTax);
     }
 
     /**
@@ -60,7 +70,7 @@ class ProductPriceHelper extends Helper implements ProductPriceHelperInterface
      */
     public function getDiscount(PurchasableInterface $product, $withTax = true)
     {
-        return $this->productPriceCalculator->getDiscount($product, $withTax);
+        return $this->productPriceCalculator->getDiscount($product, $this->getContext(), $withTax);
     }
 
     /**
@@ -69,5 +79,19 @@ class ProductPriceHelper extends Helper implements ProductPriceHelperInterface
     public function getName()
     {
         return 'coreshop_product_price';
+    }
+
+    /**
+     * @return array
+     */
+    private function getContext()
+    {
+        return  [
+            'store' => $this->shopperContext->getStore(),
+            'customer' => $this->shopperContext->hasCustomer() ? $this->shopperContext->getCustomer() : null,
+            'currency' => $this->shopperContext->getCurrency(),
+            'country' => $this->shopperContext->getCountry(),
+            'cart' => $this->shopperContext->getCart()
+        ];
     }
 }

--- a/src/CoreShop/Bundle/CoreBundle/Templating/Helper/ProductTaxHelper.php
+++ b/src/CoreShop/Bundle/CoreBundle/Templating/Helper/ProductTaxHelper.php
@@ -21,9 +21,9 @@ use Symfony\Component\Templating\Helper\Helper;
 class ProductTaxHelper extends Helper implements ProductTaxHelperInterface
 {
     /**
-     * @var TaxedProductPriceCalculatorInterface
+     * @var ProductPriceHelperInterface
      */
-    private $priceCalculator;
+    private $priceHelper;
 
     /**
      * @var ProductTaxCalculatorFactoryInterface
@@ -31,15 +31,15 @@ class ProductTaxHelper extends Helper implements ProductTaxHelperInterface
     private $taxCalculatorFactory;
 
     /**
-     * @param TaxedProductPriceCalculatorInterface $priceCalculator
+     * @param ProductPriceHelperInterface $priceHelper
      * @param ProductTaxCalculatorFactoryInterface $taxCalculatorFactory
      */
     public function __construct(
-        TaxedProductPriceCalculatorInterface $priceCalculator,
+        ProductPriceHelperInterface $priceHelper,
         ProductTaxCalculatorFactoryInterface $taxCalculatorFactory
     )
     {
-        $this->priceCalculator = $priceCalculator;
+        $this->priceHelper = $priceHelper;
         $this->taxCalculatorFactory = $taxCalculatorFactory;
     }
 
@@ -51,7 +51,7 @@ class ProductTaxHelper extends Helper implements ProductTaxHelperInterface
     {
         $taxCalculator = $this->taxCalculatorFactory->getTaxCalculator($product);
         if ($taxCalculator instanceof TaxCalculatorInterface) {
-            return $taxCalculator->getTaxesAmount($this->priceCalculator->getPrice($product, false));
+            return $taxCalculator->getTaxesAmount($this->priceHelper->getPrice($product, false));
         }
     }
 

--- a/src/CoreShop/Bundle/CoreBundle/Tracking/Builder/ItemBuilder.php
+++ b/src/CoreShop/Bundle/CoreBundle/Tracking/Builder/ItemBuilder.php
@@ -51,7 +51,7 @@ final class ItemBuilder implements ItemBuilderInterface
         }
 
         if ($product instanceof \CoreShop\Component\Core\Model\ProductInterface) {
-            $item->setPrice($this->taxedProductPriceCalculator->getPrice($product) / 100);
+            $item->setPrice($this->taxedProductPriceCalculator->getPrice($product, []) / 100);
         }
 
         if (method_exists($product, 'getManufacturer')) {

--- a/src/CoreShop/Bundle/OrderBundle/Controller/AbstractSaleDetailController.php
+++ b/src/CoreShop/Bundle/OrderBundle/Controller/AbstractSaleDetailController.php
@@ -142,7 +142,7 @@ abstract class AbstractSaleDetailController extends AbstractSaleController
             'shipping' => $sale->getShipping(),
             'totalTax' => $sale->getTotalTax(),
             'total' => $sale->getTotal(),
-            'currency' => $this->getCurrency($sale->getCurrency() ? $sale->getCurrency() : $this->get('coreshop.context.currency')->getCurrency()),
+            'currency' => $this->getCurrency($sale->getCurrency() ?: $sale->getStore()->getCurrency()),
             'currencyName' => $sale->getCurrency() instanceof CurrencyInterface ? $sale->getCurrency()->getName() : '',
             'customerName' => $sale->getCustomer() instanceof CustomerInterface ? $sale->getCustomer()->getFirstname().' '.$sale->getCustomer()->getLastname() : '',
             'customerEmail' => $sale->getCustomer() instanceof CustomerInterface ? $sale->getCustomer()->getEmail() : '',
@@ -213,7 +213,7 @@ abstract class AbstractSaleDetailController extends AbstractSaleController
         $jsonSale['details'] = $this->getItemDetails($sale);
         $jsonSale['summary'] = $this->getSummary($sale);
         $jsonSale['mailCorrespondence'] = $this->getMailCorrespondence($sale);
-        $jsonSale['currency'] = $this->getCurrency($sale->getCurrency() ? $sale->getCurrency() : $this->get('coreshop.context.currency')->getCurrency());
+        $jsonSale['currency'] = $this->getCurrency($sale->getCurrency() ?: $sale->getStore()->getCurrency());
         $jsonSale['store'] = $sale->getStore() instanceof StoreInterface ? $this->getStore($sale->getStore()) : null;
 
         $jsonSale['address'] = [

--- a/src/CoreShop/Bundle/ProductBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/config/services.yml
@@ -73,7 +73,6 @@ services:
         arguments:
             - '@coreshop.repository.currency'
             - '@coreshop.currency_converter'
-            - '@coreshop.context.currency'
         tags:
             - { name: coreshop.product_price_rule.action, type: price, form-type: CoreShop\Bundle\ProductBundle\Form\Type\Rule\Action\PriceConfigurationType }
             - { name: coreshop.product_specific_price_rule.action, type: price, form-type: CoreShop\Bundle\ProductBundle\Form\Type\Rule\Action\PriceConfigurationType }
@@ -83,7 +82,6 @@ services:
         arguments:
             - '@coreshop.repository.currency'
             - '@coreshop.currency_converter'
-            - '@coreshop.context.currency'
         tags:
             - { name: coreshop.product_price_rule.action, type: discountPrice, form-type: CoreShop\Bundle\ProductBundle\Form\Type\Rule\Action\PriceConfigurationType }
             - { name: coreshop.product_specific_price_rule.action, type: discountPrice, form-type: CoreShop\Bundle\ProductBundle\Form\Type\Rule\Action\PriceConfigurationType }
@@ -93,7 +91,6 @@ services:
         arguments:
             - '@coreshop.repository.currency'
             - '@coreshop.currency_converter'
-            - '@coreshop.context.currency'
         tags:
             - { name: coreshop.product_price_rule.action, type: discountAmount, form-type: CoreShop\Bundle\ProductBundle\Form\Type\Rule\Action\DiscountAmountConfigurationType }
             - { name: coreshop.product_specific_price_rule.action, type: discountAmount, form-type: CoreShop\Bundle\ProductBundle\Form\Type\Rule\Action\DiscountAmountConfigurationType }

--- a/src/CoreShop/Component/Core/Cart/Rule/Condition/CategoriesConditionChecker.php
+++ b/src/CoreShop/Component/Core/Cart/Rule/Condition/CategoriesConditionChecker.php
@@ -32,9 +32,9 @@ final class CategoriesConditionChecker extends AbstractConditionChecker
      * @param CategoryRepositoryInterface $categoryRepository
      * @param StoreContextInterface $storeContext
      */
-    public function __construct(CategoryRepositoryInterface $categoryRepository, StoreContextInterface $storeContext)
+    public function __construct(CategoryRepositoryInterface $categoryRepository)
     {
-        $this->__traitConstruct($categoryRepository, $storeContext);
+        $this->__traitConstruct($categoryRepository);
     }
 
     /**
@@ -42,7 +42,7 @@ final class CategoriesConditionChecker extends AbstractConditionChecker
      */
     public function isCartRuleValid(CartInterface $cart, CartPriceRuleInterface $cartPriceRule, ?CartPriceRuleVoucherCodeInterface $voucher, array $configuration)
     {
-        $categoryIdsToCheck = $this->getCategoriesToCheck($configuration['categories'], $configuration['recursive'] ?: false);
+        $categoryIdsToCheck = $this->getCategoriesToCheck($configuration['categories'], $cart->getStore(), $configuration['recursive'] ?: false);
 
         foreach ($cart->getItems() as $item) {
             $product = $item->getProduct();

--- a/src/CoreShop/Component/Core/Order/Calculator/PurchasableProductDiscountCalculator.php
+++ b/src/CoreShop/Component/Core/Order/Calculator/PurchasableProductDiscountCalculator.php
@@ -35,10 +35,10 @@ final class PurchasableProductDiscountCalculator implements PurchasableDiscountC
     /**
      * {@inheritdoc}
      */
-    public function getDiscount(PurchasableInterface $purchasable, $basePrice)
+    public function getDiscount(PurchasableInterface $purchasable, array $context, $basePrice)
     {
         if ($purchasable instanceof ProductInterface) {
-            $discount = $this->productPriceCalculator->getDiscount($purchasable, $basePrice);
+            $discount = $this->productPriceCalculator->getDiscount($purchasable, $context, $basePrice);
 
             return $discount;
         }

--- a/src/CoreShop/Component/Core/Order/Calculator/PurchasableProductDiscountPriceCalculator.php
+++ b/src/CoreShop/Component/Core/Order/Calculator/PurchasableProductDiscountPriceCalculator.php
@@ -35,10 +35,10 @@ final class PurchasableProductDiscountPriceCalculator implements PurchasableDisc
     /**
      * {@inheritdoc}
      */
-    public function getDiscountPrice(PurchasableInterface $purchasable)
+    public function getDiscountPrice(PurchasableInterface $purchasable, array $context)
     {
         if ($purchasable instanceof ProductInterface) {
-            $discount = $this->productPriceCalculator->getDiscountPrice($purchasable);
+            $discount = $this->productPriceCalculator->getDiscountPrice($purchasable, $context);
 
             return $discount;
         }

--- a/src/CoreShop/Component/Core/Order/Calculator/PurchasableProductPriceCalculator.php
+++ b/src/CoreShop/Component/Core/Order/Calculator/PurchasableProductPriceCalculator.php
@@ -36,10 +36,10 @@ final class PurchasableProductPriceCalculator implements PurchasablePriceCalcula
     /**
      * {@inheritdoc}
      */
-    public function getPrice(PurchasableInterface $purchasable, $includingDiscounts = false)
+    public function getPrice(PurchasableInterface $purchasable, array $context, $includingDiscounts = false)
     {
         if ($purchasable instanceof ProductInterface) {
-            $price = $this->productPriceCalculator->getPrice($purchasable, $includingDiscounts);
+            $price = $this->productPriceCalculator->getPrice($purchasable, $context, $includingDiscounts);
 
             return $price;
         }

--- a/src/CoreShop/Component/Core/Order/Calculator/PurchasableProductRetailPriceCalculator.php
+++ b/src/CoreShop/Component/Core/Order/Calculator/PurchasableProductRetailPriceCalculator.php
@@ -35,10 +35,10 @@ final class PurchasableProductRetailPriceCalculator implements PurchasableRetail
     /**
      * {@inheritdoc}
      */
-    public function getRetailPrice(PurchasableInterface $purchasable)
+    public function getRetailPrice(PurchasableInterface $purchasable, array $context)
     {
         if ($purchasable instanceof ProductInterface) {
-            $price = $this->productPriceCalculator->getRetailPrice($purchasable);
+            $price = $this->productPriceCalculator->getRetailPrice($purchasable, $context);
 
             return $price;
         }

--- a/src/CoreShop/Component/Core/Order/Processor/CartItemProcessor.php
+++ b/src/CoreShop/Component/Core/Order/Processor/CartItemProcessor.php
@@ -49,6 +49,14 @@ final class CartItemProcessor implements CartProcessorInterface
      */
     public function process(CartInterface $cart)
     {
+        $context = [
+            'store' => $cart->getStore(),
+            'customer' => $cart->getCustomer() ?: null,
+            'currency' => $cart->getCurrency(),
+            'country' => $cart->getStore()->getBaseCountry(),
+            'cart' => $cart
+        ];
+
         /**
          * @var $item CartItemInterface
          */
@@ -57,8 +65,8 @@ final class CartItemProcessor implements CartProcessorInterface
 
             $taxCalculator = $this->taxCalculator->getTaxCalculator($product);
 
-            $itemNetPrice = $this->productPriceCalculator->getPrice($product, false);
-            $itemGrossPrice = $this->productPriceCalculator->getPrice($product, true);
+            $itemNetPrice = $this->productPriceCalculator->getPrice($product, $context, false);
+            $itemGrossPrice = $this->productPriceCalculator->getPrice($product, $context, true);
 
             if ($taxCalculator instanceof TaxCalculatorInterface) {
                 if ($cart->getStore()->getUseGrossPrice()) {
@@ -82,12 +90,12 @@ final class CartItemProcessor implements CartProcessorInterface
             $item->setItemPrice($itemNetPrice, false);
             $item->setItemPrice($itemGrossPrice, true);
             //$item->setTotal($itemNetPrice * $item->getQuantity() + $totalTaxAmount, true);
-            $item->setItemRetailPrice($this->productPriceCalculator->getRetailPrice($product, false), false);
-            $item->setItemRetailPrice($this->productPriceCalculator->getRetailPrice($product, true), true);
-            $item->setItemDiscountPrice($this->productPriceCalculator->getDiscountPrice($product, false), false);
-            $item->setItemDiscountPrice($this->productPriceCalculator->getDiscountPrice($product, true), true);
-            $item->setItemDiscount($this->productPriceCalculator->getDiscount($product, false), false);
-            $item->setItemDiscount($this->productPriceCalculator->getDiscount($product, true), true);
+            $item->setItemRetailPrice($this->productPriceCalculator->getRetailPrice($product, $context, false), false);
+            $item->setItemRetailPrice($this->productPriceCalculator->getRetailPrice($product, $context, true), true);
+            $item->setItemDiscountPrice($this->productPriceCalculator->getDiscountPrice($product, $context, false), false);
+            $item->setItemDiscountPrice($this->productPriceCalculator->getDiscountPrice($product, $context, true), true);
+            $item->setItemDiscount($this->productPriceCalculator->getDiscount($product, $context, false), false);
+            $item->setItemDiscount($this->productPriceCalculator->getDiscount($product, $context, true), true);
             $item->setItemWholesalePrice($product->getWholesalePrice());
 
             if ($product instanceof ProductInterface) {

--- a/src/CoreShop/Component/Core/Product/Calculator/StoreProductPriceCalculator.php
+++ b/src/CoreShop/Component/Core/Product/Calculator/StoreProductPriceCalculator.php
@@ -12,38 +12,26 @@
 
 namespace CoreShop\Component\Core\Product\Calculator;
 
-use CoreShop\Component\Product\Calculator\ProductPriceCalculatorInterface;
 use CoreShop\Component\Product\Calculator\ProductRetailPriceCalculatorInterface;
 use CoreShop\Component\Product\Model\ProductInterface;
-use CoreShop\Component\Store\Context\StoreContextInterface;
+use CoreShop\Component\Store\Model\StoreInterface;
 use Webmozart\Assert\Assert;
 
 final class StoreProductPriceCalculator implements ProductRetailPriceCalculatorInterface
 {
     /**
-     * @var StoreContextInterface
-     */
-    protected $storeContext;
-
-    /**
-     * @param StoreContextInterface $storeContext
-     */
-    public function __construct(StoreContextInterface $storeContext)
-    {
-        $this->storeContext = $storeContext;
-    }
-
-    /**
      * {@inheritdoc}
      */
-    public function getRetailPrice(ProductInterface $subject)
+    public function getRetailPrice(ProductInterface $subject, array $context)
     {
         /**
          * @var $subject \CoreShop\Component\Core\Model\ProductInterface
          */
         Assert::isInstanceOf($subject, \CoreShop\Component\Core\Model\ProductInterface::class);
+        Assert::keyExists($context, 'store');
+        Assert::isInstanceOf($context['store'], StoreInterface::class);
 
-        $price = $subject->getStorePrice($this->storeContext->getStore());
+        $price = $subject->getStorePrice($context['store']);
 
         if (is_null($price)) {
             return false;

--- a/src/CoreShop/Component/Core/Product/Rule/Condition/CategoriesConditionChecker.php
+++ b/src/CoreShop/Component/Core/Product/Rule/Condition/CategoriesConditionChecker.php
@@ -19,6 +19,7 @@ use CoreShop\Component\Resource\Model\ResourceInterface;
 use CoreShop\Component\Rule\Condition\ConditionCheckerInterface;
 use CoreShop\Component\Rule\Model\RuleInterface;
 use CoreShop\Component\Store\Context\StoreContextInterface;
+use CoreShop\Component\Store\Model\StoreInterface;
 use Webmozart\Assert\Assert;
 
 final class CategoriesConditionChecker implements ConditionCheckerInterface
@@ -29,11 +30,10 @@ final class CategoriesConditionChecker implements ConditionCheckerInterface
 
     /**
      * @param CategoryRepositoryInterface $categoryRepository
-     * @param StoreContextInterface $storeContext
      */
-    public function __construct(CategoryRepositoryInterface $categoryRepository, StoreContextInterface $storeContext)
+    public function __construct(CategoryRepositoryInterface $categoryRepository)
     {
-        $this->__traitConstruct($categoryRepository, $storeContext);
+        $this->__traitConstruct($categoryRepository);
     }
 
     /**
@@ -41,12 +41,15 @@ final class CategoriesConditionChecker implements ConditionCheckerInterface
      */
     public function isValid(ResourceInterface $subject, RuleInterface $rule, array $configuration, $params = [])
     {
+        Assert::keyExists($params, 'store');
+        Assert::isInstanceOf($params['store'], StoreInterface::class);
+
         /**
          * @var $subject ProductInterface
          */
         Assert::isInstanceOf($subject, ProductInterface::class);
 
-        $categoryIdsToCheck = $this->getCategoriesToCheck($configuration['categories'], $configuration['recursive'] ?: false);
+        $categoryIdsToCheck = $this->getCategoriesToCheck($configuration['categories'], $params['store'], $configuration['recursive'] ?: false);
 
         if (!is_array($subject->getCategories())) {
             return false;

--- a/src/CoreShop/Component/Core/Product/Rule/Condition/CountriesConditionChecker.php
+++ b/src/CoreShop/Component/Core/Product/Rule/Condition/CountriesConditionChecker.php
@@ -17,33 +17,19 @@ use CoreShop\Component\Core\Model\CountryInterface;
 use CoreShop\Component\Resource\Model\ResourceInterface;
 use CoreShop\Component\Rule\Condition\ConditionCheckerInterface;
 use CoreShop\Component\Rule\Model\RuleInterface;
+use Webmozart\Assert\Assert;
 
 final class CountriesConditionChecker implements ConditionCheckerInterface
 {
-    /**
-     * @var CountryContextInterface
-     */
-    private $countryContext;
-
-    /**
-     * @param CountryContextInterface $countryContext
-     */
-    public function __construct(CountryContextInterface $countryContext)
-    {
-        $this->countryContext = $countryContext;
-    }
-
     /**
      * {@inheritdoc}
      */
     public function isValid(ResourceInterface $subject, RuleInterface $rule, array $configuration, $params = [])
     {
-        $country = $this->countryContext->getCountry();
-
-        if (!$country instanceof CountryInterface) {
+        if (!array_key_exists('country', $params)) {
             return false;
         }
 
-        return in_array($country->getId(), $configuration['countries']);
+        return in_array($params['country']->getId(), $configuration['countries']);
     }
 }

--- a/src/CoreShop/Component/Core/Product/Rule/Condition/CurrenciesConditionChecker.php
+++ b/src/CoreShop/Component/Core/Product/Rule/Condition/CurrenciesConditionChecker.php
@@ -21,29 +21,14 @@ use CoreShop\Component\Rule\Model\RuleInterface;
 final class CurrenciesConditionChecker implements ConditionCheckerInterface
 {
     /**
-     * @var CurrencyContextInterface
-     */
-    private $currencyContext;
-
-    /**
-     * @param CurrencyContextInterface $currencyContext
-     */
-    public function __construct(CurrencyContextInterface $currencyContext)
-    {
-        $this->currencyContext = $currencyContext;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function isValid(ResourceInterface $subject, RuleInterface $rule, array $configuration, $params = [])
     {
-        $currency = $this->currencyContext->getCurrency();
-
-        if (!$currency instanceof CurrencyInterface) {
+        if (!array_key_exists('currency', $params)) {
             return false;
         }
 
-        return in_array($currency->getId(), $configuration['currencies']);
+        return in_array($params['currency']->getId(), $configuration['currencies']);
     }
 }

--- a/src/CoreShop/Component/Core/Product/Rule/Condition/CustomerGroupsConditionChecker.php
+++ b/src/CoreShop/Component/Core/Product/Rule/Condition/CustomerGroupsConditionChecker.php
@@ -22,38 +22,25 @@ use CoreShop\Component\Rule\Model\RuleInterface;
 final class CustomerGroupsConditionChecker implements ConditionCheckerInterface
 {
     /**
-     * @var CustomerContextInterface
-     */
-    private $customerContext;
-
-    /**
-     * @param CustomerContextInterface $customerContext
-     */
-    public function __construct(CustomerContextInterface $customerContext)
-    {
-        $this->customerContext = $customerContext;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function isValid(ResourceInterface $subject, RuleInterface $rule, array $configuration, $params = [])
     {
-        try {
-            /**
-             * @var CustomerInterface
-             */
-            $customer = $this->customerContext->getCustomer();
+        if (!array_key_exists('customer', $params) || !$params['customer'] instanceof CustomerInterface) {
+            return false;
+        }
 
-            foreach ($customer->getCustomerGroups() as $group) {
-                if ($group instanceof ResourceInterface) {
-                    if (in_array($group->getId(), $configuration['customerGroups'])) {
-                        return true;
-                    }
+        /**
+         * @var $customer CustomerInterface
+         */
+        $customer = $params['customer'];
+
+        foreach ($customer->getCustomerGroups() as $group) {
+            if ($group instanceof ResourceInterface) {
+                if (in_array($group->getId(), $configuration['customerGroups'])) {
+                    return true;
                 }
             }
-        } catch (CustomerNotFoundException $ex) {
-            //If some goes wrong, we just ignore it and return false
         }
 
         return false;

--- a/src/CoreShop/Component/Core/Product/Rule/Condition/CustomersConditionChecker.php
+++ b/src/CoreShop/Component/Core/Product/Rule/Condition/CustomersConditionChecker.php
@@ -21,31 +21,14 @@ use CoreShop\Component\Rule\Model\RuleInterface;
 final class CustomersConditionChecker implements ConditionCheckerInterface
 {
     /**
-     * @var CustomerContextInterface
-     */
-    private $customerContext;
-
-    /**
-     * @param CustomerContextInterface $customerContext
-     */
-    public function __construct(CustomerContextInterface $customerContext)
-    {
-        $this->customerContext = $customerContext;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function isValid(ResourceInterface $subject, RuleInterface $rule, array $configuration, $params = [])
     {
-        try {
-            $customer = $this->customerContext->getCustomer();
-
-            return in_array($customer->getId(), $configuration['customers']);
-        } catch (CustomerNotFoundException $ex) {
-            //If some goes wrong, we can ignore it, since it means that there is no Customer in the context
+        if (!array_key_exists('customer', $params)) {
+            return false;
         }
 
-        return false;
+        return in_array($params['customer']->getId(), $configuration['customers']);
     }
 }

--- a/src/CoreShop/Component/Core/Product/Rule/Condition/QuantityConditionChecker.php
+++ b/src/CoreShop/Component/Core/Product/Rule/Condition/QuantityConditionChecker.php
@@ -23,29 +23,15 @@ use Webmozart\Assert\Assert;
 final class QuantityConditionChecker implements ConditionCheckerInterface
 {
     /**
-     * @var CartContextInterface
-     */
-    private $cartContext;
-
-    /**
-     * @param CartContextInterface $cartContext
-     */
-    public function __construct(CartContextInterface $cartContext)
-    {
-        $this->cartContext = $cartContext;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function isValid(ResourceInterface $subject, RuleInterface $rule, array $configuration, $params = [])
     {
-        /**
-         * @var $subject ProductInterface
-         */
-        Assert::isInstanceOf($subject, ProductInterface::class);
+        if (array_key_exists('cart', $params)) {
+            return false;
+        }
 
-        $cart = $this->cartContext->getCart();
+        $cart = $params['cart'];
 
         foreach ($cart->getItems() as $item) {
             if ($item instanceof CartItemInterface) {

--- a/src/CoreShop/Component/Core/Product/Rule/Condition/StoresConditionChecker.php
+++ b/src/CoreShop/Component/Core/Product/Rule/Condition/StoresConditionChecker.php
@@ -21,29 +21,14 @@ use CoreShop\Component\Store\Model\StoreInterface;
 final class StoresConditionChecker implements ConditionCheckerInterface
 {
     /**
-     * @var StoreContextInterface
-     */
-    private $storeContext;
-
-    /**
-     * @param StoreContextInterface $storeContext
-     */
-    public function __construct(StoreContextInterface $storeContext)
-    {
-        $this->storeContext = $storeContext;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function isValid(ResourceInterface $subject, RuleInterface $rule, array $configuration, $params = [])
     {
-        $store = $this->storeContext->getStore();
-
-        if (!$store instanceof StoreInterface) {
+        if (!array_key_exists('store', $params)) {
             return false;
         }
 
-        return in_array($store->getId(), $configuration['stores']);
+        return in_array($params['store']->getId(), $configuration['stores']);
     }
 }

--- a/src/CoreShop/Component/Core/Product/Rule/Condition/ZonesConditionChecker.php
+++ b/src/CoreShop/Component/Core/Product/Rule/Condition/ZonesConditionChecker.php
@@ -22,28 +22,15 @@ use CoreShop\Component\Rule\Model\RuleInterface;
 final class ZonesConditionChecker implements ConditionCheckerInterface
 {
     /**
-     * @var CountryContextInterface
-     */
-    private $countryContext;
-
-    /**
-     * @param CountryContextInterface $countryContext
-     */
-    public function __construct(CountryContextInterface $countryContext)
-    {
-        $this->countryContext = $countryContext;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function isValid(ResourceInterface $subject, RuleInterface $rule, array $configuration, $params = [])
     {
-        $country = $this->countryContext->getCountry();
-
-        if (!$country instanceof CountryInterface) {
+        if (!array_key_exists('country', $params)) {
             return false;
         }
+
+        $country = $params['country'];
 
         if (!$country->getZone() instanceof ZoneInterface) {
             return false;

--- a/src/CoreShop/Component/Core/Product/TaxedProductPriceCalculator.php
+++ b/src/CoreShop/Component/Core/Product/TaxedProductPriceCalculator.php
@@ -80,9 +80,9 @@ class TaxedProductPriceCalculator implements TaxedProductPriceCalculatorInterfac
     /**
      * {@inheritdoc}
      */
-    public function getPrice(PurchasableInterface $product, $withTax = true)
+    public function getPrice(PurchasableInterface $product, array $context, $withTax = true)
     {
-        $price = $this->priceCalculator->getPrice($product, true);
+        $price = $this->priceCalculator->getPrice($product, $context, true);
         $taxCalculator = $this->taxCalculatorFactory->getTaxCalculator($product);
 
         if ($taxCalculator instanceof TaxCalculatorInterface) {
@@ -95,9 +95,9 @@ class TaxedProductPriceCalculator implements TaxedProductPriceCalculatorInterfac
     /**
      * {@inheritdoc}
      */
-    public function getDiscountPrice(PurchasableInterface $product, $withTax = true)
+    public function getDiscountPrice(PurchasableInterface $product, array $context, $withTax = true)
     {
-        $price = $this->discountPriceCalculator->getDiscountPrice($product);
+        $price = $this->discountPriceCalculator->getDiscountPrice($product, $context);
 
         if (is_null($price)) {
             throw new \InvalidArgumentException(sprintf("Could not determine a discount price for Product (%s)", $product->getId()));
@@ -115,10 +115,10 @@ class TaxedProductPriceCalculator implements TaxedProductPriceCalculatorInterfac
     /**
      * {@inheritdoc}
      */
-    public function getDiscount(PurchasableInterface $product, $withTax = true)
+    public function getDiscount(PurchasableInterface $product, array $context, $withTax = true)
     {
-        $price = $this->priceCalculator->getPrice($product);
-        $discount = $this->discountCalculator->getDiscount($product, $price);
+        $price = $this->priceCalculator->getPrice($product, $context);
+        $discount = $this->discountCalculator->getDiscount($product, $context, $price);
         $taxCalculator = $this->taxCalculatorFactory->getTaxCalculator($product);
 
         if ($taxCalculator instanceof TaxCalculatorInterface) {
@@ -131,9 +131,9 @@ class TaxedProductPriceCalculator implements TaxedProductPriceCalculatorInterfac
     /**
      * {@inheritdoc}
      */
-    public function getRetailPrice(PurchasableInterface $product, $withTax = true)
+    public function getRetailPrice(PurchasableInterface $product, array $context, $withTax = true)
     {
-        $price = $this->retailPriceCalculator->getRetailPrice($product);
+        $price = $this->retailPriceCalculator->getRetailPrice($product, $context);
 
         if (is_null($price)) {
             throw new \InvalidArgumentException(sprintf("Could not determine a price for Product (%s)", $product->getId()));

--- a/src/CoreShop/Component/Core/Product/TaxedProductPriceCalculatorInterface.php
+++ b/src/CoreShop/Component/Core/Product/TaxedProductPriceCalculatorInterface.php
@@ -18,29 +18,33 @@ interface TaxedProductPriceCalculatorInterface
 {
     /**
      * @param PurchasableInterface $product
+     * @param array $context
      * @param bool $withTax
      * @return int
      */
-    public function getPrice(PurchasableInterface $product, $withTax = true);
+    public function getPrice(PurchasableInterface $product, array $context, $withTax = true);
 
     /**
      * @param PurchasableInterface $product
+     * @param array $context
      * @param bool $withTax
      * @return int
      */
-    public function getDiscountPrice(PurchasableInterface $product, $withTax = true);
+    public function getDiscountPrice(PurchasableInterface $product, array $context, $withTax = true);
 
     /**
      * @param PurchasableInterface $product
+     * @param array $context
      * @param bool $withTax
      * @return int
      */
-    public function getDiscount(PurchasableInterface $product, $withTax = true);
+    public function getDiscount(PurchasableInterface $product, array $context, $withTax = true);
 
     /**
      * @param PurchasableInterface $product
+     * @param array $context
      * @param bool $withTax
      * @return int
      */
-    public function getRetailPrice(PurchasableInterface $product, $withTax = true);
+    public function getRetailPrice(PurchasableInterface $product, array $context, $withTax = true);
 }

--- a/src/CoreShop/Component/Core/Rule/Condition/CategoriesConditionCheckerTrait.php
+++ b/src/CoreShop/Component/Core/Rule/Condition/CategoriesConditionCheckerTrait.php
@@ -15,6 +15,7 @@ namespace CoreShop\Component\Core\Rule\Condition;
 use CoreShop\Component\Core\Model\CategoryInterface;
 use CoreShop\Component\Core\Repository\CategoryRepositoryInterface;
 use CoreShop\Component\Store\Context\StoreContextInterface;
+use CoreShop\Component\Store\Model\StoreInterface;
 
 trait CategoriesConditionCheckerTrait
 {
@@ -24,26 +25,20 @@ trait CategoriesConditionCheckerTrait
     private $categoryRepository;
 
     /**
-     * @var StoreContextInterface
-     */
-    private $storeContext;
-
-    /**
      * @param CategoryRepositoryInterface $categoryRepository
-     * @param StoreContextInterface $storeContext
      */
-    public function __construct(CategoryRepositoryInterface $categoryRepository, StoreContextInterface $storeContext)
+    public function __construct(CategoryRepositoryInterface $categoryRepository)
     {
         $this->categoryRepository = $categoryRepository;
-        $this->storeContext = $storeContext;
     }
 
     /**
      * @param $categories
+     * @param StoreInterface $store
      * @param $recursive
      * @return array
      */
-    protected function getCategoriesToCheck($categories, $recursive)
+    protected function getCategoriesToCheck($categories, StoreInterface $store, $recursive)
     {
         $categoryIdsToCheck = $categories;
 
@@ -55,7 +50,7 @@ trait CategoriesConditionCheckerTrait
                     continue;
                 }
 
-                $subCategories = $this->categoryRepository->findRecursiveChildCategoryIdsForStore($category, $this->storeContext->getStore());
+                $subCategories = $this->categoryRepository->findRecursiveChildCategoryIdsForStore($category, $store);
 
                 foreach ($subCategories as $child) {
                     if (!in_array($child, $categoryIdsToCheck)) {

--- a/src/CoreShop/Component/Core/Shipping/Rule/Condition/CategoriesConditionChecker.php
+++ b/src/CoreShop/Component/Core/Shipping/Rule/Condition/CategoriesConditionChecker.php
@@ -13,6 +13,7 @@
 namespace CoreShop\Component\Core\Shipping\Rule\Condition;
 
 use CoreShop\Component\Address\Model\AddressInterface;
+use CoreShop\Component\Core\Model\CartInterface;
 use CoreShop\Component\Core\Repository\CategoryRepositoryInterface;
 use CoreShop\Component\Core\Rule\Condition\CategoriesConditionCheckerTrait;
 use CoreShop\Component\Product\Model\ProductInterface;
@@ -21,6 +22,7 @@ use CoreShop\Component\Shipping\Model\CarrierInterface;
 use CoreShop\Component\Shipping\Model\ShippableInterface;
 use CoreShop\Component\Shipping\Rule\Condition\AbstractConditionChecker;
 use CoreShop\Component\Store\Context\StoreContextInterface;
+use Webmozart\Assert\Assert;
 
 final class CategoriesConditionChecker extends AbstractConditionChecker
 {
@@ -30,11 +32,10 @@ final class CategoriesConditionChecker extends AbstractConditionChecker
 
     /**
      * @param CategoryRepositoryInterface $categoryRepository
-     * @param StoreContextInterface $storeContext
      */
-    public function __construct(CategoryRepositoryInterface $categoryRepository, StoreContextInterface $storeContext)
+    public function __construct(CategoryRepositoryInterface $categoryRepository)
     {
-        $this->__traitConstruct($categoryRepository, $storeContext);
+        $this->__traitConstruct($categoryRepository);
     }
 
     /**
@@ -42,9 +43,14 @@ final class CategoriesConditionChecker extends AbstractConditionChecker
      */
     public function isShippingRuleValid(CarrierInterface $carrier, ShippableInterface $shippable, AddressInterface $address, array $configuration)
     {
+        /**
+         * @var $shippable CartInterface
+         */
+        Assert::isInstanceOf($shippable, CartInterface::class);
+
         $cartItems = $shippable->getItems();
 
-        $categoryIdsToCheck = $this->getCategoriesToCheck($configuration['categories'], $configuration['recursive'] ?: false);
+        $categoryIdsToCheck = $this->getCategoriesToCheck($configuration['categories'], $shippable->getStore(), $configuration['recursive'] ?: false);
 
         foreach ($cartItems as $item) {
             if ($item->getProduct() instanceof ProductInterface) {

--- a/src/CoreShop/Component/Core/Shipping/Rule/Condition/CurrenciesConditionChecker.php
+++ b/src/CoreShop/Component/Core/Shipping/Rule/Condition/CurrenciesConditionChecker.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2017 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Component\Core\Shipping\Rule\Condition;
+
+use CoreShop\Component\Address\Model\AddressInterface;
+use CoreShop\Component\Core\Model\CartInterface;
+use CoreShop\Component\Shipping\Model\CarrierInterface;
+use CoreShop\Component\Shipping\Model\ShippableInterface;
+use CoreShop\Component\Shipping\Rule\Condition\AbstractConditionChecker;
+use Webmozart\Assert\Assert;
+
+final class CurrenciesConditionChecker extends AbstractConditionChecker
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isShippingRuleValid(
+        CarrierInterface $carrier,
+        ShippableInterface $shippable,
+        AddressInterface $address,
+        array $configuration
+    ) {
+        /**
+         * @var $shippable CartInterface
+         */
+        Assert::isInstanceOf($shippable, CartInterface::class);
+
+        return in_array($shippable->getCurrency()->getId(), $configuration['currencies']);
+    }
+}

--- a/src/CoreShop/Component/Core/Shipping/Rule/Condition/CustomerGroupsConditionChecker.php
+++ b/src/CoreShop/Component/Core/Shipping/Rule/Condition/CustomerGroupsConditionChecker.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2017 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Component\Core\Shipping\Rule\Condition;
+
+use CoreShop\Component\Address\Model\AddressInterface;
+use CoreShop\Component\Core\Model\CartInterface;
+use CoreShop\Component\Customer\Model\CustomerInterface;
+use CoreShop\Component\Resource\Model\ResourceInterface;
+use CoreShop\Component\Shipping\Model\CarrierInterface;
+use CoreShop\Component\Shipping\Model\ShippableInterface;
+use CoreShop\Component\Shipping\Rule\Condition\AbstractConditionChecker;
+use Webmozart\Assert\Assert;
+
+final class CustomerGroupsConditionChecker extends AbstractConditionChecker
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isShippingRuleValid(
+        CarrierInterface $carrier,
+        ShippableInterface $shippable,
+        AddressInterface $address,
+        array $configuration
+    ) {
+        /**
+         * @var $shippable CartInterface
+         */
+        Assert::isInstanceOf($shippable, CartInterface::class);
+
+        if (!$shippable->getCustomer() instanceof CustomerInterface) {
+            return false;
+        }
+
+        foreach ($shippable->getCustomer()->getCustomerGroups() as $group) {
+            if ($group instanceof ResourceInterface) {
+                if (in_array($group->getId(), $configuration['customerGroups'])) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/CoreShop/Component/Core/Shipping/Rule/Condition/CustomersConditionChecker.php
+++ b/src/CoreShop/Component/Core/Shipping/Rule/Condition/CustomersConditionChecker.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2017 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Component\Core\Shipping\Rule\Condition;
+
+use CoreShop\Component\Address\Model\AddressInterface;
+use CoreShop\Component\Core\Model\CartInterface;
+use CoreShop\Component\Customer\Model\CustomerInterface;
+use CoreShop\Component\Shipping\Model\CarrierInterface;
+use CoreShop\Component\Shipping\Model\ShippableInterface;
+use CoreShop\Component\Shipping\Rule\Condition\AbstractConditionChecker;
+use Webmozart\Assert\Assert;
+
+final class CustomersConditionChecker extends AbstractConditionChecker
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isShippingRuleValid(
+        CarrierInterface $carrier,
+        ShippableInterface $shippable,
+        AddressInterface $address,
+        array $configuration
+    ) {
+        /**
+         * @var $shippable CartInterface
+         */
+        Assert::isInstanceOf($shippable, CartInterface::class);
+
+        if (!$shippable->getCustomer() instanceof CustomerInterface) {
+            return false;
+        }
+
+        return in_array($shippable->getCustomer()->getId(), $configuration['customers']);
+    }
+}

--- a/src/CoreShop/Component/Core/Shipping/Rule/Condition/StoresConditionChecker.php
+++ b/src/CoreShop/Component/Core/Shipping/Rule/Condition/StoresConditionChecker.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2017 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Component\Core\Shipping\Rule\Condition;
+
+use CoreShop\Component\Address\Model\AddressInterface;
+use CoreShop\Component\Core\Model\CartInterface;
+use CoreShop\Component\Shipping\Model\CarrierInterface;
+use CoreShop\Component\Shipping\Model\ShippableInterface;
+use CoreShop\Component\Shipping\Rule\Condition\AbstractConditionChecker;
+use Webmozart\Assert\Assert;
+
+final class StoresConditionChecker extends AbstractConditionChecker
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isShippingRuleValid(
+        CarrierInterface $carrier,
+        ShippableInterface $shippable,
+        AddressInterface $address,
+        array $configuration
+    ) {
+        /**
+         * @var $shippable CartInterface
+         */
+        Assert::isInstanceOf($shippable, CartInterface::class);
+
+        return in_array($shippable->getStore()->getId(), $configuration['stores']);
+    }
+}

--- a/src/CoreShop/Component/Order/Calculator/CompositePurchasableDiscountCalculator.php
+++ b/src/CoreShop/Component/Order/Calculator/CompositePurchasableDiscountCalculator.php
@@ -33,7 +33,7 @@ class CompositePurchasableDiscountCalculator implements PurchasableDiscountCalcu
     /**
      * {@inheritdoc}
      */
-    public function getDiscount(PurchasableInterface $purchasable, $basePrice)
+    public function getDiscount(PurchasableInterface $purchasable, array $context, $basePrice)
     {
         $discounts = 0;
 
@@ -41,7 +41,7 @@ class CompositePurchasableDiscountCalculator implements PurchasableDiscountCalcu
          * @var $calculator PurchasableDiscountCalculatorInterface
          */
         foreach ($this->discountCalculators->all() as $calculator) {
-            $discounts += $calculator->getDiscount($purchasable, $basePrice);
+            $discounts += $calculator->getDiscount($purchasable, $context, $basePrice);
         }
 
         return $discounts;

--- a/src/CoreShop/Component/Order/Calculator/CompositePurchasableDiscountPriceCalculator.php
+++ b/src/CoreShop/Component/Order/Calculator/CompositePurchasableDiscountPriceCalculator.php
@@ -33,7 +33,7 @@ class CompositePurchasableDiscountPriceCalculator implements PurchasableDiscount
     /**
      * {@inheritdoc}
      */
-    public function getDiscountPrice(PurchasableInterface $purchasable)
+    public function getDiscountPrice(PurchasableInterface $purchasable, array $context)
     {
         $price = 0;
 
@@ -41,7 +41,7 @@ class CompositePurchasableDiscountPriceCalculator implements PurchasableDiscount
          * @var $calculator PurchasableDiscountPriceCalculatorInterface
          */
         foreach ($this->discountPriceCalculators->all() as $calculator) {
-            $actionPrice = $calculator->getDiscountPrice($purchasable);
+            $actionPrice = $calculator->getDiscountPrice($purchasable, $context);
 
             if (false !== $actionPrice && null !== $actionPrice) {
                 $price = $actionPrice;

--- a/src/CoreShop/Component/Order/Calculator/CompositePurchasablePriceCalculator.php
+++ b/src/CoreShop/Component/Order/Calculator/CompositePurchasablePriceCalculator.php
@@ -33,7 +33,7 @@ class CompositePurchasablePriceCalculator implements PurchasablePriceCalculatorI
     /**
      * {@inheritdoc}
      */
-    public function getPrice(PurchasableInterface $purchasable, $includingDiscounts = false)
+    public function getPrice(PurchasableInterface $purchasable, array $context, $includingDiscounts = false)
     {
         $price = false;
 
@@ -41,7 +41,7 @@ class CompositePurchasablePriceCalculator implements PurchasablePriceCalculatorI
          * @var $calculator PurchasablePriceCalculatorInterface
          */
         foreach ($this->calculators->all() as $calculator) {
-            $actionPrice = $calculator->getPrice($purchasable, $includingDiscounts);
+            $actionPrice = $calculator->getPrice($purchasable, $context, $includingDiscounts);
 
             if (false !== $actionPrice && null !== $actionPrice) {
                 $price = $actionPrice;

--- a/src/CoreShop/Component/Order/Calculator/CompositePurchasableRetailPriceCalculator.php
+++ b/src/CoreShop/Component/Order/Calculator/CompositePurchasableRetailPriceCalculator.php
@@ -33,7 +33,7 @@ class CompositePurchasableRetailPriceCalculator implements PurchasableRetailPric
     /**
      * {@inheritdoc}
      */
-    public function getRetailPrice(PurchasableInterface $purchasable)
+    public function getRetailPrice(PurchasableInterface $purchasable, array $context)
     {
         $price = false;
 
@@ -41,7 +41,7 @@ class CompositePurchasableRetailPriceCalculator implements PurchasableRetailPric
          * @var $calculator PurchasableRetailPriceCalculatorInterface
          */
         foreach ($this->calculators->all() as $calculator) {
-            $actionPrice = $calculator->getRetailPrice($purchasable);
+            $actionPrice = $calculator->getRetailPrice($purchasable, $context);
 
             if (false !== $actionPrice && null !== $actionPrice) {
                 $price = $actionPrice;

--- a/src/CoreShop/Component/Order/Calculator/DefaultPurchasablePriceCalculator.php
+++ b/src/CoreShop/Component/Order/Calculator/DefaultPurchasablePriceCalculator.php
@@ -50,10 +50,10 @@ final class DefaultPurchasablePriceCalculator implements PurchasablePriceCalcula
     /**
      * {@inheritdoc}
      */
-    public function getPrice(PurchasableInterface $purchasable, $includingDiscounts = false)
+    public function getPrice(PurchasableInterface $purchasable, array $context, $includingDiscounts = false)
     {
-        $retailPrice = $this->purchasableRetailPriceCalculator->getRetailPrice($purchasable);
-        $discountPrice = $this->purchasableDiscountPriceCalculator->getDiscountPrice($purchasable);
+        $retailPrice = $this->purchasableRetailPriceCalculator->getRetailPrice($purchasable, $context);
+        $discountPrice = $this->purchasableDiscountPriceCalculator->getDiscountPrice($purchasable, $context);
         $price = $retailPrice;
 
         if ($discountPrice > 0 && $discountPrice < $retailPrice) {
@@ -61,7 +61,7 @@ final class DefaultPurchasablePriceCalculator implements PurchasablePriceCalcula
         }
 
         if ($includingDiscounts) {
-            $price -= $this->purchasableDiscountCalculator->getDiscount($purchasable, $price);
+            $price -= $this->purchasableDiscountCalculator->getDiscount($purchasable, $context, $price);
         }
 
         return $price;

--- a/src/CoreShop/Component/Order/Calculator/NoDiscountPurchasableCalculator.php
+++ b/src/CoreShop/Component/Order/Calculator/NoDiscountPurchasableCalculator.php
@@ -19,7 +19,7 @@ final class NoDiscountPurchasableCalculator implements PurchasableDiscountCalcul
     /**
      * {@inheritdoc}
      */
-    public function getDiscount(PurchasableInterface $purchasable, $basePrice)
+    public function getDiscount(PurchasableInterface $purchasable, array $context, $basePrice)
     {
         return 0;
     }

--- a/src/CoreShop/Component/Order/Calculator/PriceAwarePurchasableCalculator.php
+++ b/src/CoreShop/Component/Order/Calculator/PriceAwarePurchasableCalculator.php
@@ -23,7 +23,7 @@ final class PriceAwarePurchasableCalculator implements PurchasableRetailPriceCal
     /**
      * {@inheritdoc}
      */
-    public function getRetailPrice(PurchasableInterface $purchasable)
+    public function getRetailPrice(PurchasableInterface $purchasable, array $context)
     {
         if ($purchasable instanceof PriceAwarePurchasableInterface) {
             @trigger_error('Class CoreShop\Component\Order\Calculator\PriceAwarePurchasableCalculator is deprecated since version 2.0.0-beta.4 and will be removed in 2.0.', E_USER_DEPRECATED);

--- a/src/CoreShop/Component/Order/Calculator/PurchasableDiscountCalculatorInterface.php
+++ b/src/CoreShop/Component/Order/Calculator/PurchasableDiscountCalculatorInterface.php
@@ -18,8 +18,9 @@ interface PurchasableDiscountCalculatorInterface
 {
     /**
      * @param PurchasableInterface $purchasable
+     * @param array $context
      * @param int $basePrice
      * @return int
      */
-    public function getDiscount(PurchasableInterface $purchasable, $basePrice);
+    public function getDiscount(PurchasableInterface $purchasable, array $context, $basePrice);
 }

--- a/src/CoreShop/Component/Order/Calculator/PurchasableDiscountPriceCalculatorInterface.php
+++ b/src/CoreShop/Component/Order/Calculator/PurchasableDiscountPriceCalculatorInterface.php
@@ -18,7 +18,8 @@ interface PurchasableDiscountPriceCalculatorInterface
 {
     /**
      * @param PurchasableInterface $purchasable
+     * array $context
      * @return int
      */
-    public function getDiscountPrice(PurchasableInterface $purchasable);
+    public function getDiscountPrice(PurchasableInterface $purchasable, array $context);
 }

--- a/src/CoreShop/Component/Order/Calculator/PurchasablePriceCalculatorInterface.php
+++ b/src/CoreShop/Component/Order/Calculator/PurchasablePriceCalculatorInterface.php
@@ -18,8 +18,9 @@ interface PurchasablePriceCalculatorInterface
 {
     /**
      * @param PurchasableInterface $purchasable
+     * @param array $context
      * @param bool $includingDiscounts
      * @return int
      */
-    public function getPrice(PurchasableInterface $purchasable, $includingDiscounts = false);
+    public function getPrice(PurchasableInterface $purchasable, array $context, $includingDiscounts = false);
 }

--- a/src/CoreShop/Component/Order/Calculator/PurchasableRetailPriceCalculatorInterface.php
+++ b/src/CoreShop/Component/Order/Calculator/PurchasableRetailPriceCalculatorInterface.php
@@ -18,7 +18,8 @@ interface PurchasableRetailPriceCalculatorInterface
 {
     /**
      * @param PurchasableInterface $purchasable
+     * @param array $context
      * @return int
      */
-    public function getRetailPrice(PurchasableInterface $purchasable);
+    public function getRetailPrice(PurchasableInterface $purchasable, array $context);
 }

--- a/src/CoreShop/Component/Product/Calculator/CompositeDiscountCalculator.php
+++ b/src/CoreShop/Component/Product/Calculator/CompositeDiscountCalculator.php
@@ -33,12 +33,12 @@ class CompositeDiscountCalculator implements ProductDiscountCalculatorInterface
     /**
      * {@inheritdoc}
      */
-    public function getDiscount(ProductInterface $subject, $price)
+    public function getDiscount(ProductInterface $subject, array $context, $price)
     {
         $discount = 0;
 
         foreach ($this->discountCalculator->all() as $calculator) {
-            $discount += $calculator->getDiscount($subject, $price);
+            $discount += $calculator->getDiscount($subject, $context, $price);
         }
 
         return $discount;

--- a/src/CoreShop/Component/Product/Calculator/CompositeDiscountPriceCalculator.php
+++ b/src/CoreShop/Component/Product/Calculator/CompositeDiscountPriceCalculator.php
@@ -33,12 +33,12 @@ class CompositeDiscountPriceCalculator implements ProductDiscountPriceCalculator
     /**
      * {@inheritdoc}
      */
-    public function getDiscountPrice(ProductInterface $subject)
+    public function getDiscountPrice(ProductInterface $subject, array $context)
     {
         $price = false;
 
         foreach ($this->discountPriceCalculator->all() as $calculator) {
-            $actionPrice = $calculator->getDiscountPrice($subject);
+            $actionPrice = $calculator->getDiscountPrice($subject, $context, $context);
 
             if (false !== $actionPrice && null !== $actionPrice) {
                 $price = $actionPrice;

--- a/src/CoreShop/Component/Product/Calculator/CompositeRetailPriceCalculator.php
+++ b/src/CoreShop/Component/Product/Calculator/CompositeRetailPriceCalculator.php
@@ -33,12 +33,12 @@ class CompositeRetailPriceCalculator implements ProductRetailPriceCalculatorInte
     /**
      * {@inheritdoc}
      */
-    public function getRetailPrice(ProductInterface $subject)
+    public function getRetailPrice(ProductInterface $subject, array $context)
     {
         $price = false;
 
         foreach ($this->retailPriceCalculator->all() as $calculator) {
-            $actionPrice = $calculator->getRetailPrice($subject);
+            $actionPrice = $calculator->getRetailPrice($subject, $context);
 
             if (false !== $actionPrice && null !== $actionPrice) {
                 $price = $actionPrice;

--- a/src/CoreShop/Component/Product/Calculator/MemoryCachedProductPriceCalculator.php
+++ b/src/CoreShop/Component/Product/Calculator/MemoryCachedProductPriceCalculator.php
@@ -60,16 +60,16 @@ final class MemoryCachedProductPriceCalculator implements ProductPriceCalculator
     /**
      * {@inheritdoc}
      */
-    public function getPrice(ProductInterface $subject, $includingDiscounts = false)
+    public function getPrice(ProductInterface $subject, array $context, $includingDiscounts = false)
     {
         if (!$this->requestStack->getCurrentRequest()) {
-            return $this->inner->getPrice($subject, $includingDiscounts);
+            return $this->inner->getPrice($subject, $context, $includingDiscounts);
         }
 
         $identifier = sprintf('%s%s', $subject->getId(), $includingDiscounts);
 
         if (!isset($this->cachedPrice[$identifier])) {
-            $this->cachedPrice[$identifier] = $this->inner->getPrice($subject, $includingDiscounts);
+            $this->cachedPrice[$identifier] = $this->inner->getPrice($subject, $context, $includingDiscounts);
         }
 
         return $this->cachedPrice[$identifier];
@@ -78,14 +78,14 @@ final class MemoryCachedProductPriceCalculator implements ProductPriceCalculator
     /**
      * {@inheritdoc}
      */
-    public function getRetailPrice(ProductInterface $subject)
+    public function getRetailPrice(ProductInterface $subject, array $context)
     {
         if (!$this->requestStack->getCurrentRequest()) {
-            return $this->inner->getRetailPrice($subject);
+            return $this->inner->getRetailPrice($subject, $context);
         }
 
         if (!isset($this->cachedRetailPrice[$subject->getId()])) {
-            $this->cachedRetailPrice[$subject->getId()] = $this->inner->getRetailPrice($subject);
+            $this->cachedRetailPrice[$subject->getId()] = $this->inner->getRetailPrice($subject, $context);
         }
 
         return $this->cachedRetailPrice[$subject->getId()];
@@ -94,14 +94,14 @@ final class MemoryCachedProductPriceCalculator implements ProductPriceCalculator
     /**
      * {@inheritdoc}
      */
-    public function getDiscountPrice(ProductInterface $subject)
+    public function getDiscountPrice(ProductInterface $subject, array $context)
     {
         if (!$this->requestStack->getCurrentRequest()) {
-            return $this->inner->getDiscountPrice($subject);
+            return $this->inner->getDiscountPrice($subject, $context);
         }
 
         if (!isset($this->cachedDiscountPrice[$subject->getId()])) {
-            $this->cachedDiscountPrice[$subject->getId()] = $this->inner->getDiscountPrice($subject);
+            $this->cachedDiscountPrice[$subject->getId()] = $this->inner->getDiscountPrice($subject, $context);
         }
 
         return $this->cachedDiscountPrice[$subject->getId()];
@@ -110,14 +110,14 @@ final class MemoryCachedProductPriceCalculator implements ProductPriceCalculator
     /**
      * {@inheritdoc}
      */
-    public function getDiscount(ProductInterface $subject, $price)
+    public function getDiscount(ProductInterface $subject, array $context, $price)
     {
         if (!$this->requestStack->getCurrentRequest()) {
-            return $this->inner->getDiscount($subject, $price);
+            return $this->inner->getDiscount($subject, $context, $price);
         }
 
         if (!isset($this->cachedDiscount[$subject->getId()])) {
-            $this->cachedDiscount[$subject->getId()] = $this->inner->getDiscount($subject, $price);
+            $this->cachedDiscount[$subject->getId()] = $this->inner->getDiscount($subject, $context, $price);
         }
 
         return $this->cachedDiscount[$subject->getId()];

--- a/src/CoreShop/Component/Product/Calculator/ProductDiscountCalculatorInterface.php
+++ b/src/CoreShop/Component/Product/Calculator/ProductDiscountCalculatorInterface.php
@@ -18,9 +18,10 @@ interface ProductDiscountCalculatorInterface
 {
     /**
      * @param $subject
+     * @param array $context
      * @param $price
      *
      * @return mixed
      */
-    public function getDiscount(ProductInterface $subject, $price);
+    public function getDiscount(ProductInterface $subject, array $context, $price);
 }

--- a/src/CoreShop/Component/Product/Calculator/ProductDiscountPriceCalculatorInterface.php
+++ b/src/CoreShop/Component/Product/Calculator/ProductDiscountPriceCalculatorInterface.php
@@ -18,8 +18,9 @@ interface ProductDiscountPriceCalculatorInterface
 {
     /**
      * @param $subject
+     * @param array $context
      *
      * @return mixed
      */
-    public function getDiscountPrice(ProductInterface $subject);
+    public function getDiscountPrice(ProductInterface $subject, array $context);
 }

--- a/src/CoreShop/Component/Product/Calculator/ProductPriceCalculator.php
+++ b/src/CoreShop/Component/Product/Calculator/ProductPriceCalculator.php
@@ -51,10 +51,10 @@ final class ProductPriceCalculator implements ProductPriceCalculatorInterface
     /**
      * {@inheritdoc}
      */
-    public function getPrice(ProductInterface $product, $includingDiscounts = false)
+    public function getPrice(ProductInterface $product, array $context, $includingDiscounts = false)
     {
-        $retailPrice = $this->getRetailPrice($product);
-        $discountPrice = $this->getDiscountPrice($product);
+        $retailPrice = $this->getRetailPrice($product, $context);
+        $discountPrice = $this->getDiscountPrice($product, $context);
         $price = $retailPrice;
 
         if ($discountPrice > 0 && $discountPrice < $retailPrice) {
@@ -62,7 +62,7 @@ final class ProductPriceCalculator implements ProductPriceCalculatorInterface
         }
 
         if ($includingDiscounts) {
-            $price -= $this->getDiscount($product, $price);
+            $price -= $this->getDiscount($product, $context, $price);
         }
 
         return $price;
@@ -71,24 +71,24 @@ final class ProductPriceCalculator implements ProductPriceCalculatorInterface
     /**
      * {@inheritdoc}
      */
-    public function getRetailPrice(ProductInterface $subject)
+    public function getRetailPrice(ProductInterface $subject, array $context)
     {
-        return $this->retailPriceCalculator->getRetailPrice($subject);
+        return $this->retailPriceCalculator->getRetailPrice($subject, $context);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getDiscountPrice(ProductInterface $subject)
+    public function getDiscountPrice(ProductInterface $subject, array $context)
     {
-        return $this->discountPriceCalculator->getDiscountPrice($subject);
+        return $this->discountPriceCalculator->getDiscountPrice($subject, $context);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getDiscount(ProductInterface $subject, $price)
+    public function getDiscount(ProductInterface $subject, array $context, $price)
     {
-        return $this->discountCalculator->getDiscount($subject, $price);
+        return $this->discountCalculator->getDiscount($subject, $context, $price);
     }
 }

--- a/src/CoreShop/Component/Product/Calculator/ProductPriceCalculatorInterface.php
+++ b/src/CoreShop/Component/Product/Calculator/ProductPriceCalculatorInterface.php
@@ -18,9 +18,10 @@ interface ProductPriceCalculatorInterface extends ProductRetailPriceCalculatorIn
 {
     /**
      * @param ProductInterface $subject
+     * @param array $context
      * @param bool $withDiscount
      *
      * @return int
      */
-    public function getPrice(ProductInterface $subject, $withDiscount = true);
+    public function getPrice(ProductInterface $subject, array $context, $withDiscount = true);
 }

--- a/src/CoreShop/Component/Product/Calculator/ProductRetailPriceCalculatorInterface.php
+++ b/src/CoreShop/Component/Product/Calculator/ProductRetailPriceCalculatorInterface.php
@@ -18,8 +18,9 @@ interface ProductRetailPriceCalculatorInterface
 {
     /**
      * @param $subject
+     * @param array $context
      *
      * @return mixed
      */
-    public function getRetailPrice(ProductInterface $subject);
+    public function getRetailPrice(ProductInterface $subject, array $context);
 }

--- a/src/CoreShop/Component/Product/Calculator/PropertyPriceCalculator.php
+++ b/src/CoreShop/Component/Product/Calculator/PropertyPriceCalculator.php
@@ -19,7 +19,7 @@ class PropertyPriceCalculator implements ProductRetailPriceCalculatorInterface
     /**
      * {@inheritdoc}
      */
-    public function getRetailPrice(ProductInterface $subject)
+    public function getRetailPrice(ProductInterface $subject, array $context)
     {
         return $subject->getPrice();
     }

--- a/src/CoreShop/Component/Product/Rule/Action/DiscountAmountActionProcessor.php
+++ b/src/CoreShop/Component/Product/Rule/Action/DiscountAmountActionProcessor.php
@@ -14,6 +14,7 @@ namespace CoreShop\Component\Product\Rule\Action;
 
 use CoreShop\Component\Currency\Context\CurrencyContextInterface;
 use CoreShop\Component\Currency\Converter\CurrencyConverterInterface;
+use CoreShop\Component\Currency\Model\CurrencyInterface;
 use CoreShop\Component\Currency\Repository\CurrencyRepositoryInterface;
 use CoreShop\Component\Product\Model\ProductInterface;
 use Webmozart\Assert\Assert;
@@ -31,32 +32,26 @@ class DiscountAmountActionProcessor implements ProductDiscountActionProcessorInt
     protected $currencyRepository;
 
     /**
-     * @var CurrencyContextInterface
-     */
-    protected $currencyContext;
-
-    /**
      * @param CurrencyRepositoryInterface $currencyRepository
      * @param CurrencyConverterInterface $moneyConverter
-     * @param CurrencyContextInterface $currencyContext
      */
-    public function __construct(CurrencyRepositoryInterface $currencyRepository, CurrencyConverterInterface $moneyConverter, CurrencyContextInterface $currencyContext)
+    public function __construct(CurrencyRepositoryInterface $currencyRepository, CurrencyConverterInterface $moneyConverter)
     {
         $this->currencyRepository = $currencyRepository;
         $this->moneyConverter = $moneyConverter;
-        $this->currencyContext = $currencyContext;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getDiscount($subject, $price, array $configuration)
+    public function getDiscount($subject, $price, array $context, array $configuration)
     {
-        Assert::isInstanceOf($subject, ProductInterface::class);
+        Assert::keyExists($context, 'currency');
+        Assert::isInstanceOf($context['currency'], CurrencyInterface::class);
 
         $amount = $configuration['amount'];
         $currency = $this->currencyRepository->find($configuration['currency']);
 
-        return $this->moneyConverter->convert($amount, $currency->getIsoCode(), $this->currencyContext->getCurrency()->getIsoCode());
+        return $this->moneyConverter->convert($amount, $currency->getIsoCode(), $context['currency']->getIsoCode());
     }
 }

--- a/src/CoreShop/Component/Product/Rule/Action/DiscountPercentActionProcessor.php
+++ b/src/CoreShop/Component/Product/Rule/Action/DiscountPercentActionProcessor.php
@@ -20,7 +20,7 @@ class DiscountPercentActionProcessor implements ProductDiscountActionProcessorIn
     /**
      * {@inheritdoc}
      */
-    public function getDiscount($subject, $price, array $configuration)
+    public function getDiscount($subject, $price, array $context, array $configuration)
     {
         Assert::isInstanceOf($subject, ProductInterface::class);
 

--- a/src/CoreShop/Component/Product/Rule/Action/DiscountPriceActionProcessor.php
+++ b/src/CoreShop/Component/Product/Rule/Action/DiscountPriceActionProcessor.php
@@ -14,7 +14,9 @@ namespace CoreShop\Component\Product\Rule\Action;
 
 use CoreShop\Component\Currency\Context\CurrencyContextInterface;
 use CoreShop\Component\Currency\Converter\CurrencyConverterInterface;
+use CoreShop\Component\Currency\Model\CurrencyInterface;
 use CoreShop\Component\Currency\Repository\CurrencyRepositoryInterface;
+use Webmozart\Assert\Assert;
 
 class DiscountPriceActionProcessor implements ProductDiscountPriceActionProcessorInterface
 {
@@ -29,30 +31,26 @@ class DiscountPriceActionProcessor implements ProductDiscountPriceActionProcesso
     protected $currencyRepository;
 
     /**
-     * @var CurrencyContextInterface
-     */
-    protected $currencyContext;
-
-    /**
      * @param CurrencyRepositoryInterface $currencyRepository
      * @param CurrencyConverterInterface $moneyConverter
-     * @param CurrencyContextInterface $currencyContext
      */
-    public function __construct(CurrencyRepositoryInterface $currencyRepository, CurrencyConverterInterface $moneyConverter, CurrencyContextInterface $currencyContext)
+    public function __construct(CurrencyRepositoryInterface $currencyRepository, CurrencyConverterInterface $moneyConverter)
     {
         $this->currencyRepository = $currencyRepository;
         $this->moneyConverter = $moneyConverter;
-        $this->currencyContext = $currencyContext;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getDiscountPrice($subject, array $configuration)
+    public function getDiscountPrice($subject, array $context, array $configuration)
     {
+        Assert::keyExists($context, 'currency');
+        Assert::isInstanceOf($context['currency'], CurrencyInterface::class);
+
         $price = $configuration['price'];
         $currency = $this->currencyRepository->find($configuration['currency']);
 
-        return $this->moneyConverter->convert($price, $currency->getIsoCode(), $this->currencyContext->getCurrency()->getIsoCode());
+        return $this->moneyConverter->convert($price, $currency->getIsoCode(), $context['currency']->getIsoCode());
     }
 }

--- a/src/CoreShop/Component/Product/Rule/Action/PriceActionProcessor.php
+++ b/src/CoreShop/Component/Product/Rule/Action/PriceActionProcessor.php
@@ -14,7 +14,9 @@ namespace CoreShop\Component\Product\Rule\Action;
 
 use CoreShop\Component\Currency\Context\CurrencyContextInterface;
 use CoreShop\Component\Currency\Converter\CurrencyConverterInterface;
+use CoreShop\Component\Currency\Model\CurrencyInterface;
 use CoreShop\Component\Currency\Repository\CurrencyRepositoryInterface;
+use Webmozart\Assert\Assert;
 
 class PriceActionProcessor implements ProductPriceActionProcessorInterface
 {
@@ -29,30 +31,26 @@ class PriceActionProcessor implements ProductPriceActionProcessorInterface
     protected $currencyRepository;
 
     /**
-     * @var CurrencyContextInterface
-     */
-    protected $currencyContext;
-
-    /**
      * @param CurrencyRepositoryInterface $currencyRepository
      * @param CurrencyConverterInterface $moneyConverter
-     * @param CurrencyContextInterface $currencyContext
      */
-    public function __construct(CurrencyRepositoryInterface $currencyRepository, CurrencyConverterInterface $moneyConverter, CurrencyContextInterface $currencyContext)
+    public function __construct(CurrencyRepositoryInterface $currencyRepository, CurrencyConverterInterface $moneyConverter)
     {
         $this->currencyRepository = $currencyRepository;
         $this->moneyConverter = $moneyConverter;
-        $this->currencyContext = $currencyContext;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getPrice($subject, array $configuration)
+    public function getPrice($subject, array $context, array $configuration)
     {
+        Assert::keyExists($context, 'currency');
+        Assert::isInstanceOf($context['currency'], CurrencyInterface::class);
+
         $price = $configuration['price'];
         $currency = $this->currencyRepository->find($configuration['currency']);
 
-        return $this->moneyConverter->convert($price, $currency->getIsoCode(), $this->currencyContext->getCurrency()->getIsoCode());
+        return $this->moneyConverter->convert($price, $currency->getIsoCode(), $context['currency']->getIsoCode());
     }
 }

--- a/src/CoreShop/Component/Product/Rule/Action/ProductDiscountActionProcessorInterface.php
+++ b/src/CoreShop/Component/Product/Rule/Action/ProductDiscountActionProcessorInterface.php
@@ -17,9 +17,10 @@ interface ProductDiscountActionProcessorInterface extends ActionProcessorInterfa
     /**
      * @param $subject
      * @param $price
+     * @param array $context
      * @param array $configuration
      *
      * @return mixed
      */
-    public function getDiscount($subject, $price, array $configuration);
+    public function getDiscount($subject, $price, array $context, array $configuration);
 }

--- a/src/CoreShop/Component/Product/Rule/Action/ProductDiscountPriceActionProcessorInterface.php
+++ b/src/CoreShop/Component/Product/Rule/Action/ProductDiscountPriceActionProcessorInterface.php
@@ -16,9 +16,10 @@ interface ProductDiscountPriceActionProcessorInterface extends ActionProcessorIn
 {
     /**
      * @param $subject
+     * @param array $context
      * @param array $configuration
      *
      * @return mixed
      */
-    public function getDiscountPrice($subject, array $configuration);
+    public function getDiscountPrice($subject, array $context, array $configuration);
 }

--- a/src/CoreShop/Component/Product/Rule/Action/ProductPriceActionProcessorInterface.php
+++ b/src/CoreShop/Component/Product/Rule/Action/ProductPriceActionProcessorInterface.php
@@ -16,9 +16,10 @@ interface ProductPriceActionProcessorInterface extends ActionProcessorInterface
 {
     /**
      * @param $subject
+     * @param array $context
      * @param array $configuration
      *
      * @return mixed
      */
-    public function getPrice($subject, array $configuration);
+    public function getPrice($subject, array $context, array $configuration);
 }

--- a/src/CoreShop/Component/Product/Rule/Calculator/ProductPriceRuleCalculator.php
+++ b/src/CoreShop/Component/Product/Rule/Calculator/ProductPriceRuleCalculator.php
@@ -52,14 +52,14 @@ final class ProductPriceRuleCalculator implements ProductDiscountCalculatorInter
     /**
      * {@inheritdoc}
      */
-    public function getRetailPrice(ProductInterface $subject)
+    public function getRetailPrice(ProductInterface $subject, array $context)
     {
         $price = 0;
 
         /**
          * @var RuleInterface[]
          */
-        $rules = $this->validRulesFetcher->getValidRules($subject);
+        $rules = $this->validRulesFetcher->getValidRules($subject, $context);
 
         if (is_array($rules)) {
             foreach ($rules as $rule) {
@@ -73,44 +73,7 @@ final class ProductPriceRuleCalculator implements ProductDiscountCalculatorInter
                         continue;
                     }
 
-                    $actionPrice = $processor->getPrice($subject, $action->getConfiguration());
-
-                    if (false !== $actionPrice && null !== $actionPrice) {
-                        $price = $actionPrice;
-                    }
-                }
-            }
-        }
-
-        return $price === 0 ? false : $price;
-    }
-
-    /**
-     * @param ProductInterface $subject
-     * @return bool|int|mixed
-     */
-    public function getDiscountPrice(ProductInterface $subject)
-    {
-        $price = 0;
-
-        /**
-         * @var RuleInterface[]
-         */
-        $rules = $this->validRulesFetcher->getValidRules($subject);
-
-        if (is_array($rules)) {
-            foreach ($rules as $rule) {
-                /**
-                 * @var ActionInterface
-                 */
-                foreach ($rule->getActions() as $action) {
-                    $processor = $this->actionServiceRegistry->get($action->getType());
-
-                    if (!$processor instanceof ProductDiscountPriceActionProcessorInterface) {
-                        continue;
-                    }
-
-                    $actionPrice = $processor->getDiscountPrice($subject, $action->getConfiguration());
+                    $actionPrice = $processor->getPrice($subject, $context, $action->getConfiguration());
 
                     if (false !== $actionPrice && null !== $actionPrice) {
                         $price = $actionPrice;
@@ -125,14 +88,50 @@ final class ProductPriceRuleCalculator implements ProductDiscountCalculatorInter
     /**
      * {@inheritdoc}
      */
-    public function getDiscount(ProductInterface $subject, $price)
+    public function getDiscountPrice(ProductInterface $subject, array $context)
+    {
+        $price = 0;
+
+        /**
+         * @var RuleInterface[]
+         */
+        $rules = $this->validRulesFetcher->getValidRules($subject, $context);
+
+        if (is_array($rules)) {
+            foreach ($rules as $rule) {
+                /**
+                 * @var ActionInterface
+                 */
+                foreach ($rule->getActions() as $action) {
+                    $processor = $this->actionServiceRegistry->get($action->getType());
+
+                    if (!$processor instanceof ProductDiscountPriceActionProcessorInterface) {
+                        continue;
+                    }
+
+                    $actionPrice = $processor->getDiscountPrice($subject, $context, $action->getConfiguration());
+
+                    if (false !== $actionPrice && null !== $actionPrice) {
+                        $price = $actionPrice;
+                    }
+                }
+            }
+        }
+
+        return $price === 0 ? false : $price;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDiscount(ProductInterface $subject, array $context, $price)
     {
         $discount = 0;
 
         /**
          * @var RuleInterface[]
          */
-        $rules = $this->validRulesFetcher->getValidRules($subject);
+        $rules = $this->validRulesFetcher->getValidRules($subject, $context);
 
         if (!is_array($rules)) {
             return $discount;
@@ -147,7 +146,7 @@ final class ProductPriceRuleCalculator implements ProductDiscountCalculatorInter
                     continue;
                 }
 
-                $discount += $processor->getDiscount($subject, $price, $action->getConfiguration());
+                $discount += $processor->getDiscount($subject, $price, $context, $action->getConfiguration());
             }
         }
 

--- a/src/CoreShop/Component/Product/Rule/Fetcher/CompositeValidRuleFetcher.php
+++ b/src/CoreShop/Component/Product/Rule/Fetcher/CompositeValidRuleFetcher.php
@@ -33,7 +33,7 @@ final class CompositeValidRuleFetcher implements ValidRulesFetcherInterface
     /**
      * {@inheritdoc}
      */
-    public function getValidRules(ProductInterface $product)
+    public function getValidRules(ProductInterface $product, array $context)
     {
         $rules = [];
 
@@ -41,7 +41,7 @@ final class CompositeValidRuleFetcher implements ValidRulesFetcherInterface
          * @var $validRuleFetcher ValidRulesFetcherInterface
          */
         foreach ($this->validRuleFetchers->all() as $validRuleFetcher) {
-            $rules = array_merge($rules, $validRuleFetcher->getValidRules($product));
+            $rules = array_merge($rules, $validRuleFetcher->getValidRules($product, $context));
         }
 
         return $rules;

--- a/src/CoreShop/Component/Product/Rule/Fetcher/MemoryCachedValidRuleFetcher.php
+++ b/src/CoreShop/Component/Product/Rule/Fetcher/MemoryCachedValidRuleFetcher.php
@@ -47,7 +47,7 @@ final class MemoryCachedValidRuleFetcher implements ValidRulesFetcherInterface
     /**
      * {@inheritdoc}
      */
-    public function getValidRules(ProductInterface $product)
+    public function getValidRules(ProductInterface $product, array $context)
     {
         if ($this->requestStack->getMasterRequest() instanceof Request) {
             if (isset($this->checkedProducts[$product->getId()])) {
@@ -55,7 +55,7 @@ final class MemoryCachedValidRuleFetcher implements ValidRulesFetcherInterface
             }
         }
 
-        $rules = $this->validRuleFetcher->getValidRules($product);
+        $rules = $this->validRuleFetcher->getValidRules($product, $context);
 
         $this->checkedProducts[$product->getId()] = $rules;
 

--- a/src/CoreShop/Component/Product/Rule/Fetcher/ValidProductPriceRuleFetcher.php
+++ b/src/CoreShop/Component/Product/Rule/Fetcher/ValidProductPriceRuleFetcher.php
@@ -41,13 +41,13 @@ final class ValidProductPriceRuleFetcher implements ValidRulesFetcherInterface
     /**
      * {@inheritdoc}
      */
-    public function getValidRules(ProductInterface $product)
+    public function getValidRules(ProductInterface $product, array $context)
     {
         $validRules = [];
         $rules = $this->productPriceRuleRepository->findActive();
 
         foreach ($rules as $rule) {
-            if (!$this->ruleValidationProcessor->isValid($product, $rule)) {
+            if (!$this->ruleValidationProcessor->isValid($product, $rule, $context)) {
                 continue;
             }
 

--- a/src/CoreShop/Component/Product/Rule/Fetcher/ValidProductSpecificPriceRuleFetcher.php
+++ b/src/CoreShop/Component/Product/Rule/Fetcher/ValidProductSpecificPriceRuleFetcher.php
@@ -33,7 +33,7 @@ final class ValidProductSpecificPriceRuleFetcher implements ValidRulesFetcherInt
     /**
      * {@inheritdoc}
      */
-    public function getValidRules(ProductInterface $product)
+    public function getValidRules(ProductInterface $product, array $context)
     {
         $validRules = [];
         $rules = $product->getSpecificPriceRules();
@@ -43,7 +43,7 @@ final class ValidProductSpecificPriceRuleFetcher implements ValidRulesFetcherInt
         }
 
         foreach ($rules as $rule) {
-            if (!$this->ruleValidationProcessor->isValid($product, $rule)) {
+            if (!$this->ruleValidationProcessor->isValid($product, $rule, $context)) {
                 continue;
             }
 

--- a/src/CoreShop/Component/Product/Rule/Fetcher/ValidRulesFetcherInterface.php
+++ b/src/CoreShop/Component/Product/Rule/Fetcher/ValidRulesFetcherInterface.php
@@ -19,7 +19,8 @@ interface ValidRulesFetcherInterface
 {
     /**
      * @param ProductInterface $product
+     * @param array $context
      * @return RuleInterface[]
      */
-    public function getValidRules(ProductInterface $product);
+    public function getValidRules(ProductInterface $product, array $context);
 }

--- a/src/CoreShop/Component/Product/composer.json
+++ b/src/CoreShop/Component/Product/composer.json
@@ -19,6 +19,7 @@
   ],
   "require": {
     "coreshop/resource": "^2.0",
+    "coreshop/currency": "^2.0",
     "coreshop/rule": "^2.0",
     "coreshop/address": "^2.0"
   },

--- a/tests/lib/CoreShop/Test/PHPUnit/Suites/Product.php
+++ b/tests/lib/CoreShop/Test/PHPUnit/Suites/Product.php
@@ -35,8 +35,8 @@ class Product extends Base
     {
         $this->printTestName();
 
-        $this->assertEquals(1800, $this->getPriceCalculator()->getPrice(Data::$product1));
-        $this->assertEquals(1500, $this->getPriceCalculator()->getPrice(Data::$product1, false));
+        $this->assertEquals(1800, $this->getPriceCalculator()->getPrice(Data::$product1, $this->getContext()));
+        $this->assertEquals(1500, $this->getPriceCalculator()->getPrice(Data::$product1, $this->getContext(), false));
     }
 
     public function testProductPriceGross()
@@ -45,8 +45,8 @@ class Product extends Base
 
         self::get('coreshop.context.store.fixed')->setStore(Data::$storeGrossPrices);
 
-        $this->assertEquals(1800, $this->getPriceCalculator()->getPrice(Data::$product1));
-        $this->assertEquals(1500, $this->getPriceCalculator()->getPrice(Data::$product1, false));
+        $this->assertEquals(1800, $this->getPriceCalculator()->getPrice(Data::$product1, $this->getContext()));
+        $this->assertEquals(1500, $this->getPriceCalculator()->getPrice(Data::$product1, $this->getContext(), false));
 
         self::get('coreshop.context.store.fixed')->setStore(Data::$store);
     }
@@ -57,5 +57,19 @@ class Product extends Base
     private function getPriceCalculator()
     {
         return $this->get('coreshop.product.taxed_price_calculator');
+    }
+
+    /**
+     * @return array
+     */
+    protected function getContext()
+    {
+        return [
+            'store' => $this->get('coreshop.context.shopper')->getStore(),
+            'customer' => $this->get('coreshop.context.shopper')->hasCustomer() ? $this->get('coreshop.context.shopper')->getCustomer() : null,
+            'currency' => $this->get('coreshop.context.shopper')->getCurrency(),
+            'country' => $this->get('coreshop.context.shopper')->getCountry(),
+            'cart' => $this->get('coreshop.context.shopper')->getCart()
+        ];
     }
 }

--- a/tests/lib/CoreShop/Test/PHPUnit/Suites/Product/PriceRule.php
+++ b/tests/lib/CoreShop/Test/PHPUnit/Suites/Product/PriceRule.php
@@ -343,11 +343,11 @@ class PriceRule extends RuleTest
         $this->getEntityManager()->persist($rule);
         $this->getEntityManager()->flush();
 
-        $discount = $this->getPriceCalculator()->getDiscount($this->product, $this->product->getStorePrice(Data::$store));
+        $discount = $this->getPriceCalculator()->getDiscount($this->product, $this->getContext(), $this->product->getStorePrice(Data::$store));
 
         $this->assertEquals(500, $discount);
-        $this->assertEquals(1000, $this->getTaxedPriceCalculator()->getPrice($this->product, false));
-        $this->assertEquals(1200, $this->getTaxedPriceCalculator()->getPrice($this->product));
+        $this->assertEquals(1000, $this->getTaxedPriceCalculator()->getPrice($this->product, $this->getContext(), false));
+        $this->assertEquals(1200, $this->getTaxedPriceCalculator()->getPrice($this->product, $this->getContext()));
 
         $this->getEntityManager()->remove($rule);
         $this->getEntityManager()->flush();
@@ -372,11 +372,11 @@ class PriceRule extends RuleTest
         $this->getEntityManager()->persist($rule);
         $this->getEntityManager()->flush();
 
-        $discount = $this->getPriceCalculator()->getDiscount($this->product, $this->product->getStorePrice(Data::$store));
+        $discount = $this->getPriceCalculator()->getDiscount($this->product, $this->getContext(), $this->product->getStorePrice(Data::$store));
 
         $this->assertEquals(512, $discount);
-        $this->assertEquals(988, $this->getTaxedPriceCalculator()->getPrice($this->product, false));
-        $this->assertEquals(1186, $this->getTaxedPriceCalculator()->getPrice($this->product));
+        $this->assertEquals(988, $this->getTaxedPriceCalculator()->getPrice($this->product, $this->getContext(), false));
+        $this->assertEquals(1186, $this->getTaxedPriceCalculator()->getPrice($this->product, $this->getContext()));
 
         $this->getEntityManager()->remove($rule);
         $this->getEntityManager()->flush();
@@ -400,11 +400,11 @@ class PriceRule extends RuleTest
         $this->getEntityManager()->persist($rule);
         $this->getEntityManager()->flush();
 
-        $discount = $this->getPriceCalculator()->getDiscount($this->product, $this->product->getStorePrice(Data::$store));
+        $discount = $this->getPriceCalculator()->getDiscount($this->product, $this->getContext(), $this->product->getStorePrice(Data::$store));
 
         $this->assertEquals(150, $discount);
-        $this->assertEquals(1350, $this->getTaxedPriceCalculator()->getPrice($this->product, false));
-        $this->assertEquals(1620, $this->getTaxedPriceCalculator()->getPrice($this->product));
+        $this->assertEquals(1350, $this->getTaxedPriceCalculator()->getPrice($this->product, $this->getContext(), false));
+        $this->assertEquals(1620, $this->getTaxedPriceCalculator()->getPrice($this->product, $this->getContext()));
 
         $this->getEntityManager()->remove($rule);
         $this->getEntityManager()->flush();
@@ -429,13 +429,13 @@ class PriceRule extends RuleTest
         $this->getEntityManager()->persist($rule);
         $this->getEntityManager()->flush();
 
-        $discount = $this->getPriceCalculator()->getDiscount($this->product, $this->product->getStorePrice(Data::$store));
+        $discount = $this->getPriceCalculator()->getDiscount($this->product, $this->getContext(), $this->product->getStorePrice(Data::$store));
 
         $this->assertEquals(0, $discount);
-        $this->assertEquals(100, $this->getTaxedPriceCalculator()->getPrice($this->product, false));
-        $this->assertEquals(120, $this->getTaxedPriceCalculator()->getPrice($this->product));
-        $this->assertEquals(100, $this->getTaxedPriceCalculator()->getRetailPrice($this->product, false));
-        $this->assertEquals(120, $this->getTaxedPriceCalculator()->getRetailPrice($this->product));
+        $this->assertEquals(100, $this->getTaxedPriceCalculator()->getPrice($this->product, $this->getContext(), false));
+        $this->assertEquals(120, $this->getTaxedPriceCalculator()->getPrice($this->product, $this->getContext()));
+        $this->assertEquals(100, $this->getTaxedPriceCalculator()->getRetailPrice($this->product, $this->getContext(), false));
+        $this->assertEquals(120, $this->getTaxedPriceCalculator()->getRetailPrice($this->product, $this->getContext()));
 
         $this->getEntityManager()->remove($rule);
         $this->getEntityManager()->flush();
@@ -460,15 +460,15 @@ class PriceRule extends RuleTest
         $this->getEntityManager()->persist($rule);
         $this->getEntityManager()->flush();
 
-        $discount = $this->getPriceCalculator()->getDiscount($this->product, $this->product->getStorePrice(Data::$store));
+        $discount = $this->getPriceCalculator()->getDiscount($this->product, $this->getContext(), $this->product->getStorePrice(Data::$store));
 
         $this->assertEquals(0, $discount);
-        $this->assertEquals(1500, $this->getTaxedPriceCalculator()->getRetailPrice($this->product, false));
-        $this->assertEquals(1800, $this->getTaxedPriceCalculator()->getRetailPrice($this->product));
-        $this->assertEquals(100, $this->getTaxedPriceCalculator()->getDiscountPrice($this->product, false));
-        $this->assertEquals(120, $this->getTaxedPriceCalculator()->getDiscountPrice($this->product));
-        $this->assertEquals(100, $this->getTaxedPriceCalculator()->getPrice($this->product, false));
-        $this->assertEquals(120, $this->getTaxedPriceCalculator()->getPrice($this->product));
+        $this->assertEquals(1500, $this->getTaxedPriceCalculator()->getRetailPrice($this->product, $this->getContext(), false));
+        $this->assertEquals(1800, $this->getTaxedPriceCalculator()->getRetailPrice($this->product, $this->getContext()));
+        $this->assertEquals(100, $this->getTaxedPriceCalculator()->getDiscountPrice($this->product, $this->getContext(), false));
+        $this->assertEquals(120, $this->getTaxedPriceCalculator()->getDiscountPrice($this->product, $this->getContext()));
+        $this->assertEquals(100, $this->getTaxedPriceCalculator()->getPrice($this->product, $this->getContext(), false));
+        $this->assertEquals(120, $this->getTaxedPriceCalculator()->getPrice($this->product, $this->getContext()));
 
         $this->getEntityManager()->remove($rule);
         $this->getEntityManager()->flush();

--- a/tests/lib/CoreShop/Test/PHPUnit/Suites/Product/SpecificPrice.php
+++ b/tests/lib/CoreShop/Test/PHPUnit/Suites/Product/SpecificPrice.php
@@ -301,11 +301,11 @@ class SpecificPrice extends RuleTest
         $this->getEntityManager()->persist($rule);
         $this->getEntityManager()->flush();
 
-        $discount = $this->getPriceCalculator()->getDiscount($this->product, $this->product->getStorePrice(Data::$store));
+        $discount = $this->getPriceCalculator()->getDiscount($this->product, $this->getContext(), $this->product->getStorePrice(Data::$store));
 
         $this->assertEquals(500, $discount);
-        $this->assertEquals(1000, $this->getTaxedPriceCalculator()->getPrice($this->product,false));
-        $this->assertEquals(1200, $this->getTaxedPriceCalculator()->getPrice($this->product));
+        $this->assertEquals(1000, $this->getTaxedPriceCalculator()->getPrice($this->product, $this->getContext(),false));
+        $this->assertEquals(1200, $this->getTaxedPriceCalculator()->getPrice($this->product, $this->getContext()));
 
         $this->getEntityManager()->remove($rule);
         $this->getEntityManager()->flush();
@@ -331,11 +331,11 @@ class SpecificPrice extends RuleTest
         $this->getEntityManager()->persist($rule);
         $this->getEntityManager()->flush();
 
-        $discount = $this->getPriceCalculator()->getDiscount($this->product, $this->product->getStorePrice(Data::$store));
+        $discount = $this->getPriceCalculator()->getDiscount($this->product, $this->getContext(), $this->product->getStorePrice(Data::$store));
 
         $this->assertEquals(150, $discount);
-        $this->assertEquals(1350, $this->getTaxedPriceCalculator()->getPrice($this->product,false));
-        $this->assertEquals(1620, $this->getTaxedPriceCalculator()->getPrice($this->product));
+        $this->assertEquals(1350, $this->getTaxedPriceCalculator()->getPrice($this->product, $this->getContext(),false));
+        $this->assertEquals(1620, $this->getTaxedPriceCalculator()->getPrice($this->product, $this->getContext()));
 
         $this->getEntityManager()->remove($rule);
         $this->getEntityManager()->flush();
@@ -362,11 +362,11 @@ class SpecificPrice extends RuleTest
         $this->getEntityManager()->persist($rule);
         $this->getEntityManager()->flush();
 
-        $discount = $this->getPriceCalculator()->getDiscount($this->product, $this->product->getStorePrice(Data::$store));
+        $discount = $this->getPriceCalculator()->getDiscount($this->product, $this->getContext(), $this->product->getStorePrice(Data::$store));
 
         $this->assertEquals(0, $discount);
-        $this->assertEquals(10000, $this->getTaxedPriceCalculator()->getPrice($this->product,false));
-        $this->assertEquals(12000, $this->getTaxedPriceCalculator()->getPrice($this->product));
+        $this->assertEquals(10000, $this->getTaxedPriceCalculator()->getPrice($this->product, $this->getContext(),false));
+        $this->assertEquals(12000, $this->getTaxedPriceCalculator()->getPrice($this->product, $this->getContext()));
 
         $this->getEntityManager()->remove($rule);
         $this->getEntityManager()->flush();
@@ -393,13 +393,13 @@ class SpecificPrice extends RuleTest
         $this->getEntityManager()->persist($rule);
         $this->getEntityManager()->flush();
 
-        $discount = $this->getPriceCalculator()->getDiscount($this->product, $this->product->getStorePrice(Data::$store));
+        $discount = $this->getPriceCalculator()->getDiscount($this->product, $this->getContext(), $this->product->getStorePrice(Data::$store));
 
         $this->assertEquals(0, $discount);
-        $this->assertEquals(100, $this->getTaxedPriceCalculator()->getDiscountPrice($this->product,false));
-        $this->assertEquals(120, $this->getTaxedPriceCalculator()->getDiscountPrice($this->product));
-        $this->assertEquals(100, $this->getTaxedPriceCalculator()->getPrice($this->product,false));
-        $this->assertEquals(120, $this->getTaxedPriceCalculator()->getPrice($this->product));
+        $this->assertEquals(100, $this->getTaxedPriceCalculator()->getDiscountPrice($this->product, $this->getContext(),false));
+        $this->assertEquals(120, $this->getTaxedPriceCalculator()->getDiscountPrice($this->product, $this->getContext()));
+        $this->assertEquals(100, $this->getTaxedPriceCalculator()->getPrice($this->product, $this->getContext(),false));
+        $this->assertEquals(120, $this->getTaxedPriceCalculator()->getPrice($this->product, $this->getContext()));
 
         $this->getEntityManager()->remove($rule);
         $this->getEntityManager()->flush();

--- a/tests/lib/CoreShop/Test/RuleTest.php
+++ b/tests/lib/CoreShop/Test/RuleTest.php
@@ -157,6 +157,8 @@ abstract class RuleTest extends Base
      */
     protected function assertPriceRuleCondition($subject, RuleInterface $rule, $params = [], $trueOrFalse = true)
     {
+        $params = array_merge($params, $this->getContext());
+
         $result = $this->getConditionValidator()->isValid($subject, $rule, $params);
         if ($trueOrFalse) {
             $this->assertTrue($result);
@@ -214,5 +216,19 @@ abstract class RuleTest extends Base
         $this->assertInstanceOf(ActionInterface::class, $action);
 
         return $action;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getContext()
+    {
+        return [
+            'store' => $this->get('coreshop.context.shopper')->getStore(),
+            'customer' => $this->get('coreshop.context.shopper')->hasCustomer() ? $this->get('coreshop.context.shopper')->getCustomer() : null,
+            'currency' => $this->get('coreshop.context.shopper')->getCurrency(),
+            'country' => $this->get('coreshop.context.shopper')->getCountry(),
+            'cart' => $this->get('coreshop.context.shopper')->getCart()
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no

Before they where context-active, now they are context passive. The context is now passed as a parameter and makes it easier and comprehensible what context is used to calculate price-rules.

This PR makes it easier on CLI level to get product prices, before you had to manually use the fixed context and set a store, currency, or whatever there to calculate right prices, just like

```php
$customer = $this->getContainer()->get('coreshop.repository.customer')->find(52);
$store = $this->getContainer()->get('coreshop.repository.store')->find(1);

$this->getContainer()->get('coreshop.context.store.fixed')->setStore($store);
$this->getContainer()->get('coreshop.context.customer.fixed')->setCustomer($customer);
$this->getContainer()->get('coreshop.context.country.fixed')->setCountry($store->getBaseCountry());
$this->getContainer()->get('coreshop.context.locale.fixed')->setLocale('en');

echo $this->getContainer()->get('coreshop.product.taxed_price_calculator')->getPrice($product, true)
```

Which in my opinion is quite hideous.

With this PR, it looks like this:

```php
echo $this->getContainer()->get('coreshop.product.taxed_price_calculator')->getPrice($product, [
    'store' => $store,
    'customer' => $customer,
    'currency' => $currency,
    'country' => $country
],  true);

//OR for non taxed prices
echo $this->getContainer()->get('coreshop.product.price_calculator')->getPrice($product, [
    'store' => $store,
    'customer' => $customer,
    'currency' => $currency,
    'country' => $country
]);
``` 

Which is way more comprehensible and easier to understand why and how CoreShop calculates the price. And you can decide on what base you wanna calculate prices without using a shared service and changing something in there. This PR actually could also deprecate the fixed context services.

**BUT:** This is a huge BC if you either use the Calculation Service, or have Product Price Rule Conditions or Actions.


