### PR TITLE
Keep notification param in MailActionProcessor

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/EventListener/Order/OrderMailNoteEventListener.php
+++ b/src/CoreShop/Bundle/CoreBundle/EventListener/Order/OrderMailNoteEventListener.php
@@ -64,17 +64,23 @@ final class OrderMailNoteEventListener
         $noteInstance->addData('subject', 'text', $mail->getSubjectRendered());
 
         $mailTos = [];
+        $recipients = isset($params['recipient']) && !empty($params['recipient']) ? $params['recipient'] : $mail->getTo();
 
-        foreach ($mail->getTo() as $mail => $name) {
-            if ($name) {
-                $mailTos[] = sprintf('%s <%s>', $name, $mail);
+        if (is_array($recipients)) {
+            foreach ($recipients as $mail => $name) {
+                if ($name) {
+                    $mailTos[] = sprintf('%s <%s>', $name, $mail);
+                } else {
+                    $mailTos[] = $mail;
+                }
             }
-            else {
-                $mailTos[] = $mail;
-            }
+        } elseif (is_string($recipients)) {
+            $mailTos[] = $recipients;
         }
 
-        $noteInstance->addData('recipient', 'text', implode(', ', $mailTos));
+        $noteInstance->addData('recipient', 'text', (empty($mailTos) ? '--' : implode(', ', $mailTos)));
+
+        unset($params['recipient']);
 
         foreach ($params as $key => $value) {
             if (is_string($value)) {

--- a/src/CoreShop/Component/Notification/Rule/Action/MailActionProcessor.php
+++ b/src/CoreShop/Component/Notification/Rule/Action/MailActionProcessor.php
@@ -65,8 +65,6 @@ class MailActionProcessor implements NotificationRuleProcessorInterface
 
             $params['rule'] = $rule;
 
-            unset($params['recipient'], $params['_locale']);
-
             if ($mailDocument instanceof Document\Email) {
                 $params['object'] = $subject;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | --

Sending mails via default mail actions in notification rules will remove the recipient note. 
