### PR TITLE
Use decimal as column type instead of double

### DIFF
--- a/src/CoreShop/Bundle/IndexBundle/Worker/MysqlWorker.php
+++ b/src/CoreShop/Bundle/IndexBundle/Worker/MysqlWorker.php
@@ -408,7 +408,7 @@ QUERY;
                 return 'datetime';
 
             case IndexColumnInterface::FIELD_TYPE_DOUBLE:
-                return 'double';
+                return 'decimal';
 
             case IndexColumnInterface::FIELD_TYPE_STRING:
                 return 'string';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Use `decimal` as column type, because `double` is not registered with `\Doctrine\DBAL\Types\Type::addType()`.
