### PR TITLE
Couriers addition fix

### DIFF
--- a/src/CoreShop/Bundle/ShippingBundle/Resources/public/pimcore/js/carrier/panel.js
+++ b/src/CoreShop/Bundle/ShippingBundle/Resources/public/pimcore/js/carrier/panel.js
@@ -34,5 +34,10 @@ coreshop.carrier.panel = Class.create(coreshop.resource.panel, {
 
     getDefaultGridDisplayColumnName: function() {
         return 'identifier';
+    },
+
+    prepareAdd: function (object) {
+        object['identifier'] = object.name;
+        return object;
     }
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | ---

Fix for adding new carrier from Admin Panel - without it you needed to write identifier twice (name from first window wasn't filled to the identifier)
