### PR TITLE
[TrackingBundle] fix template notation for tracking

### DIFF
--- a/src/CoreShop/Bundle/TrackingBundle/Tracker/AbstractEcommerceTracker.php
+++ b/src/CoreShop/Bundle/TrackingBundle/Tracker/AbstractEcommerceTracker.php
@@ -105,7 +105,7 @@ abstract class AbstractEcommerceTracker implements TrackerInterface
     protected function getTemplatePath(string $name)
     {
         return sprintf(
-            '%s:%s.js.%s',
+            '%s/%s.js.%s',
             $this->templatePrefix,
             $name,
             $this->templateExtension

--- a/src/CoreShop/Bundle/TrackingBundle/Tracker/Google/AnalyticsEnhancedEcommerce.php
+++ b/src/CoreShop/Bundle/TrackingBundle/Tracker/Google/AnalyticsEnhancedEcommerce.php
@@ -66,7 +66,7 @@ class AnalyticsEnhancedEcommerce extends AbstractEcommerceTracker
         parent::configureOptions($resolver);
 
         $resolver->setDefaults([
-            'template_prefix' => 'CoreShopTrackingBundle:Tracking/analytics/enhanced'
+            'template_prefix' => '@CoreShopTracking/Tracking/analytics/enhanced'
         ]);
     }
 

--- a/src/CoreShop/Bundle/TrackingBundle/Tracker/Google/GlobalSiteTagEnhancedEcommerce.php
+++ b/src/CoreShop/Bundle/TrackingBundle/Tracker/Google/GlobalSiteTagEnhancedEcommerce.php
@@ -55,7 +55,7 @@ class GlobalSiteTagEnhancedEcommerce extends AbstractEcommerceTracker
         parent::configureOptions($resolver);
 
         $resolver->setDefaults([
-            'template_prefix' => 'CoreShopTrackingBundle:Tracking/gtag'
+            'template_prefix' => '@CoreShopTracking/Tracking/gtag'
         ]);
     }
 

--- a/src/CoreShop/Bundle/TrackingBundle/Tracker/Google/TagManager/TagManagerClassicEcommerce.php
+++ b/src/CoreShop/Bundle/TrackingBundle/Tracker/Google/TagManager/TagManagerClassicEcommerce.php
@@ -66,7 +66,7 @@ class TagManagerClassicEcommerce extends AbstractEcommerceTracker
         parent::configureOptions($resolver);
 
         $resolver->setDefaults([
-            'template_prefix' => 'CoreShopTrackingBundle:Tracking/gtm/classic'
+            'template_prefix' => '@CoreShopTracking/Tracking/gtm/classic'
         ]);
     }
 

--- a/src/CoreShop/Bundle/TrackingBundle/Tracker/Google/TagManager/TagManagerEnhancedEcommerce.php
+++ b/src/CoreShop/Bundle/TrackingBundle/Tracker/Google/TagManager/TagManagerEnhancedEcommerce.php
@@ -56,7 +56,7 @@ class TagManagerEnhancedEcommerce extends AbstractEcommerceTracker
         parent::configureOptions($resolver);
 
         $resolver->setDefaults([
-            'template_prefix' => 'CoreShopTrackingBundle:Tracking/gtm/enhanced'
+            'template_prefix' => '@CoreShopTracking/Tracking/gtm/enhanced'
         ]);
     }
 

--- a/src/CoreShop/Bundle/TrackingBundle/Tracker/Google/UniversalEcommerce.php
+++ b/src/CoreShop/Bundle/TrackingBundle/Tracker/Google/UniversalEcommerce.php
@@ -54,7 +54,7 @@ class UniversalEcommerce extends AbstractEcommerceTracker
         parent::configureOptions($resolver);
 
         $resolver->setDefaults([
-            'template_prefix' => 'CoreShopTrackingBundle:Tracking/analytics/universal'
+            'template_prefix' => '@CoreShopTracking/Tracking/analytics/universal'
         ]);
     }
 

--- a/src/CoreShop/Bundle/TrackingBundle/Tracker/Matomo/Matomo.php
+++ b/src/CoreShop/Bundle/TrackingBundle/Tracker/Matomo/Matomo.php
@@ -50,7 +50,7 @@ final class Matomo extends AbstractEcommerceTracker
         parent::configureOptions($resolver);
 
         $resolver->setDefaults([
-            'template_prefix'    => 'CoreShopTrackingBundle:Tracking/matomo',
+            'template_prefix'    => '@CoreShopTracking/Tracking/matomo',
 
             // by default, a cart add/remove delegates to cart update
             // if you manually trigger cart update on every change you can


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

LiipTheme introduced a Bug here, so we decided to change the notation, since the colon notation is not supported in Symfony 4 anymore as well.

https://github.com/liip/LiipThemeBundle/issues/194