### PR TITLE
[fix] StorePrice CSV import: check for JSON decode errors

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/CoreExtension/StorePrice.php
+++ b/src/CoreShop/Bundle/CoreBundle/CoreExtension/StorePrice.php
@@ -468,6 +468,11 @@ class StorePrice extends Model\DataObject\ClassDefinition\Data
         $storeRepo = $this->getStoreRepository();
 
         $data = $importValue == "" ? [] : json_decode($importValue, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \RuntimeException('Error decoding Store Price JSON `' . $importValue . '`: ' . json_last_error_msg());
+        }
+
         $this->checkValidity($data, true);
 
         if (is_array($data) && !empty($data)) {

--- a/src/CoreShop/Bundle/CoreBundle/CoreExtension/StorePrice.php
+++ b/src/CoreShop/Bundle/CoreBundle/CoreExtension/StorePrice.php
@@ -470,7 +470,7 @@ class StorePrice extends Model\DataObject\ClassDefinition\Data
         $data = $importValue == "" ? [] : json_decode($importValue, true);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new \RuntimeException('Error decoding Store Price JSON `' . $importValue . '`: ' . json_last_error_msg());
+            throw new \InvalidArgumentException(sprintf('Error decoding Store Price JSON `%s`: %s', $importValue, json_last_error_msg()));
         }
 
         $this->checkValidity($data, true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #643 

screenshot of the import screen after the fix is applied:

![spectacle sl2724](https://user-images.githubusercontent.com/4286829/45960306-7bdc2b80-c00b-11e8-9fa3-88759a1e6cd3.png)

The storePrice value was `{"1":0196}`