### PR TITLE
Add possibility to define a custom name for fields combo box

### DIFF
--- a/src/CoreShop/Bundle/IndexBundle/Resources/public/pimcore/js/filter/abstract.js
+++ b/src/CoreShop/Bundle/IndexBundle/Resources/public/pimcore/js/filter/abstract.js
@@ -69,8 +69,11 @@ coreshop.filter.abstract = Class.create({
         return data;
     },
 
-    getFieldsComboBox: function () {
-        if (!this.fieldsCombo) {
+    getFieldsComboBox: function (fieldName) {
+        fieldName = Ext.isDefined(fieldName) ? fieldName : 'field';
+        var comboName = fieldName + 'sCombo';
+
+        if (!this[comboName]) {
 
             this.valueStore = new Ext.data.ArrayStore({
                 proxy: new Ext.data.HttpProxy({
@@ -82,10 +85,10 @@ coreshop.filter.abstract = Class.create({
                 ])
             });
 
-            this.fieldsCombo = Ext.create({
+            this[comboName] = Ext.create({
                 xtype: 'combo',
-                fieldLabel: t('coreshop_filters_field'),
-                name: 'field',
+                fieldLabel: t('coreshop_filters_' + fieldName),
+                name: fieldName,
                 width: 400,
                 store: this.parent.getFieldsStore(),
                 displayField: 'name',
@@ -95,7 +98,7 @@ coreshop.filter.abstract = Class.create({
                 editable: false,
                 forceSelection: true,
                 queryMode: 'local',
-                value: this.data.configuration.hasOwnProperty('field') ? this.data.configuration.field : null,
+                value: this.data.configuration.hasOwnProperty(fieldName) ? this.data.configuration[fieldName] : null,
                 listeners: {
                     change: function (combo, newValue) {
                         this.onFieldChange.call(this, combo, newValue);
@@ -104,11 +107,11 @@ coreshop.filter.abstract = Class.create({
             });
         }
 
-        if (this.data.configuration.hasOwnProperty('field') && this.data.configuration.field) {
-            this.onFieldChange(this.fieldsCombo, this.data.configuration.field);
+        if (this.data.configuration.hasOwnProperty(fieldName) && this.data.configuration[fieldName]) {
+            this.onFieldChange(this[comboName], this.data.configuration[fieldName]);
         }
 
-        return this.fieldsCombo;
+        return this[comboName];
     },
 
     onFieldChange: function (combo, newValue) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

When developing custom `FilterConditions` it would be very handy to be able to also define custom names for the field combo box. For example, when you want to query multiple fields of the index.
