### PR TITLE
[NotificationBundle] Fix coreshop_path and inherited product getters …

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Pimcore/LinkGenerator/DataObjectLinkGenerator.php
+++ b/src/CoreShop/Bundle/CoreBundle/Pimcore/LinkGenerator/DataObjectLinkGenerator.php
@@ -12,6 +12,7 @@
 
 namespace CoreShop\Bundle\CoreBundle\Pimcore\LinkGenerator;
 
+use CoreShop\Component\Pimcore\DataObject\InheritanceHelper;
 use CoreShop\Component\Pimcore\DataObject\AbstractSluggableLinkGenerator;
 use Pimcore\Model\DataObject\Concrete;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -55,8 +56,12 @@ class DataObjectLinkGenerator extends AbstractSluggableLinkGenerator
 
         $locale = isset($params['_locale']) ? $params['_locale'] : null;
 
+        $name = InheritanceHelper::useInheritedValues(function () use ($object, $locale) {
+            return $object->getName($locale);
+        });
+
         $routeParams = [
-            'name' => $this->slugify($object->getName($locale)),
+            'name' => $this->slugify($name),
             $this->type => $object->getId()
         ];
 

--- a/src/CoreShop/Component/Notification/Rule/Action/MailActionProcessor.php
+++ b/src/CoreShop/Component/Notification/Rule/Action/MailActionProcessor.php
@@ -12,6 +12,7 @@
 
 namespace CoreShop\Component\Notification\Rule\Action;
 
+use CoreShop\Component\Pimcore\DataObject\InheritanceHelper;
 use CoreShop\Bundle\PimcoreBundle\Mail\MailProcessorInterface;
 use CoreShop\Component\Notification\Model\NotificationRuleInterface;
 use Pimcore\Model\Document;
@@ -69,7 +70,9 @@ class MailActionProcessor implements NotificationRuleProcessorInterface
             if ($mailDocument instanceof Document\Email) {
                 $params['object'] = $subject;
 
-                $this->mailProcessor->sendMail($mailDocument, $subject, $recipient, [], $params);
+                InheritanceHelper::useInheritedValues(function () use ($mailDocument, $subject, $recipient, $params) {
+                    $this->mailProcessor->sendMail($mailDocument, $subject, $recipient, [], $params);
+                });
             }
         }
     }


### PR DESCRIPTION
…not working in backend context/notification mails (AbstractObject::getGetInheritedValues() is false in backend)


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

When using coreshop_path/coreshop_url or any product getter in a notification mail template it does not work, if your product is a **variant** and the respective properties get inherited from the paren, because inheritance is disabled in backend context.
