### PR TITLE
[Setup] change setup command to only install CoreShop tables

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Installer/Provider/DatabaseSetupCommandsProvider.php
+++ b/src/CoreShop/Bundle/CoreBundle/Installer/Provider/DatabaseSetupCommandsProvider.php
@@ -55,7 +55,7 @@ final class DatabaseSetupCommandsProvider implements DatabaseSetupCommandsProvid
     private function getRequiredCommands(InputInterface $input, OutputInterface $output, QuestionHelper $questionHelper)
     {
         if ($input->getOption('no-interaction')) {
-            $commands['doctrine:schema:update'] = ['--force' => true];
+            $commands['coreshop:resources:drop-tables'] = ['application-name' => 'coreshop', '--force' => true];
         }
 
         return $this->setupDatabase($input, $output, $questionHelper);
@@ -73,16 +73,16 @@ final class DatabaseSetupCommandsProvider implements DatabaseSetupCommandsProvid
         $outputStyle = new SymfonyStyle($input, $output);
 
         if (!$this->isSchemaPresent()) {
-            return ['doctrine:schema:create'];
+            return ['coreshop:resources:create-tables' => ['application-name' => 'coreshop', '--force' => true]];
         }
 
         $outputStyle->writeln('Seems like your database contains schema.');
-        $outputStyle->writeln('<error>Warning! This action will erase your database.</error>');
+        $outputStyle->writeln('<error>Warning! This action will erase your CoreShop Tables.</error>');
         $question = new ConfirmationQuestion('Do you want to reset your CoreShop scheme it? (y/N) ', false);
         if ($questionHelper->ask($input, $output, $question)) {
             return [
-                'doctrine:schema:drop' => ['--force' => true],
-                'doctrine:schema:create',
+                'coreshop:resources:drop-tables' => ['application-name' => 'coreshop', '--force' => true],
+                'coreshop:resources:create-tables' => ['application-name' => 'coreshop', '--force' => true],
             ];
         }
 

--- a/src/CoreShop/Bundle/ResourceBundle/Command/CreateDatabaseTablesCommand.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Command/CreateDatabaseTablesCommand.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2017 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\ResourceBundle\Command;
+
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+final class CreateDatabaseTablesCommand extends ContainerAwareCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('coreshop:resources:create-tables')
+            ->setDescription('Create Tables.')
+            ->setHelp(
+                <<<EOT
+The <info>%command.name%</info> command creates Database Tables
+EOT
+            )
+            ->addArgument(
+                'application-name',
+                InputArgument::REQUIRED
+            )
+            ->addOption(
+                'dump-sql',
+                null,
+                InputOption::VALUE_NONE,
+                'Dumps the generated SQL statements to the screen (does not execute them).'
+            )
+            ->addOption(
+                'force',
+                'f',
+                InputOption::VALUE_NONE,
+                'Causes the generated SQL statements to be physically executed against your database.'
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $ui = new SymfonyStyle($input, $output);
+
+        $resources = $this->getContainer()->getParameter('coreshop.resources');
+        $em = $this->getContainer()->get('doctrine.orm.entity_manager');
+
+        $metadatas = [];
+
+        foreach ($resources as $alias => $resource) {
+            $applicationName = explode('.', $alias)[0];
+
+            if ($applicationName === $input->getArgument('application-name')) {
+                $metadatas[] = $em->getMetadataFactory()->getMetadataFor($resource['classes']['model']);
+            }
+        }
+
+        $schemaTool = new SchemaTool($em);
+        $sqls = $schemaTool->getUpdateSchemaSql($metadatas, true);
+
+        $dumpSql = true === $input->getOption('dump-sql');
+        $force = true === $input->getOption('force');
+
+        if ($dumpSql) {
+            $ui->text('The following SQL statements will be executed:');
+            $ui->newLine();
+
+            foreach ($sqls as $sql) {
+                $ui->text(sprintf('    %s;', $sql));
+            }
+        }
+
+        if ($force) {
+            if ($dumpSql) {
+                $ui->newLine();
+            }
+            $ui->text('Updating database schema...');
+            $ui->newLine();
+
+            $schemaTool->updateSchema($metadatas, true);
+
+            $pluralization = (1 === count($sqls)) ? 'query was' : 'queries were';
+
+            $ui->text(sprintf('    <info>%s</info> %s executed', count($sqls), $pluralization));
+            $ui->success('Database schema updated successfully!');
+        }
+
+        if ($dumpSql || $force) {
+            return 0;
+        }
+
+        return 0;
+    }
+}

--- a/src/CoreShop/Bundle/ResourceBundle/Command/DropDatabaseTablesCommand.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Command/DropDatabaseTablesCommand.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2017 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\ResourceBundle\Command;
+
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+final class DropDatabaseTablesCommand extends ContainerAwareCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('coreshop:resources:drop-tables')
+            ->setDescription('Drop Tables.')
+            ->setHelp(
+                <<<EOT
+The <info>%command.name%</info> command drops Database Tables
+EOT
+            )
+            ->addArgument(
+                'application-name',
+                InputArgument::REQUIRED
+            )
+            ->addOption(
+                'dump-sql',
+                null,
+                InputOption::VALUE_NONE,
+                'Dumps the generated SQL statements to the screen (does not execute them).'
+            )
+            ->addOption(
+                'force',
+                'f',
+                InputOption::VALUE_NONE,
+                'Causes the generated SQL statements to be physically executed against your database.'
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $ui = new SymfonyStyle($input, $output);
+
+        $resources = $this->getContainer()->getParameter('coreshop.resources');
+        $em = $this->getContainer()->get('doctrine.orm.entity_manager');
+
+        $metadatas = [];
+
+        foreach ($resources as $alias => $resource) {
+            $applicationName = explode('.', $alias)[0];
+
+            if ($applicationName === $input->getArgument('application-name')) {
+                $metadatas[] = $em->getMetadataFactory()->getMetadataFor($resource['classes']['model']);
+            }
+        }
+
+        $schemaTool = new SchemaTool($em);
+        $sqls = $schemaTool->getDropSchemaSQL($metadatas, true);
+
+        $dumpSql = true === $input->getOption('dump-sql');
+        $force = true === $input->getOption('force');
+
+        if ($dumpSql) {
+            $ui->text('The following SQL statements will be executed:');
+            $ui->newLine();
+
+            foreach ($sqls as $sql) {
+                $ui->text(sprintf('    %s;', $sql));
+            }
+        }
+
+        if ($force) {
+            if ($dumpSql) {
+                $ui->newLine();
+            }
+            $ui->text('Drop database schema...');
+            $ui->newLine();
+
+            $schemaTool->dropSchema($metadatas);
+
+            $pluralization = (1 === count($sqls)) ? 'query was' : 'queries were';
+
+            $ui->text(sprintf('    <info>%s</info> %s executed', count($sqls), $pluralization));
+            $ui->success('Database schema dropped successfully!');
+        }
+
+        if ($dumpSql || $force) {
+            return 0;
+        }
+
+        return 0;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

Only install CoreShop related tables on install. This affects installations where other bundles use ORM as well.