### PR TITLE
[Rule] fix active check for rules in production mode

### DIFF
--- a/src/CoreShop/Component/Rule/Condition/RuleConditionsValidationProcessor.php
+++ b/src/CoreShop/Component/Rule/Condition/RuleConditionsValidationProcessor.php
@@ -55,6 +55,10 @@ class RuleConditionsValidationProcessor implements RuleConditionsValidationProce
             return true;
         }
 
+        if (!$rule->getActive()) {
+            return false;
+        }
+
         foreach ($conditions as $condition) {
             if (!$this->isConditionValid($subject, $rule, $condition, $params)) {
                 return false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

The active flag for rules was never validated when in Production mode. For DEV mode, the `TraceableRuleConditionsValidationProcessor` checked for that, but not the `RuleConditionsValidationProcessor`
