### PR TITLE
Country (mainly) and currency (additionaly) fixtures fixes

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Fixtures/Data/Application/CountryFixture.php
+++ b/src/CoreShop/Bundle/CoreBundle/Fixtures/Data/Application/CountryFixture.php
@@ -103,11 +103,8 @@ class CountryFixture extends AbstractFixture implements ContainerAwareInterface,
         $languageDataProvider = Intl::getLanguageBundle();
 
         foreach ($languages as $lang) {
-            if (strpos($lang, '_')) {
-                $lang = explode('_', $lang)[0];
-            }
-
-            $alpha3CodeMap[$lang] = $languageDataProvider->getAlpha3Code($lang);
+            $langPart = strpos($lang, '_') ? explode('_', $lang)[0] : $lang;
+            $alpha3CodeMap[$lang] = $languageDataProvider->getAlpha3Code($langPart);
         }
 
         foreach ($countries as $country) {
@@ -128,7 +125,7 @@ class CountryFixture extends AbstractFixture implements ContainerAwareInterface,
                 }
 
                 $newCountry->setIsoCode($country->getIsoAlpha2());
-                $newCountry->setActive($country->getIsoAlpha2() === 'AT');
+                $newCountry->setActive($country->getIsoAlpha2() === 'AT' || $newCountry->getActive());
                 $newCountry->setZone($this->container->get('coreshop.repository.zone')->findOneBy(['name' => $country->getContinent()]));
                 $newCountry->setCurrency($this->container->get('coreshop.repository.currency')->getByCode($country->getCurrency()['iso_4217_code']));
 

--- a/src/CoreShop/Bundle/CoreBundle/Fixtures/Data/Application/CurrencyFixture.php
+++ b/src/CoreShop/Bundle/CoreBundle/Fixtures/Data/Application/CurrencyFixture.php
@@ -73,7 +73,10 @@ class CurrencyFixture extends AbstractFixture implements ContainerAwareInterface
             /**
              * @var CurrencyInterface
              */
-            $currency = $this->container->get('coreshop.factory.currency')->createNew();
+            $currency = $this->container->get('coreshop.repository.currency')->getByCode($iso);
+            if (null === $currency) {
+                $currency = $this->container->get('coreshop.factory.currency')->createNew();
+            }
             $currency->setName($c['iso_4217_name']);
             $currency->setIsoCode($iso);
             $currency->setNumericIsoCode($c['iso_4217_numeric']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

Fixes for command `coreshop:fixture:data:load`:
* Country:
  * **major fix** - countries weren't correctly installed for locals like en_GB of fr_FR
  * minor fix/upgrade - if a country was already active (in case of a 2nd run) leave it active
* Currency:
  * similar to Country Fixture - if Currency is already there don't add it a 2nd time (in case of run second time the command and remove a row from coreshop_fixtures_data of course)


