### PR TITLE
Fix for StoreMailActionProcessor exception in Notification Rule.

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/EventListener/NotificationRules/CustomerListener.php
+++ b/src/CoreShop/Bundle/CoreBundle/EventListener/NotificationRules/CustomerListener.php
@@ -164,6 +164,7 @@ final class CustomerListener extends AbstractNotificationRuleListener
             'lastname' => $customer->getLastname(),
             'email' => $customer->getEmail(),
             'object' => $customer,
+            'store' => $this->shopperContext->getStore(),
         ];
     }
 }

--- a/src/CoreShop/Bundle/CoreBundle/EventListener/NotificationRules/CustomerListener.php
+++ b/src/CoreShop/Bundle/CoreBundle/EventListener/NotificationRules/CustomerListener.php
@@ -164,7 +164,7 @@ final class CustomerListener extends AbstractNotificationRuleListener
             'lastname' => $customer->getLastname(),
             'email' => $customer->getEmail(),
             'object' => $customer,
-            'store' => $this->shopperContext->getStore(),
+            'store' => $this->shopperContext->hasStore() ? $this->shopperContext->getStore() : null,
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

When I add 'Store based Mail' action in 'User Reset Password' I get the error during reset password request (dispatch event 'coreshop.customer.request_password_reset'):
`'StoreMailActionProcessor: Store is not set.'`
This PR should fix this.