### PR TITLE
[Index, IndeBundle] allow condition renderers to be registered dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Within V2
 
+## 2.0.0
+ - CoreShop\Component\Index\Condition\RendererInterface has been deprecated in favor of CoreShop\Component\Index\Condition\DynamicRendererInterface to allow dynamic registration of condition renderers
+
 ## 2.0.0-RC.1
  - Flash Messages are translated in the Controllers now, not in views anymore. If you have custom Flash Messages, translate them in your Controller instead of the view.
 

--- a/src/CoreShop/Behat/Resources/config/services/contexts/domain.yml
+++ b/src/CoreShop/Behat/Resources/config/services/contexts/domain.yml
@@ -204,6 +204,7 @@ services:
         class: CoreShop\Behat\Context\Domain\IndexConditionContext
         arguments:
             - '@coreshop.behat.shared_storage'
+            - '@__symfony__.coreshop.registry.index.worker'
         tags:
             - { name: fob.context_service }
 

--- a/src/CoreShop/Bundle/IndexBundle/Condition/Mysql/AbstractMysqlDynamicRenderer.php
+++ b/src/CoreShop/Bundle/IndexBundle/Condition/Mysql/AbstractMysqlDynamicRenderer.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2017 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\IndexBundle\Condition\Mysql;
+
+use CoreShop\Component\Index\Condition\DynamicRendererInterface;
+use Doctrine\DBAL\Connection;
+
+abstract class AbstractMysqlDynamicRenderer implements DynamicRendererInterface
+{
+    /**
+     * @var Connection
+     */
+    protected $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * @param $identifier
+     * @return string
+     */
+    protected function quoteIdentifier($identifier)
+    {
+        return $this->connection->quoteIdentifier($identifier);
+    }
+
+    /**
+     * @param $identifier
+     * @return string
+     */
+    protected function quote($identifier)
+    {
+        return $this->connection->quote($identifier);
+    }
+
+    /**
+     * @param null $prefix
+     * @return string
+     */
+    protected function renderPrefix($prefix = null)
+    {
+        if (null === $prefix) {
+            return '';
+        }
+
+        return $prefix.'.';
+    }
+
+    /**
+     * @param      $fieldName
+     * @param null $prefix
+     * @return string
+     */
+    protected function quoteFieldName($fieldName, $prefix = null)
+    {
+        return $this->renderPrefix($prefix).$this->quoteIdentifier($fieldName);
+    }
+}

--- a/src/CoreShop/Bundle/IndexBundle/Condition/Mysql/CompareRenderer.php
+++ b/src/CoreShop/Bundle/IndexBundle/Condition/Mysql/CompareRenderer.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2017 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\IndexBundle\Condition\Mysql;
+
+use CoreShop\Bundle\IndexBundle\Worker\MysqlWorker;
+use CoreShop\Component\Index\Condition\CompareCondition;
+use CoreShop\Component\Index\Condition\ConditionInterface;
+use CoreShop\Component\Index\Worker\WorkerInterface;
+use Webmozart\Assert\Assert;
+
+class CompareRenderer extends AbstractMysqlDynamicRenderer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function render(WorkerInterface $worker, ConditionInterface $condition, $prefix = null)
+    {
+        /**
+         * @var $condition CompareCondition
+         */
+        Assert::isInstanceOf($condition, CompareCondition::class);
+
+        $value = $condition->getValue();
+        $operator = $condition->getOperator();
+
+        return ''.$this->quoteFieldName($condition->getFieldName(), $prefix).' '.$operator.' '.$this->quote($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(WorkerInterface $worker, ConditionInterface $condition)
+    {
+        return $worker instanceof MysqlWorker && $condition instanceof CompareCondition;
+    }
+}

--- a/src/CoreShop/Bundle/IndexBundle/Condition/Mysql/ConcatRenderer.php
+++ b/src/CoreShop/Bundle/IndexBundle/Condition/Mysql/ConcatRenderer.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2017 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\IndexBundle\Condition\Mysql;
+
+use CoreShop\Bundle\IndexBundle\Worker\MysqlWorker;
+use CoreShop\Component\Index\Condition\ConcatCondition;
+use CoreShop\Component\Index\Condition\ConditionInterface;
+use CoreShop\Component\Index\Condition\ConditionRendererInterface;
+use CoreShop\Component\Index\Worker\WorkerInterface;
+use Doctrine\DBAL\Connection;
+use Webmozart\Assert\Assert;
+
+class ConcatRenderer extends AbstractMysqlDynamicRenderer
+{
+    /**
+     * @var ConditionRendererInterface
+     */
+    private $renderer;
+
+    /**
+     * @param Connection                 $connection
+     * @param ConditionRendererInterface $renderer
+     */
+    public function __construct(Connection $connection, ConditionRendererInterface $renderer)
+    {
+        parent::__construct($connection);
+
+        $this->renderer = $renderer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render(WorkerInterface $worker, ConditionInterface $condition, $prefix = null)
+    {
+        /**
+         * @var $condition ConcatCondition
+         */
+        Assert::isInstanceOf($condition, ConcatCondition::class);
+
+        $conditions = [];
+
+        foreach ($condition->getConditions() as $subCondition) {
+            /**
+             * @var $subCondition ConditionInterface
+             */
+            Assert::isInstanceOf($subCondition, ConditionInterface::class);
+
+            $conditions[] = $this->renderer->render($worker, $subCondition, $prefix);
+        }
+
+        if (count($conditions) > 0) {
+            return '('.implode(' '.trim($condition->getOperator()).' ', $conditions).')';
+        }
+
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(WorkerInterface $worker, ConditionInterface $condition)
+    {
+        return $worker instanceof MysqlWorker && $condition instanceof ConcatCondition;
+    }
+}

--- a/src/CoreShop/Bundle/IndexBundle/Condition/Mysql/InRenderer.php
+++ b/src/CoreShop/Bundle/IndexBundle/Condition/Mysql/InRenderer.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2017 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\IndexBundle\Condition\Mysql;
+
+use CoreShop\Bundle\IndexBundle\Worker\MysqlWorker;
+use CoreShop\Component\Index\Condition\ConditionInterface;
+use CoreShop\Component\Index\Condition\InCondition;
+use CoreShop\Component\Index\Condition\NotInCondition;
+use CoreShop\Component\Index\Worker\WorkerInterface;
+use Webmozart\Assert\Assert;
+
+class InRenderer extends AbstractMysqlDynamicRenderer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function render(WorkerInterface $worker, ConditionInterface $condition, $prefix = null)
+    {
+        /**
+         * @var $condition InCondition
+         */
+        Assert::isInstanceOf($condition, InCondition::class);
+
+        $inValues = [];
+
+        if (is_array($condition->getValues())) {
+            foreach ($condition->getValues() as $c => $value) {
+                $inValues[] = $this->quote($value);
+            }
+        }
+
+        if (count($inValues) > 0) {
+            $operator = 'IN';
+
+            if ($condition instanceof NotInCondition) {
+                $operator = 'NOT IN';
+            }
+
+            return sprintf(
+                '%s %s (%s)',
+                $this->quoteFieldName($condition->getFieldName(), $prefix),
+                $operator,
+                implode(',', $inValues)
+            );
+        }
+
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(WorkerInterface $worker, ConditionInterface $condition)
+    {
+        return $worker instanceof MysqlWorker && $condition instanceof InCondition;
+    }
+}

--- a/src/CoreShop/Bundle/IndexBundle/Condition/Mysql/IsNullRenderer.php
+++ b/src/CoreShop/Bundle/IndexBundle/Condition/Mysql/IsNullRenderer.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2017 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\IndexBundle\Condition\Mysql;
+
+use CoreShop\Bundle\IndexBundle\Worker\MysqlWorker;
+use CoreShop\Component\Index\Condition\ConditionInterface;
+use CoreShop\Component\Index\Condition\IsNotNullCondition;
+use CoreShop\Component\Index\Condition\IsNullCondition;
+use CoreShop\Component\Index\Worker\WorkerInterface;
+use Webmozart\Assert\Assert;
+
+class IsNullRenderer extends AbstractMysqlDynamicRenderer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function render(WorkerInterface $worker, ConditionInterface $condition, $prefix = null)
+    {
+        /**
+         * @var $condition IsNullCondition
+         */
+        Assert::isInstanceOf($condition, IsNullCondition::class);
+
+        $operator = 'IS NULL';
+
+        if ($condition instanceof IsNotNullCondition) {
+            $operator = 'IS NOT NULL';
+        }
+
+        return sprintf('%s %s', $this->quoteFieldName($condition->getFieldName(), $prefix), $operator);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(WorkerInterface $worker, ConditionInterface $condition)
+    {
+        return $worker instanceof MysqlWorker && $condition instanceof IsNullCondition;
+    }
+}

--- a/src/CoreShop/Bundle/IndexBundle/Condition/Mysql/IsRenderer.php
+++ b/src/CoreShop/Bundle/IndexBundle/Condition/Mysql/IsRenderer.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2017 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\IndexBundle\Condition\Mysql;
+
+use CoreShop\Bundle\IndexBundle\Worker\MysqlWorker;
+use CoreShop\Component\Index\Condition\ConditionInterface;
+use CoreShop\Component\Index\Condition\IsCondition;
+use CoreShop\Component\Index\Worker\WorkerInterface;
+use Webmozart\Assert\Assert;
+
+class IsRenderer extends AbstractMysqlDynamicRenderer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function render(WorkerInterface $worker, ConditionInterface $condition, $prefix = null)
+    {
+        /**
+         * @var $condition IsCondition
+         */
+        Assert::isInstanceOf($condition, IsCondition::class);
+
+        $value = $condition->getValue();
+
+        return ''.$this->quoteFieldName($condition->getFieldName(), $prefix).' IS '.($value ? '' : ' NOT ').'NULL';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(WorkerInterface $worker, ConditionInterface $condition)
+    {
+        return $worker instanceof MysqlWorker && $condition instanceof IsCondition;
+    }
+}

--- a/src/CoreShop/Bundle/IndexBundle/Condition/Mysql/LikeRenderer.php
+++ b/src/CoreShop/Bundle/IndexBundle/Condition/Mysql/LikeRenderer.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2017 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\IndexBundle\Condition\Mysql;
+
+use CoreShop\Bundle\IndexBundle\Worker\MysqlWorker;
+use CoreShop\Component\Index\Condition\ConditionInterface;
+use CoreShop\Component\Index\Condition\LikeCondition;
+use CoreShop\Component\Index\Condition\NotLikeCondition;
+use CoreShop\Component\Index\Worker\WorkerInterface;
+use Webmozart\Assert\Assert;
+
+class LikeRenderer extends AbstractMysqlDynamicRenderer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function render(WorkerInterface $worker, ConditionInterface $condition, $prefix = null)
+    {
+        /**
+         * @var $condition LikeCondition
+         */
+        Assert::isInstanceOf($condition, LikeCondition::class);
+
+        $value = $condition->getValue();
+        $pattern = $condition->getPattern();
+        $operator = 'LIKE';
+        $patternValue = '';
+
+        switch ($pattern) {
+            case 'left':
+                $patternValue = '%'.$value;
+                break;
+            case 'right':
+                $patternValue = $value.'%';
+                break;
+            case 'both':
+                $patternValue = '%'.$value.'%';
+                break;
+        }
+
+        if ($condition instanceof NotLikeCondition) {
+            $operator = 'NOT LIKE';
+        }
+
+        return sprintf(
+            '%s %s %s',
+            $this->quoteFieldName($condition->getFieldName(), $prefix),
+            $operator,
+            $this->quote($patternValue)
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(WorkerInterface $worker, ConditionInterface $condition)
+    {
+        return $worker instanceof MysqlWorker && $condition instanceof LikeCondition;
+    }
+}

--- a/src/CoreShop/Bundle/IndexBundle/Condition/Mysql/RangeRenderer.php
+++ b/src/CoreShop/Bundle/IndexBundle/Condition/Mysql/RangeRenderer.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2017 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\IndexBundle\Condition\Mysql;
+
+use CoreShop\Bundle\IndexBundle\Worker\MysqlWorker;
+use CoreShop\Component\Index\Condition\ConditionInterface;
+use CoreShop\Component\Index\Condition\RangeCondition;
+use CoreShop\Component\Index\Worker\WorkerInterface;
+use Webmozart\Assert\Assert;
+
+class RangeRenderer extends AbstractMysqlDynamicRenderer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function render(WorkerInterface $worker, ConditionInterface $condition, $prefix = null)
+    {
+        /**
+         * @var $condition RangeCondition
+         */
+        Assert::isInstanceOf($condition, RangeCondition::class);
+
+        $from = $condition->getFrom();
+        $to = $condition->getTo();
+
+        return ''.$this->quoteFieldName($condition->getFieldName(), $prefix).' >= '.$from.' AND '.$this->quoteFieldName(
+                $condition->getFieldName(),
+                $prefix
+            ).' <= '.$to;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(WorkerInterface $worker, ConditionInterface $condition)
+    {
+        return $worker instanceof MysqlWorker && $condition instanceof RangeCondition;
+    }
+}

--- a/src/CoreShop/Bundle/IndexBundle/Condition/MysqlRenderer.php
+++ b/src/CoreShop/Bundle/IndexBundle/Condition/MysqlRenderer.php
@@ -12,237 +12,42 @@
 
 namespace CoreShop\Bundle\IndexBundle\Condition;
 
-use CoreShop\Component\Index\Condition\CompareCondition;
-use CoreShop\Component\Index\Condition\ConcatCondition;
 use CoreShop\Component\Index\Condition\ConditionInterface;
-use CoreShop\Component\Index\Condition\InCondition;
-use CoreShop\Component\Index\Condition\IsCondition;
-use CoreShop\Component\Index\Condition\IsNotCondition;
-use CoreShop\Component\Index\Condition\IsNotNullCondition;
-use CoreShop\Component\Index\Condition\IsNullCondition;
-use CoreShop\Component\Index\Condition\LikeCondition;
-use CoreShop\Component\Index\Condition\MatchCondition;
-use CoreShop\Component\Index\Condition\NotInCondition;
-use CoreShop\Component\Index\Condition\NotLikeCondition;
-use CoreShop\Component\Index\Condition\NotMatchCondition;
-use CoreShop\Component\Index\Condition\RangeCondition;
+use CoreShop\Component\Index\Condition\ConditionRendererInterface;
 use CoreShop\Component\Index\Condition\RendererInterface;
-use Pimcore\Db;
+use CoreShop\Component\Index\Worker\WorkerInterface;
 
+/**
+ * @deprecated MysqlRenderer is deprecated since 2.0.0, please use the CoreShop\Component\Index\Condition˜ConditionRendererInterface instead
+ */
 class MysqlRenderer implements RendererInterface
 {
     /**
-     * @var \Pimcore\Db\Connection
+     * @var WorkerInterface
      */
-    protected $database;
+    protected $mysqlWorker;
+
+    /**
+     * @var ConditionRendererInterface
+     */
+    protected $renderer;
 
     /**
      * Condition constructor.
      */
     public function __construct()
     {
-        $this->database = Db::get();
+        $this->mysqlWorker = \Pimcore::getContainer()->get('coreshop.index.worker.mysql');;
+        $this->renderer = \Pimcore::getContainer()->get('coreshop.index.condition.renderer');
+
+        @trigger_error(
+            'Class CoreShop\Bundle\IndexBundle\Condition\MysqlRenderer is deprecated since 2.0.0, please use the CoreShop\Component\Index\Condition˜ConditionRendererInterface instead.',
+            E_USER_DEPRECATED
+        );
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function render(ConditionInterface $condition, $prefix = null)
     {
-        if ($condition instanceof IsCondition) {
-            return $this->renderIs($condition, $prefix);
-        }
-        elseif ($condition instanceof InCondition) {
-            return $this->renderIn($condition, $prefix);
-        }
-        elseif ($condition instanceof LikeCondition) {
-            return $this->renderLike($condition, $prefix);
-        }
-        elseif ($condition instanceof RangeCondition) {
-            return $this->renderRange($condition, $prefix);
-        }
-        elseif ($condition instanceof ConcatCondition) {
-            return $this->renderConcat($condition, $prefix);
-        }
-        elseif ($condition instanceof CompareCondition) {
-            return $this->renderCompare($condition, $prefix);
-        }
-        elseif ($condition instanceof IsNullCondition) {
-            return $this->renderIsNull($condition, $prefix);
-        }
-
-        throw new \InvalidArgumentException(sprintf('Class %s is not implemented in Mysql Condition Renderer', get_class($condition)));
-    }
-
-    /**
-     * @param InCondition $condition
-     * @param string $prefix
-     *
-     * @return string
-     */
-    protected function renderIn(InCondition $condition, $prefix = null)
-    {
-        $inValues = [];
-
-        if (is_array($condition->getValues())) {
-            foreach ($condition->getValues() as $c => $value) {
-                $inValues[] = $this->database->quote($value);
-            }
-        }
-
-        if (count($inValues) > 0) {
-            $operator = 'IN';
-
-            if ($condition instanceof NotInCondition) {
-                $operator = 'NOT IN';
-            }
-
-            return sprintf('%s %s (%s)', $this->quoteFieldName($condition->getFieldName(), $prefix), $operator, implode(',', $inValues));
-        }
-
-        return '';
-    }
-
-    /**
-     * @param IsCondition $condition
-     * @param string $prefix
-     *
-     * @return string
-     */
-    protected function renderIs(IsCondition $condition, $prefix = null)
-    {
-        $value = $condition->getValue();
-
-        return '' . $this->quoteFieldName($condition->getFieldName(), $prefix) . ' IS ' . ($value ? '' : ' NOT ') . 'NULL';
-    }
-
-    /**
-     * @param IsNullCondition $condition
-     * @param string $prefix
-     *
-     * @return string
-     */
-    protected function renderIsNull(IsNullCondition $condition, $prefix = null)
-    {
-        $operator = 'IS NULL';
-
-        if ($condition instanceof IsNotNullCondition) {
-            $operator = 'IS NOT NULL';
-        }
-
-        return sprintf('%s %s', $this->quoteFieldName($condition->getFieldName(), $prefix), $operator);
-    }
-
-    /**
-     * @param LikeCondition $condition
-     * @param string $prefix
-     *
-     * @return string
-     */
-    protected function renderLike(LikeCondition $condition, $prefix = null)
-    {
-        $value = $condition->getValue();
-        $pattern = $condition->getPattern();
-        $operator = 'LIKE';
-        $patternValue = '';
-
-        switch ($pattern) {
-            case 'left':
-                $patternValue = '%' . $value;
-                break;
-            case 'right':
-                $patternValue = $value . '%';
-                break;
-            case 'both':
-                $patternValue = '%' . $value . '%';
-                break;
-        }
-
-        if ($condition instanceof NotLikeCondition) {
-            $operator = 'NOT LIKE';
-        }
-
-        return sprintf('%s %s %s', $this->quoteFieldName($condition->getFieldName(), $prefix), $operator, $this->database->quote($patternValue));
-    }
-
-    /**
-     * @param RangeCondition $condition
-     * @param string $prefix
-     *
-     * @return string
-     */
-    protected function renderRange(RangeCondition $condition, $prefix = null)
-    {
-        $from = $condition->getFrom();
-        $to = $condition->getTo();
-
-        return '' . $this->quoteFieldName($condition->getFieldName(), $prefix) . ' >= ' . $from . ' AND ' . $this->quoteFieldName($condition->getFieldName(), $prefix) . ' <= ' . $to;
-    }
-
-    /**
-     * @param ConcatCondition $condition
-     * @param string $prefix
-     *
-     * @return string
-     */
-    protected function renderConcat(ConcatCondition $condition, $prefix = null)
-    {
-        $conditions = [];
-
-        foreach ($condition->getConditions() as $cond) {
-            $conditions[] = $this->render($cond, $prefix);
-        }
-
-        if (count($conditions) > 0) {
-            return '('.implode(' '.trim($condition->getOperator()).' ', $conditions).')';
-        }
-
-        return '';
-    }
-
-    /**
-     * @param CompareCondition $condition
-     * @param string $prefix
-     *
-     * @return string
-     */
-    protected function renderCompare(CompareCondition $condition, $prefix = null)
-    {
-        $value = $condition->getValue();
-        $operator = $condition->getOperator();
-
-        return '' . $this->quoteFieldName($condition->getFieldName(), $prefix) . ' ' . $operator . ' ' . $this->database->quote($value);
-    }
-
-    /**
-     * @param $identifier
-     * @return string
-     */
-    protected function quoteIdentifier($identifier)
-    {
-        return $this->database->quoteIdentifier($identifier);
-    }
-
-    /**
-     * @param null $prefix
-     * @return string
-     */
-    protected function renderPrefix($prefix = null)
-    {
-        if (null === $prefix) {
-            return '';
-        }
-
-        return $prefix . '.';
-    }
-
-    /**
-     * @param $fieldName
-     * @param null $prefix
-     * @return string
-     */
-    protected function quoteFieldName($fieldName, $prefix = null)
-    {
-        return $this->renderPrefix($prefix) . $this->quoteIdentifier($fieldName);
+        return $this->renderer->render($this->mysqlWorker, $condition, $prefix);
     }
 }

--- a/src/CoreShop/Bundle/IndexBundle/Condition/MysqlRenderer.php
+++ b/src/CoreShop/Bundle/IndexBundle/Condition/MysqlRenderer.php
@@ -18,7 +18,7 @@ use CoreShop\Component\Index\Condition\RendererInterface;
 use CoreShop\Component\Index\Worker\WorkerInterface;
 
 /**
- * @deprecated MysqlRenderer is deprecated since 2.0.0, please use the CoreShop\Component\Index\Condition˜ConditionRendererInterface instead
+ * @deprecated MysqlRenderer is deprecated since 2.0.0, please use the CoreShop\Component\Index\Condition\ConditionRendererInterface instead
  */
 class MysqlRenderer implements RendererInterface
 {
@@ -41,7 +41,7 @@ class MysqlRenderer implements RendererInterface
         $this->renderer = \Pimcore::getContainer()->get('coreshop.index.condition.renderer');
 
         @trigger_error(
-            'Class CoreShop\Bundle\IndexBundle\Condition\MysqlRenderer is deprecated since 2.0.0, please use the CoreShop\Component\Index\Condition˜ConditionRendererInterface instead.',
+            'Class CoreShop\Bundle\IndexBundle\Condition\MysqlRenderer is deprecated since 2.0.0, please use the CoreShop\Component\Index\Condition\ConditionRendererInterface instead.',
             E_USER_DEPRECATED
         );
     }

--- a/src/CoreShop/Bundle/IndexBundle/CoreShopIndexBundle.php
+++ b/src/CoreShop/Bundle/IndexBundle/CoreShopIndexBundle.php
@@ -12,6 +12,7 @@
 
 namespace CoreShop\Bundle\IndexBundle;
 
+use CoreShop\Bundle\IndexBundle\DependencyInjection\Compiler\RegisterConditionRendererTypesPass;
 use CoreShop\Bundle\IndexBundle\DependencyInjection\Compiler\RegisterExtensionsPass;
 use CoreShop\Bundle\IndexBundle\DependencyInjection\Compiler\RegisterColumnTypePass;
 use CoreShop\Bundle\IndexBundle\DependencyInjection\Compiler\RegisterFilterConditionTypesPass;
@@ -47,6 +48,7 @@ final class CoreShopIndexBundle extends AbstractResourceBundle
         $container->addCompilerPass(new RegisterGetterPass());
         $container->addCompilerPass(new RegisterFilterConditionTypesPass());
         $container->addCompilerPass(new RegisterExtensionsPass());
+        $container->addCompilerPass(new RegisterConditionRendererTypesPass());
     }
 
     /**

--- a/src/CoreShop/Bundle/IndexBundle/DependencyInjection/Compiler/RegisterConditionRendererTypesPass.php
+++ b/src/CoreShop/Bundle/IndexBundle/DependencyInjection/Compiler/RegisterConditionRendererTypesPass.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2017 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\IndexBundle\DependencyInjection\Compiler;
+
+use CoreShop\Bundle\PimcoreBundle\DependencyInjection\Compiler\RegisterSimpleRegistryTypePass;
+
+class RegisterConditionRendererTypesPass extends RegisterSimpleRegistryTypePass
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'coreshop.registry.index.condition.renderers',
+            'coreshop.index.condition.renderers',
+            'coreshop.index.condition.renderer'
+        );
+    }
+}

--- a/src/CoreShop/Bundle/IndexBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/IndexBundle/Resources/config/services.yml
@@ -3,6 +3,7 @@ imports:
     - { resource: "services/listeners.yml" }
     - { resource: "services/commands.yml" }
     - { resource: "services/pimcore.yml" }
+    - { resource: "services/condition_renderer.yml" }
 
 services:
     _defaults:
@@ -95,6 +96,8 @@ services:
             - '@coreshop.registry.index.getter'
             - '@coreshop.registry.index.interpreter'
             - '@coreshop.index.filter_group_helper'
+            - '@coreshop.index.condition.renderer'
+            - '@doctrine.dbal.default_connection'
         shared: false
         calls:
             - { method: setLogger, arguments: ['@logger'] }

--- a/src/CoreShop/Bundle/IndexBundle/Resources/config/services/condition_renderer.yml
+++ b/src/CoreShop/Bundle/IndexBundle/Resources/config/services/condition_renderer.yml
@@ -1,0 +1,62 @@
+services:
+    coreshop.registry.index.condition.renderers:
+        class: CoreShop\Component\Registry\ServiceRegistry
+        arguments:
+            - CoreShop\Component\Index\Condition\DynamicRendererInterface
+            - condition-renderers
+
+    ## Renderer
+    coreshop.index.condition.renderer:
+        class: CoreShop\Component\Index\Condition\ConditionRenderer
+        arguments:
+            - '@coreshop.registry.index.condition.renderers'
+
+    coreshop.index.condition.renderer.mysql.abstract:
+        class: CoreShop\Bundle\IndexBundle\Condition\Mysql\AbstractMysqlDynamicRenderer
+        abstract: true
+        arguments:
+            - '@doctrine.dbal.default_connection'
+
+    coreshop.index.condition.renderer.mysql.compare:
+        class: CoreShop\Bundle\IndexBundle\Condition\Mysql\CompareRenderer
+        parent: coreshop.index.condition.renderer.mysql.abstract
+        tags:
+            - { name: coreshop.index.condition.renderer, type: mysql_compare }
+
+    coreshop.index.condition.renderer.mysql.concat:
+        class: CoreShop\Bundle\IndexBundle\Condition\Mysql\ConcatRenderer
+        arguments:
+            - '@doctrine.dbal.default_connection'
+            - '@coreshop.index.condition.renderer'
+        tags:
+            - { name: coreshop.index.condition.renderer, type: mysql_concat }
+
+    coreshop.index.condition.renderer.mysql.in:
+        class: CoreShop\Bundle\IndexBundle\Condition\Mysql\InRenderer
+        parent: coreshop.index.condition.renderer.mysql.abstract
+        tags:
+            - { name: coreshop.index.condition.renderer, type: mysql_in }
+
+    coreshop.index.condition.renderer.mysql.is_null:
+        class: CoreShop\Bundle\IndexBundle\Condition\Mysql\IsNullRenderer
+        parent: coreshop.index.condition.renderer.mysql.abstract
+        tags:
+            - { name: coreshop.index.condition.renderer, type: mysql_is_null }
+
+    coreshop.index.condition.renderer.mysql.is:
+        class: CoreShop\Bundle\IndexBundle\Condition\Mysql\IsRenderer
+        parent: coreshop.index.condition.renderer.mysql.abstract
+        tags:
+            - { name: coreshop.index.condition.renderer, type: mysql_is }
+
+    coreshop.index.condition.renderer.mysql.like:
+        class: CoreShop\Bundle\IndexBundle\Condition\Mysql\LikeRenderer
+        parent: coreshop.index.condition.renderer.mysql.abstract
+        tags:
+            - { name: coreshop.index.condition.renderer, type: mysql_like }
+
+    coreshop.index.condition.renderer.mysql.range:
+        class: CoreShop\Bundle\IndexBundle\Condition\Mysql\RangeRenderer
+        parent: coreshop.index.condition.renderer.mysql.abstract
+        tags:
+            - { name: coreshop.index.condition.renderer, type: mysql_range }

--- a/src/CoreShop/Bundle/IndexBundle/Worker/AbstractWorker.php
+++ b/src/CoreShop/Bundle/IndexBundle/Worker/AbstractWorker.php
@@ -13,6 +13,7 @@
 namespace CoreShop\Bundle\IndexBundle\Worker;
 
 use CoreShop\Component\Index\Condition\ConditionInterface;
+use CoreShop\Component\Index\Condition\ConditionRendererInterface;
 use CoreShop\Component\Index\Extension\IndexColumnsExtensionInterface;
 use CoreShop\Component\Index\Extension\IndexExtensionInterface;
 use CoreShop\Component\Index\Getter\GetterInterface;
@@ -57,21 +58,30 @@ abstract class AbstractWorker implements WorkerInterface
     protected $filterGroupHelper;
 
     /**
+     * @var ConditionRendererInterface
+     */
+    protected $conditionRenderer;
+
+    /**
      * @param ServiceRegistryInterface $extensions
      * @param ServiceRegistryInterface $getterServiceRegistry
      * @param ServiceRegistryInterface $interpreterServiceRegistry
      * @param FilterGroupHelperInterface $filterGroupHelper
+     * @param ConditionRendererInterface $conditionRenderer
      */
     public function __construct(
         ServiceRegistryInterface $extensions,
         ServiceRegistryInterface $getterServiceRegistry,
         ServiceRegistryInterface $interpreterServiceRegistry,
-        FilterGroupHelperInterface $filterGroupHelper
-    ) {
+        FilterGroupHelperInterface $filterGroupHelper,
+        ConditionRendererInterface $conditionRenderer
+    )
+    {
         $this->extensions = $extensions;
         $this->getterServiceRegistry = $getterServiceRegistry;
         $this->interpreterServiceRegistry = $interpreterServiceRegistry;
         $this->filterGroupHelper = $filterGroupHelper;
+        $this->conditionRenderer = $conditionRenderer;
     }
 
     /**
@@ -89,6 +99,14 @@ abstract class AbstractWorker implements WorkerInterface
         }
 
         return $eligibleExtensions;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function renderCondition(ConditionInterface $condition, $prefix = null)
+    {
+        return $this->conditionRenderer->render($this, $condition, $prefix);
     }
 
     /**
@@ -400,11 +418,6 @@ abstract class AbstractWorker implements WorkerInterface
      * {@inheritdoc}
      */
     abstract public function getList(IndexInterface $index);
-
-    /**
-     * {@inheritdoc}
-     */
-    abstract public function renderCondition(ConditionInterface $condition, $prefix = null);
 
     /**
      * {@inheritdoc}

--- a/src/CoreShop/Component/Index/Condition/ConditionRenderer.php
+++ b/src/CoreShop/Component/Index/Condition/ConditionRenderer.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2017 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Component\Index\Condition;
+
+use CoreShop\Component\Index\Worker\WorkerInterface;
+use CoreShop\Component\Registry\ServiceRegistryInterface;
+
+final class ConditionRenderer implements ConditionRendererInterface
+{
+    /**
+     * @var ServiceRegistryInterface
+     */
+    protected $registry;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render(WorkerInterface $worker, ConditionInterface $condition, $prefix = null)
+    {
+        /**
+         * @var $renderer DynamicRendererInterface
+         */
+        foreach ($this->registry->all() as $renderer) {
+            if ($renderer->supports($worker, $condition)) {
+                return $renderer->render($worker, $condition, $prefix);
+            }
+        }
+
+        throw new \InvalidArgumentException(
+            sprintf('No Renderer found for condition with type %s', get_class($condition))
+        );
+    }
+
+    /**
+     * @param ServiceRegistryInterface $registry
+     */
+    public function __construct(ServiceRegistryInterface $registry)
+    {
+        $this->registry = $registry;
+    }
+}

--- a/src/CoreShop/Component/Index/Condition/ConditionRendererInterface.php
+++ b/src/CoreShop/Component/Index/Condition/ConditionRendererInterface.php
@@ -12,18 +12,18 @@
 
 namespace CoreShop\Component\Index\Condition;
 
-/**
- * @deprecated RendererInterface is deprecated since 2.0.0, please use the CoreShop\Component\Index\Condition\DynamicRendererInterface instead
- */
-interface RendererInterface
+use CoreShop\Component\Index\Worker\WorkerInterface;
+
+interface ConditionRendererInterface
 {
     /**
      * Renders the condition.
      *
+     * @param WorkerInterface    $worker
      * @param ConditionInterface $condition
-     * @param string $prefix
+     * @param string             $prefix
      *
      * @return mixed
      */
-    public function render(ConditionInterface $condition, $prefix = null);
+    public function render(WorkerInterface $worker, ConditionInterface $condition, $prefix = null);
 }

--- a/src/CoreShop/Component/Index/Condition/DynamicRendererInterface.php
+++ b/src/CoreShop/Component/Index/Condition/DynamicRendererInterface.php
@@ -12,18 +12,25 @@
 
 namespace CoreShop\Component\Index\Condition;
 
-/**
- * @deprecated RendererInterface is deprecated since 2.0.0, please use the CoreShop\Component\Index\Condition\DynamicRendererInterface instead
- */
-interface RendererInterface
+use CoreShop\Component\Index\Worker\WorkerInterface;
+
+interface DynamicRendererInterface
 {
     /**
      * Renders the condition.
      *
+     * @param WorkerInterface    $worker
      * @param ConditionInterface $condition
-     * @param string $prefix
+     * @param string             $prefix
      *
      * @return mixed
      */
-    public function render(ConditionInterface $condition, $prefix = null);
+    public function render(WorkerInterface $worker, ConditionInterface $condition, $prefix = null);
+
+    /**
+     * @param WorkerInterface    $worker
+     * @param ConditionInterface $condition
+     * @return bool
+     */
+    public function supports(WorkerInterface $worker, ConditionInterface $condition);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | #711 

This allows to register new `ConditionRenderer` and therefore a more dynamic approach to add new Conditions.

This deprecates the `MysqlRenderer` which was actually supposed to be used internally only anyway.