### PR TITLE
[FixtureBundle] refactor fixture-bundle to be a resource-bundle

### DIFF
--- a/src/CoreShop/Bundle/FixtureBundle/CoreShopFixtureBundle.php
+++ b/src/CoreShop/Bundle/FixtureBundle/CoreShopFixtureBundle.php
@@ -2,16 +2,26 @@
 
 namespace CoreShop\Bundle\FixtureBundle;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
+use CoreShop\Bundle\ResourceBundle\AbstractResourceBundle;
+use CoreShop\Bundle\ResourceBundle\CoreShopResourceBundle;
 
-class CoreShopFixtureBundle extends Bundle
+class CoreShopFixtureBundle extends AbstractResourceBundle
 {
     /**
      * {@inheritdoc}
      */
-    public function build(ContainerBuilder $container)
+    public function getSupportedDrivers()
     {
-        parent::build($container);
+        return [
+            CoreShopResourceBundle::DRIVER_DOCTRINE_ORM,
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getModelNamespace()
+    {
+        return 'CoreShop\Bundle\FixtureBundle\Model';
     }
 }

--- a/src/CoreShop/Bundle/FixtureBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/FixtureBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2017 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+*/
+
+namespace CoreShop\Bundle\FixtureBundle\DependencyInjection;
+
+use CoreShop\Bundle\FixtureBundle\Model\DataFixture;
+use CoreShop\Bundle\FixtureBundle\Model\DataFixtureInterface;
+use CoreShop\Bundle\FixtureBundle\Repository\DataFixtureRepository;
+use CoreShop\Bundle\ResourceBundle\CoreShopResourceBundle;
+use CoreShop\Component\Resource\Factory\Factory;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+final class Configuration implements ConfigurationInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('coreshop_fixture');
+
+        $rootNode
+            ->children()
+                ->scalarNode('driver')->defaultValue(CoreShopResourceBundle::DRIVER_DOCTRINE_ORM)->end()
+            ->end()
+        ;
+        $this->addModelsSection($rootNode);
+
+        return $treeBuilder;
+    }
+
+    /**
+     * @param ArrayNodeDefinition $node
+     */
+    private function addModelsSection(ArrayNodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->arrayNode('resources')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->arrayNode('data_fixture')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->variableNode('options')->end()
+                                ->arrayNode('classes')
+                                    ->addDefaultsIfNotSet()
+                                    ->children()
+                                        ->scalarNode('model')->defaultValue(DataFixture::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('interface')->defaultValue(DataFixtureInterface::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('factory')->defaultValue(Factory::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('repository')->defaultValue(DataFixtureRepository::class)->cannotBeEmpty()->end()
+                                    ->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+}

--- a/src/CoreShop/Bundle/FixtureBundle/DependencyInjection/CoreShopFixtureExtension.php
+++ b/src/CoreShop/Bundle/FixtureBundle/DependencyInjection/CoreShopFixtureExtension.php
@@ -2,16 +2,19 @@
 
 namespace CoreShop\Bundle\FixtureBundle\DependencyInjection;
 
+use CoreShop\Bundle\ResourceBundle\DependencyInjection\Extension\AbstractModelExtension;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
-class CoreShopFixtureExtension extends Extension
+class CoreShopFixtureExtension extends AbstractModelExtension
 {
     public function load(array $config, ContainerBuilder $container)
     {
+        $config = $this->processConfiguration($this->getConfiguration([], $container), $config);
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+
+        $this->registerResources('coreshop', $config['driver'], $config['resources'], $container);
 
         $loader->load('services.yml');
     }

--- a/src/CoreShop/Bundle/FixtureBundle/Fixture/UpdateDataFixturesFixture.php
+++ b/src/CoreShop/Bundle/FixtureBundle/Fixture/UpdateDataFixturesFixture.php
@@ -2,18 +2,38 @@
 
 namespace CoreShop\Bundle\FixtureBundle\Fixture;
 
-use CoreShop\Bundle\FixtureBundle\Entity\DataFixture;
+use CoreShop\Bundle\FixtureBundle\Repository\DataFixtureRepositoryInterface;
+use CoreShop\Component\Resource\Factory\FactoryInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\Persistence\ObjectManager;
 
 class UpdateDataFixturesFixture extends AbstractFixture
 {
     /**
+     * @var FactoryInterface
+     */
+    protected $fixtureFactory;
+
+    /**
+     * @var DataFixtureRepositoryInterface
+     */
+    protected $fixtureRepository;
+
+    /**
      * @var array
      *  key - class name
      *  value - current loaded version
      */
     protected $dataFixturesClassNames;
+
+    /**
+     * @param FactoryInterface $fixtureFactory
+     */
+    public function __construct(FactoryInterface $fixtureFactory, DataFixtureRepositoryInterface $fixtureRepository)
+    {
+        $this->fixtureFactory = $fixtureFactory;
+        $this->fixtureRepository = $fixtureRepository;
+    }
 
     /**
      * Set a list of data fixtures to be updated
@@ -35,18 +55,16 @@ class UpdateDataFixturesFixture extends AbstractFixture
             foreach ($this->dataFixturesClassNames as $className => $version) {
                 $dataFixture = null;
                 if ($version !== null) {
-                    $dataFixture = $manager
-                        ->getRepository('CoreShopFixtureBundle:DataFixture')
-                        ->findOneBy(['className' => $className]);
+                    $dataFixture = $this->fixtureRepository->findOneBy(['className' => $className]);
                 }
                 if (!$dataFixture) {
-                    $dataFixture = new DataFixture();
+                    $dataFixture = $this->fixtureFactory->createNew();
                     $dataFixture->setClassName($className);
                 }
 
-                $dataFixture
-                    ->setVersion($version)
-                    ->setLoadedAt($loadedAt);
+                $dataFixture->setVersion($version);
+                $dataFixture->setLoadedAt($loadedAt);
+
                 $manager->persist($dataFixture);
             }
             $manager->flush();

--- a/src/CoreShop/Bundle/FixtureBundle/Model/DataFixture.php
+++ b/src/CoreShop/Bundle/FixtureBundle/Model/DataFixture.php
@@ -1,47 +1,36 @@
 <?php
 
-namespace CoreShop\Bundle\FixtureBundle\Entity;
+namespace CoreShop\Bundle\FixtureBundle\Model;
 
-use Doctrine\ORM\Mapping as ORM;
+use CoreShop\Component\Resource\Model\AbstractResource;
+use CoreShop\Component\Resource\Model\SetValuesTrait;
 
-/**
- * @ORM\Table("coreshop_fixtures_data")
- * @ORM\Entity(repositoryClass="CoreShop\Bundle\FixtureBundle\Entity\Repository\DataFixtureRepository")
- */
-class DataFixture
+class DataFixture extends AbstractResource implements DataFixtureInterface
 {
+    use SetValuesTrait;
+
     /**
      * @var integer
-     *
-     * @ORM\Column(name="id", type="integer")
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
      */
     protected $id;
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="class_name", type="string", length=255)
      */
     protected $className;
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="version", type="string", length=255, nullable=true)
      */
     protected $version;
 
     /**
      * @var \DateTime
-     *
-     * @ORM\Column(name="loaded_at", type="datetime")
      */
     protected $loadedAt;
 
     /**
-     * @return int
+     * {@inheritdoc}
      */
     public function getId()
     {
@@ -49,7 +38,7 @@ class DataFixture
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
      */
     public function getClassName()
     {
@@ -57,18 +46,15 @@ class DataFixture
     }
 
     /**
-     * @param string $className
-     * @return $this
+     * {@inheritdoc}
      */
     public function setClassName($className)
     {
         $this->className = $className;
-
-        return $this;
     }
 
     /**
-     * @return \DateTime
+     * {@inheritdoc}
      */
     public function getLoadedAt()
     {
@@ -76,29 +62,23 @@ class DataFixture
     }
 
     /**
-     * @param \DateTime $loadedAt
-     * @return $this
+     * {@inheritdoc}
      */
     public function setLoadedAt($loadedAt)
     {
         $this->loadedAt = $loadedAt;
-
-        return $this;
     }
 
     /**
-     * @param string $version
-     * @return $this
+     * {@inheritdoc}
      */
     public function setVersion($version)
     {
         $this->version = $version;
-
-        return $this;
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
      */
     public function getVersion()
     {

--- a/src/CoreShop/Bundle/FixtureBundle/Model/DataFixtureInterface.php
+++ b/src/CoreShop/Bundle/FixtureBundle/Model/DataFixtureInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace CoreShop\Bundle\FixtureBundle\Model;
+
+use CoreShop\Component\Resource\Model\ResourceInterface;
+
+interface DataFixtureInterface extends ResourceInterface
+{
+    /**
+     * @return string
+     */
+    public function getClassName();
+
+    /**
+     * @param string $className
+     */
+    public function setClassName($className);
+
+    /**
+     * @return \DateTime
+     */
+    public function getLoadedAt();
+
+    /**
+     * @param \DateTime $loadedAt
+     */
+    public function setLoadedAt($loadedAt);
+
+    /**
+     * @param string $version
+     * @return $this
+     */
+    public function setVersion($version);
+
+    /**
+     * @return string
+     */
+    public function getVersion();
+}

--- a/src/CoreShop/Bundle/FixtureBundle/Repository/DataFixtureRepository.php
+++ b/src/CoreShop/Bundle/FixtureBundle/Repository/DataFixtureRepository.php
@@ -1,16 +1,13 @@
 <?php
 
-namespace CoreShop\Bundle\FixtureBundle\Entity\Repository;
+namespace CoreShop\Bundle\FixtureBundle\Repository;
 
-use CoreShop\Bundle\FixtureBundle\Entity\DataFixture;
-use Doctrine\ORM\EntityRepository;
+use CoreShop\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
 
-class DataFixtureRepository extends EntityRepository
+class DataFixtureRepository extends EntityRepository implements DataFixtureRepositoryInterface
 {
     /**
-     * @param $className
-     *
-     * @return DataFixture[]
+     * {@inheritdoc}
      */
     public function findByClassName($className)
     {
@@ -18,10 +15,7 @@ class DataFixtureRepository extends EntityRepository
     }
 
     /**
-     * @param string $where
-     * @param array $parameters
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function isDataFixtureExists($where, array $parameters = [])
     {
@@ -36,17 +30,13 @@ class DataFixtureRepository extends EntityRepository
     }
 
     /**
-     * Update data fixture history
-     *
-     * @param array $updateFields assoc array with field names and values that should be updated
-     * @param string $where condition
-     * @param array $parameters optional parameters for where condition
+     * {@inheritdoc}
      */
     public function updateDataFixtureHistory(array $updateFields, $where, array $parameters = [])
     {
         $qb = $this->_em
             ->createQueryBuilder()
-            ->update('CoreShopFixtureBundle:DataFixture', 'm')
+            ->update($this->getEntityName(), 'm')
             ->where($where);
 
         foreach ($updateFields as $fieldName => $fieldValue) {

--- a/src/CoreShop/Bundle/FixtureBundle/Repository/DataFixtureRepositoryInterface.php
+++ b/src/CoreShop/Bundle/FixtureBundle/Repository/DataFixtureRepositoryInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace CoreShop\Bundle\FixtureBundle\Repository;
+
+use CoreShop\Bundle\FixtureBundle\Model\DataFixture;
+use CoreShop\Component\Resource\Repository\RepositoryInterface;
+use Doctrine\ORM\EntityRepository;
+
+interface DataFixtureRepositoryInterface extends RepositoryInterface
+{
+    /**
+     * @param $className
+     *
+     * @return DataFixture[]
+     */
+    public function findByClassName($className);
+    /**
+     * @param string $where
+     * @param array $parameters
+     *
+     * @return bool
+     */
+    public function isDataFixtureExists($where, array $parameters = []);
+
+    /**
+     * Update data fixture history
+     *
+     * @param array $updateFields assoc array with field names and values that should be updated
+     * @param string $where condition
+     * @param array $parameters optional parameters for where condition
+     */
+    public function updateDataFixtureHistory(array $updateFields, $where, array $parameters = []);
+}

--- a/src/CoreShop/Bundle/FixtureBundle/Resources/config/doctrine/model/DataFixture.orm.yml
+++ b/src/CoreShop/Bundle/FixtureBundle/Resources/config/doctrine/model/DataFixture.orm.yml
@@ -1,0 +1,20 @@
+CoreShop\Bundle\FixtureBundle\Model\DataFixture:
+    type: mappedSuperclass
+    table: coreshop_fixtures_data
+    fields:
+        id:
+            type: integer
+            column: id
+            id: true
+            generator:
+                strategy: AUTO
+        className:
+            type: string
+            column: class_name
+        version:
+            column: version
+            type: string
+            nullable: true
+        loadedAt:
+            column: loaded_at
+            type: datetime

--- a/src/CoreShop/Bundle/FixtureBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/FixtureBundle/Resources/config/services.yml
@@ -8,11 +8,19 @@ services:
             - '@doctrine.orm.entity_manager'
             - '@event_dispatcher'
 
+    coreshop.fixture.update_data_fixtures:
+        class: CoreShop\Bundle\FixtureBundle\Fixture\UpdateDataFixturesFixture
+        arguments:
+            - '@coreshop.factory.data_fixture'
+            - '@coreshop.repository.data_fixture'
+
     coreshop.fixture.data.loader:
         class: CoreShop\Bundle\FixtureBundle\Fixture\Loader\DataFixturesLoader
         arguments:
             - '@doctrine.orm.entity_manager'
             - '@service_container'
+            - '@coreshop.fixture.update_data_fixtures'
+            - '@coreshop.repository.data_fixture'
 
     coreshop.command.load_fixtures:
         class: CoreShop\Bundle\FixtureBundle\Command\LoadDataFixturesCommand

--- a/src/CoreShop/Bundle/FixtureBundle/composer.json
+++ b/src/CoreShop/Bundle/FixtureBundle/composer.json
@@ -19,6 +19,7 @@
   ],
   "require": {
     "php": "^7.0",
+    "coreshop/resource-bundle": "^2.0",
     "symfony/framework-bundle": "^3.3",
     "symfony/doctrine-bridge": "^3.3",
     "symfony/twig-bundle": "^3.3",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |  no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

The reason for this is to have all CoreShop entities registered as a coreshop resource to change the installer to only create coreshop tables instead of the whole doctrine managed entities.