### PR TITLE
[ResourceBundle] remove fos-rest bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Within V2
 
+## 2.0.0-beta.4
+ - Completely remove FOSRestBundle, you still can use it, but you need to install it yourself. CoreShop only used the BodyListener to decode POST/PUT Requests, this Listener is now added by CoreShop if FOSRestBundle is not installed.
+
 ## 2.0.0-beta.3 to 2.0.0-beta.4
  - **BC break**: All occurrences of parameters `coreshop.all.stack.pimcore_class_ids`, `"application".model."class".pimcore_class_id`, `coreshop.all.pimcore_classes.ids` have been removed. Inject the corresponding Repository and use `classId` function instead
  - **Pimcore**: CoreShop now requires at least Pimcore 5.4.0. You need to update Pimcore to the at least 5.4.0 in order to use/update CoreShop.

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,6 @@
   "require": {
     "doctrine/orm": "~2.5",
     "jms/serializer-bundle": "^1.3",
-    "friendsofsymfony/rest-bundle": "^2.1",
     "webmozart/assert": "^1.2",
     "doctrine/doctrine-cache-bundle": "^1.3",
     "payum/payum-bundle": "^2.2",

--- a/docs/02_Bundles/Resource_Bundle/README.md
+++ b/docs/02_Bundles/Resource_Bundle/README.md
@@ -26,7 +26,6 @@ public function registerBundlesToCollection(BundleCollection $collection)
     $collection->addBundles([
         new \JMS\SerializerBundle\JMSSerializerBundle(),
         new \CoreShop\Bundle\ResourceBundle\CoreShopResourceBundle(),
-        new \FOS\RestBundle\FOSRestBundle(),
         new \Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle(),
         new \Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle()
     ]);

--- a/src/CoreShop/Bundle/ResourceBundle/CoreShopResourceBundle.php
+++ b/src/CoreShop/Bundle/ResourceBundle/CoreShopResourceBundle.php
@@ -61,7 +61,6 @@ final class CoreShopResourceBundle extends AbstractPimcoreBundle implements Depe
     {
         $collection->addBundle(new JMSSerializerBundle(), 3900);
         $collection->addBundle(new \CoreShop\Bundle\PimcoreBundle\CoreShopPimcoreBundle(), 3850);
-        $collection->addBundle(new \FOS\RestBundle\FOSRestBundle(), 1500);
         $collection->addBundle(new \Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle(), 1400);
         $collection->addBundle(new \Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(), 1200);
     }

--- a/src/CoreShop/Bundle/ResourceBundle/DependencyInjection/CoreShopResourceExtension.php
+++ b/src/CoreShop/Bundle/ResourceBundle/DependencyInjection/CoreShopResourceExtension.php
@@ -13,15 +13,18 @@
 namespace CoreShop\Bundle\ResourceBundle\DependencyInjection;
 
 use CoreShop\Bundle\ResourceBundle\DependencyInjection\Extension\AbstractModelExtension;
+use CoreShop\Bundle\ResourceBundle\EventListener\BodyListener;
+use Pimcore\DependencyInjection\ConfigMerger;
+use ReflectionClass;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderInterface;
-use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
-final class CoreShopResourceExtension extends AbstractModelExtension implements PrependExtensionInterface
+final class CoreShopResourceExtension extends AbstractModelExtension
 {
     /**
      * {@inheritdoc}
@@ -36,10 +39,7 @@ final class CoreShopResourceExtension extends AbstractModelExtension implements 
         if ($config['translation']['enabled']) {
             $loader->load('services/integrations/translation.yml');
 
-            $alias = new Alias($config['translation']['locale_provider']);
-            $alias->setPublic(true);
-
-            $container->setAlias('coreshop.translation_locale_provider', $alias);
+            $container->setAlias('coreshop.translation_locale_provider', $config['translation']['locale_provider']);
         }
 
         if (array_key_exists('pimcore_admin', $config)) {
@@ -54,32 +54,20 @@ final class CoreShopResourceExtension extends AbstractModelExtension implements 
             $container->setParameter('coreshop.all.stack', []);
         }
 
+        $bundles = $container->getParameter('kernel.bundles');
+
+        if (!array_key_exists('FOSRestBundle', $bundles)) {
+            $bodyListener = new Definition(BodyListener::class);
+            $bodyListener->addTag('kernel.event_listener', [
+                'event' => 'kernel.request',
+                'method' => 'onKernelRequest',
+                'priority' => 10
+            ]);
+
+            $container->setDefinition('coreshop.body_listener', $bodyListener);
+        }
+
         $this->loadPersistence($config['drivers'], $config['resources'], $loader);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function prepend(ContainerBuilder $container)
-    {
-        $fosRestConfig = [
-            'format_listener' => [
-                'rules' => [
-                    [
-                        'path' => '^/admin/coreshop',
-                        'priorities' => ['json', 'xml'],
-                        'fallback_format' => 'json',
-                        'prefer_extension' => true
-                    ],
-                    [
-                        'path' => '^/',
-                        'stop' => true
-                    ]
-                ]
-            ]
-        ];
-
-        $container->prependExtensionConfig('fos_rest', $fosRestConfig);
     }
 
     private function loadPersistence(array $drivers, array $resources, LoaderInterface $loader)

--- a/src/CoreShop/Bundle/ResourceBundle/DependencyInjection/CoreShopResourceExtension.php
+++ b/src/CoreShop/Bundle/ResourceBundle/DependencyInjection/CoreShopResourceExtension.php
@@ -14,14 +14,11 @@ namespace CoreShop\Bundle\ResourceBundle\DependencyInjection;
 
 use CoreShop\Bundle\ResourceBundle\DependencyInjection\Extension\AbstractModelExtension;
 use CoreShop\Bundle\ResourceBundle\EventListener\BodyListener;
-use Pimcore\DependencyInjection\ConfigMerger;
-use ReflectionClass;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
-use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 final class CoreShopResourceExtension extends AbstractModelExtension

--- a/src/CoreShop/Bundle/ResourceBundle/EventListener/BodyListener.php
+++ b/src/CoreShop/Bundle/ResourceBundle/EventListener/BodyListener.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2017 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\ResourceBundle\EventListener;
+
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+class BodyListener
+{
+    /**
+     * Core request handler.
+     *
+     * @param GetResponseEvent $event
+     *
+     * @throws BadRequestHttpException
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $request = $event->getRequest();
+        $contentType = $request->headers->get('Content-Type');
+
+        $format = null === $contentType ? $request->getRequestFormat() : $request->getFormat($contentType);
+
+        $content = $request->getContent();
+
+        if ($this->isDecodeable($request)) {
+            if ($format === 'json') {
+                if (!empty($content)) {
+                    $data = @json_decode($content, true);
+
+                    if (is_array($data)) {
+                        $request->request = new ParameterBag($data);
+                    } else {
+                        throw new BadRequestHttpException('Invalid '.$format.' message received');
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Check if we should try to decode the body.
+     *
+     * @param Request $request
+     *
+     * @return bool
+     */
+    protected function isDecodeable(Request $request)
+    {
+        if (!in_array($request->getMethod(), ['POST', 'PUT', 'PATCH', 'DELETE'])) {
+            return false;
+        }
+
+        return !$this->isFormRequest($request);
+    }
+
+    /**
+     * Check if the content type indicates a form submission.
+     *
+     * @param Request $request
+     *
+     * @return bool
+     */
+    private function isFormRequest(Request $request)
+    {
+        $contentTypeParts = explode(';', $request->headers->get('Content-Type'));
+
+        if (isset($contentTypeParts[0])) {
+            return in_array($contentTypeParts[0], ['multipart/form-data', 'application/x-www-form-urlencoded']);
+        }
+
+        return false;
+    }
+}

--- a/src/CoreShop/Bundle/ResourceBundle/composer.json
+++ b/src/CoreShop/Bundle/ResourceBundle/composer.json
@@ -20,7 +20,6 @@
   "require": {
     "doctrine/orm": "^2.5",
     "doctrine/doctrine-bundle": "^1.6",
-    "friendsofsymfony/rest-bundle": "^2.1",
     "jms/serializer-bundle": "^1.1",
     "stof/doctrine-extensions-bundle": "^1.2",
     "coreshop/pimcore-bundle": "^2.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |  no
| New feature?  | no
| BC breaks?    | not really
| Deprecations? | no

Remove the dependency to FOSRestBundle, only thing that was actually used was the BodyListener, therefore it was a bit of a overhead to install a complete bundle just for that. The BodyListener is now provided by CoreShop and is only used if fos-rest is not installed.