### PR TITLE
Quotes folder is created during installation and Quotes menu works wi…

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Installer/Executor/FolderInstallerProvider.php
+++ b/src/CoreShop/Bundle/CoreBundle/Installer/Executor/FolderInstallerProvider.php
@@ -17,44 +17,15 @@ use Pimcore\Model\DataObject;
 final class FolderInstallerProvider
 {
     /**
-     * @var string
+     * @var array
      */
-    private $cartFolder;
+    private $folders;
 
     /**
-     * @var string
+     * @param array $folders
      */
-    private $productFolder;
-
-    /**
-     * @var string
-     */
-    private $customerFolder;
-
-    /**
-     * @var string
-     */
-    private $customerGroupFolder;
-
-    /**
-     * @var string
-     */
-    private $orderFolder;
-
-    /**
-     * @param string $cartFolder
-     * @param string $productFolder
-     * @param string $customerFolder
-     * @param string $customerGroupFolder
-     * @param string $orderFolder
-     */
-    public function __construct($cartFolder, $productFolder, $customerFolder, $customerGroupFolder, $orderFolder)
-    {
-        $this->cartFolder = $cartFolder;
-        $this->productFolder = $productFolder;
-        $this->customerFolder = $customerFolder;
-        $this->customerGroupFolder = $customerGroupFolder;
-        $this->orderFolder = $orderFolder;
+    public function __construct(array $folders) {
+        $this->folders = $folders;
     }
 
     /**
@@ -62,15 +33,7 @@ final class FolderInstallerProvider
      */
     public function installFolders()
     {
-        $folders = [
-            $this->cartFolder,
-            $this->productFolder,
-            $this->customerFolder,
-            $this->customerGroupFolder,
-            $this->orderFolder,
-        ];
-
-        foreach ($folders as $folder) {
+        foreach ($this->folders as $folder) {
             DataObject\Service::createFolderByPath(sprintf('/%s', $folder));
         }
     }

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services/installer.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services/installer.yml
@@ -18,8 +18,11 @@ services:
     coreshop.installer.executor.folder_installer:
         class: CoreShop\Bundle\CoreBundle\Installer\Executor\FolderInstallerProvider
         arguments:
-            - '%coreshop.folder.cart%'
-            - '%coreshop.folder.product%'
-            - '%coreshop.folder.customer%'
-            - '%coreshop.folder.customer_group%'
-            - '%coreshop.folder.order%'
+            - [
+                '%coreshop.folder.cart%',
+                '%coreshop.folder.product%',
+                '%coreshop.folder.customer%',
+                '%coreshop.folder.customer_group%',
+                '%coreshop.folder.order%',
+                '%coreshop.folder.quote%'
+              ]


### PR DESCRIPTION
…thout need to manual addition

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -----

Right now quotes listing menu doesn't work after installation. The reason is that there is no coreshop/quotes folder. This PR fix the installation to add this folder and additionaly add some tiny code improvement so adding/removing folders should be one-line change next time.
