### PR TITLE
Introduce theme-bundle

### DIFF
--- a/bin/subtree-release
+++ b/bin/subtree-release
@@ -62,3 +62,4 @@ split 'src/CoreShop/Bundle/InventoryBundle' inventory-bundle
 split 'src/CoreShop/Bundle/WorkflowBundle' workflow-bundle
 split 'src/CoreShop/Bundle/SEOBundle' seo-bundle
 split 'src/CoreShop/Bundle/PimcoreBundle' pimcore-bundle
+split 'src/CoreShop/Bundle/ThemeBundle' theme-bundle

--- a/bin/subtree-split
+++ b/bin/subtree-split
@@ -93,6 +93,7 @@ remote inventory-bundle git@github.com:CoreShop/InventoryBundle.git
 remote workflow-bundle git@github.com:CoreShop/WorkflowBundle.git
 remote seo-bundle git@github.com:CoreShop/SEOBundle.git
 remote pimcore-bundle git@github.com:CoreShop/PimcoreBundle.git
+remote theme-bundle git@github.com:CoreShop/ThemeBundle.git
 
 split 'src/CoreShop/Component/Resource' resource
 split 'src/CoreShop/Component/Registry' registry
@@ -144,3 +145,4 @@ split 'src/CoreShop/Bundle/InventoryBundle' inventory-bundle
 split 'src/CoreShop/Bundle/WorkflowBundle' workflow-bundle
 split 'src/CoreShop/Bundle/SEOBundle' seo-bundle
 split 'src/CoreShop/Bundle/PimcoreBundle' pimcore-bundle
+split 'src/CoreShop/Bundle/ThemeBundle' theme-bundle

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,8 @@
     "coreshop/seo": "self.version",
     "coreshop/seo-bundle": "self.version",
     "coreshop/pimcore-bundle": "self.version",
-    "coreshop/tracking": "self.version"
+    "coreshop/tracking": "self.version",
+    "coreshop/theme-bundle": "self.version"
   },
   "require": {
     "doctrine/orm": "~2.5",

--- a/features/theme/theme.feature
+++ b/features/theme/theme.feature
@@ -1,0 +1,25 @@
+@theme
+Feature: In order to allow multishop with different designs
+  we allow each store a different template
+
+  Background:
+    Given the site operates on a store in "Austria"
+
+  Scenario: Default Store theme
+    Then the current theme name should be "standard"
+
+  Scenario: Store Theme
+    Given the site has a country "Germany" with currency "EUR"
+    And the country "Germany" is active
+    And the site has a store "Germany" with country "Germany" and currency "EUR"
+    And the store "Germany" uses theme "germany"
+    And I am in store "Germany"
+    Then the current theme name should be "germany"
+
+  Scenario: Multiple Stores with one active
+    Given the site has a country "Germany" with currency "EUR"
+    And the country "Germany" is active
+    And the site has a store "Germany" with country "Germany" and currency "EUR"
+    And the store "Germany" uses theme "germany"
+    Then the current theme name should be "standard"
+

--- a/src/CoreShop/Behat/Context/Domain/ThemeContext.php
+++ b/src/CoreShop/Behat/Context/Domain/ThemeContext.php
@@ -10,12 +10,21 @@
  * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
  */
 
-namespace CoreShop\Bundle\ThemeBundle\Service;
+namespace CoreShop\Behat\Context\Domain;
 
+use Behat\Behat\Context\Context;
+use CoreShop\Behat\Service\SharedStorageInterface;
+use CoreShop\Bundle\ThemeBundle\Service\ThemeResolverInterface;
 use Liip\ThemeBundle\ActiveTheme;
+use Webmozart\Assert\Assert;
 
-final class ThemeHelper implements ThemeHelperInterface
+final class ThemeContext implements Context
 {
+    /**
+     * @var SharedStorageInterface
+     */
+    private $sharedStorage;
+
     /**
      * @var ThemeResolverInterface
      */
@@ -27,39 +36,28 @@ final class ThemeHelper implements ThemeHelperInterface
     private $activeTheme;
 
     /**
+     * ThemeContext constructor.
+     * @param SharedStorageInterface $sharedStorage
      * @param ThemeResolverInterface $themeResolver
      * @param ActiveTheme            $activeTheme
      */
     public function __construct(
+        SharedStorageInterface $sharedStorage,
         ThemeResolverInterface $themeResolver,
         ActiveTheme $activeTheme
     ) {
+        $this->sharedStorage = $sharedStorage;
         $this->themeResolver = $themeResolver;
         $this->activeTheme = $activeTheme;
     }
 
     /**
-     * @param string   $themeName
-     * @param \Closure $function
-     * @return mixed
+     * @Then /^the current theme name should be "([^"]+)"$/
      */
-    public function useTheme($themeName, \Closure $function)
+    public function currentThemeNameIs(string $currentThemeName)
     {
         $this->themeResolver->resolveTheme();
 
-        $backupTheme = $this->activeTheme->getName();
-        $this->activeTheme->setName($themeName);
-
-        $result = $function();
-
-        if (in_array($backupTheme, $this->activeTheme->getThemes())) {
-            $this->activeTheme->setName($backupTheme);
-        } else {
-            $this->activeTheme->setName('standard');
-        }
-
-        return $result;
+        Assert::same($this->activeTheme->getName(), $currentThemeName);
     }
 }
-
-class_alias(ThemeHelper::class, 'CoreShop\Bundle\StoreBundle\Theme\ThemeHelper');

--- a/src/CoreShop/Behat/Context/Setup/StoreContext.php
+++ b/src/CoreShop/Behat/Context/Setup/StoreContext.php
@@ -137,6 +137,16 @@ final class StoreContext implements Context
     }
 
     /**
+     * @Given /^the (store "[^"]+") uses theme "([^"]+)"$/
+     */
+    public function theStoreusesTheme(StoreInterface $store, $template)
+    {
+        $store->setTemplate($template);
+
+        $this->saveStore($store);
+    }
+
+    /**
      * @param string                 $name
      * @param CurrencyInterface|null $currency
      * @param CountryInterface|null  $country

--- a/src/CoreShop/Behat/Resources/config/services/contexts/domain.yml
+++ b/src/CoreShop/Behat/Resources/config/services/contexts/domain.yml
@@ -217,3 +217,12 @@ services:
             - '@__symfony__.coreshop.cart_price_rule.rule_validation.processor'
         tags:
             - { name: fob.context_service }
+
+    coreshop.behat.context.domain.theme:
+        class: CoreShop\Behat\Context\Domain\ThemeContext
+        arguments:
+            - '@coreshop.behat.shared_storage'
+            - '@__symfony__.coreshop.theme.resolver'
+            - '@__symfony__.liip_theme.active_theme'
+        tags:
+            - { name: fob.context_service }

--- a/src/CoreShop/Behat/Resources/config/suites.yml
+++ b/src/CoreShop/Behat/Resources/config/suites.yml
@@ -15,3 +15,4 @@ imports:
     - suites/domain/cli.yml
     - suites/domain/filter.yml
     - suites/domain/tracking.yml
+    - suites/domain/theme.yml

--- a/src/CoreShop/Behat/Resources/config/suites/domain/theme.yml
+++ b/src/CoreShop/Behat/Resources/config/suites/domain/theme.yml
@@ -1,0 +1,20 @@
+default:
+    suites:
+        domain_cart:
+            contexts_services:
+                - coreshop.behat.context.hook.pimcore_setup
+                - coreshop.behat.context.hook.coreshop_setup
+
+                - coreshop.behat.context.hook.doctrine_orm
+                - coreshop.behat.context.hook.pimcore_dao
+
+                - coreshop.behat.context.transform.store
+                - coreshop.behat.context.transform.country
+                - coreshop.behat.context.transform.currency
+
+                - coreshop.behat.context.setup.store
+                - coreshop.behat.context.setup.country
+
+                - coreshop.behat.context.domain.theme
+            filters:
+                tags: "@theme"

--- a/src/CoreShop/Bundle/CoreBundle/Order/OrderMailProcessor.php
+++ b/src/CoreShop/Bundle/CoreBundle/Order/OrderMailProcessor.php
@@ -13,7 +13,7 @@
 namespace CoreShop\Bundle\CoreBundle\Order;
 
 use CoreShop\Bundle\PimcoreBundle\Mail\MailProcessorInterface;
-use CoreShop\Bundle\StoreBundle\Theme\ThemeHelperInterface;
+use CoreShop\Bundle\ThemeBundle\Service\ThemeHelperInterface;
 use CoreShop\Component\Core\Order\OrderMailProcessorInterface;
 use CoreShop\Component\Currency\Formatter\MoneyFormatterInterface;
 use CoreShop\Component\Order\InvoiceStates;

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services/order.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services/order.yml
@@ -104,5 +104,5 @@ services:
            - '@coreshop.repository.order_invoice'
            - '@coreshop.repository.order_shipment'
            - '@coreshop.renderer.order.pdf'
-           - '@coreshop.store.theme_helper'
+           - '@coreshop.theme.helper'
            - '@coreshop.mail_processor'

--- a/src/CoreShop/Bundle/OrderBundle/Renderer/OrderDocumentPdfRenderer.php
+++ b/src/CoreShop/Bundle/OrderBundle/Renderer/OrderDocumentPdfRenderer.php
@@ -14,7 +14,7 @@ namespace CoreShop\Bundle\OrderBundle\Renderer;
 
 use CoreShop\Bundle\OrderBundle\Event\WkhtmlOptionsEvent;
 use CoreShop\Bundle\OrderBundle\Renderer\Pdf\PdfRendererInterface;
-use CoreShop\Bundle\StoreBundle\Theme\ThemeHelperInterface;
+use CoreShop\Bundle\ThemeBundle\Service\ThemeHelperInterface;
 use CoreShop\Component\Order\Model\OrderDocumentInterface;
 use CoreShop\Component\Order\Renderer\OrderDocumentRendererInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;

--- a/src/CoreShop/Bundle/OrderBundle/Resources/config/services/pdf.yml
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/config/services/pdf.yml
@@ -14,7 +14,7 @@ services:
             - '@fragment.renderer.inline'
             - '@event_dispatcher'
             - '@coreshop.order.renderer.pdf'
-            - '@coreshop.store.theme_helper'
+            - '@coreshop.theme.helper'
 
     coreshop.renderer.order.pdf.asset:
         class: CoreShop\Bundle\OrderBundle\Renderer\AssetOrderDocumentPdfRenderer

--- a/src/CoreShop/Bundle/StoreBundle/CoreShopStoreBundle.php
+++ b/src/CoreShop/Bundle/StoreBundle/CoreShopStoreBundle.php
@@ -17,7 +17,7 @@ use CoreShop\Bundle\ResourceBundle\AbstractResourceBundle;
 use CoreShop\Bundle\ResourceBundle\CoreShopResourceBundle;
 use CoreShop\Bundle\StoreBundle\DependencyInjection\Compiler\CompositeRequestResolverPass;
 use CoreShop\Bundle\StoreBundle\DependencyInjection\Compiler\CompositeStoreContextPass;
-use Liip\ThemeBundle\LiipThemeBundle;
+use CoreShop\Bundle\ThemeBundle\CoreShopThemeBundle;
 use Pimcore\HttpKernel\BundleCollection\BundleCollection;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -52,7 +52,7 @@ final class CoreShopStoreBundle extends AbstractResourceBundle
         parent::registerDependentBundles($collection);
 
         $collection->addBundle(new CoreShopCurrencyBundle(), 2700);
-        $collection->addBundle(new LiipThemeBundle(), 1100);
+        $collection->addBundle(new CoreShopThemeBundle(), 2800);
     }
 
     /**

--- a/src/CoreShop/Bundle/StoreBundle/Resources/config/pimcore/config.yml
+++ b/src/CoreShop/Bundle/StoreBundle/Resources/config/pimcore/config.yml
@@ -9,13 +9,9 @@ pimcore:
                     coreShopStore: CoreShop\Bundle\StoreBundle\CoreExtension\Store
                     coreShopStoreMultiselect: CoreShop\Bundle\StoreBundle\CoreExtension\StoreMultiselect
 
-
 jms_serializer:
     metadata:
         directories:
             coreshop-store:
                 namespace_prefix: "CoreShop\\Component\\Store"
                 path: "@CoreShopStoreBundle/Resources/config/serializer"
-
-liip_theme:
-    load_controllers: false

--- a/src/CoreShop/Bundle/StoreBundle/Resources/config/services/theme.yml
+++ b/src/CoreShop/Bundle/StoreBundle/Resources/config/services/theme.yml
@@ -3,21 +3,15 @@ services:
         public: true
 
     coreshop.store.theme_resolver:
-        class: CoreShop\Bundle\StoreBundle\Theme\ThemeResolver
+        alias: coreshop.theme.resolver
+
+    coreshop.store.theme_helper:
+        alias: coreshop.theme.helper
+
+    coreshop.theme.store_resolver:
+        class: CoreShop\Bundle\StoreBundle\Theme\StoreThemeResolver
+        decorates: 'coreshop.theme.resolver'
         arguments:
             - '@liip_theme.active_theme'
             - '@coreshop.context.store'
             - '@coreshop.repository.store'
-
-    coreshop.store.theme_helper:
-        class: CoreShop\Bundle\StoreBundle\Theme\ThemeHelper
-        arguments:
-            - '@coreshop.store.theme_resolver'
-            - '@liip_theme.active_theme'
-
-    coreshop.listener.theme_request:
-        class: CoreShop\Bundle\StoreBundle\EventListener\ThemeRequestListener
-        arguments:
-            - '@coreshop.store.theme_resolver'
-        tags:
-            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }

--- a/src/CoreShop/Bundle/StoreBundle/Theme/StoreThemeResolver.php
+++ b/src/CoreShop/Bundle/StoreBundle/Theme/StoreThemeResolver.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2019 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\StoreBundle\Theme;
+
+use CoreShop\Component\Resource\Repository\RepositoryInterface;
+use CoreShop\Component\Store\Context\StoreContextInterface;
+use CoreShop\Component\Store\Context\StoreNotFoundException;
+use CoreShop\Component\Store\Model\StoreInterface;
+use Liip\ThemeBundle\ActiveTheme;
+
+final class StoreThemeResolver implements \CoreShop\Bundle\ThemeBundle\Service\ThemeResolverInterface
+{
+    /**
+     * @var ActiveTheme
+     */
+    private $activeTheme;
+
+    /**
+     * @var StoreContextInterface
+     */
+    private $storeContext;
+
+    /**
+     * @var RepositoryInterface
+     */
+    private $storeRepository;
+
+    /**
+     * @param ActiveTheme           $activeTheme
+     * @param StoreContextInterface $storeContext
+     * @param RepositoryInterface   $storeRepository
+     */
+    public function __construct(
+        ActiveTheme $activeTheme,
+        StoreContextInterface $storeContext,
+        RepositoryInterface $storeRepository
+    ) {
+        $this->activeTheme = $activeTheme;
+        $this->storeContext = $storeContext;
+        $this->storeRepository = $storeRepository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolveTheme()
+    {
+        $themes = [];
+
+        /**
+         * @var StoreInterface $store
+         */
+        foreach ($this->storeRepository->findAll() as $store) {
+            $storeTheme = $store->getTemplate();
+
+            if ($storeTheme) {
+                $themes[] = $storeTheme;
+            }
+        }
+
+        if (!in_array('standard', $themes)) {
+            $themes[] = 'standard';
+        }
+
+        $this->activeTheme->setThemes($themes);
+
+        try {
+            $store = $this->storeContext->getStore();
+
+            if ($theme = $store->getTemplate()) {
+                $this->activeTheme->setName($theme);
+            }
+        } catch (StoreNotFoundException $exception) {
+        }
+    }
+}

--- a/src/CoreShop/Bundle/StoreBundle/Theme/ThemeHelper.php
+++ b/src/CoreShop/Bundle/StoreBundle/Theme/ThemeHelper.php
@@ -12,50 +12,16 @@
 
 namespace CoreShop\Bundle\StoreBundle\Theme;
 
-use Liip\ThemeBundle\ActiveTheme;
+use CoreShop\Bundle\ThemeBundle\Service\ThemeHelper as NewThemeHelper;
 
-final class ThemeHelper implements ThemeHelperInterface
-{
+if (class_exists(NewThemeHelper::class)) {
+    @trigger_error('Class CoreShop\Bundle\StoreBundle\Theme\ThemeHelper is deprecated since version 2.1.0 and will be removed in 3.0.0. Use CoreShop\Bundle\ThemeBundle\Service\ThemeHelper class instead.', E_USER_DEPRECATED);
+} else {
     /**
-     * @var ThemeResolverInterface
+     * @deprecated Class CoreShop\Bundle\StoreBundle\Theme\ThemeHelper is deprecated since version 2.1.0 and will be removed in 3.0.0. Use CoreShop\Bundle\ThemeBundle\Service\ThemeHelper class instead.
      */
-    private $themeResolver;
-
-    /**
-     * @var ActiveTheme
-     */
-    private $activeTheme;
-
-    /**
-     * @param ThemeResolverInterface $themeResolver
-     * @param ActiveTheme            $activeTheme
-     */
-    public function __construct(
-        ThemeResolverInterface $themeResolver,
-        ActiveTheme $activeTheme
-    ) {
-        $this->themeResolver = $themeResolver;
-        $this->activeTheme = $activeTheme;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function useTheme($themeName, \Closure $function)
+    class ThemeHelper
     {
-        $this->themeResolver->resolveTheme();
 
-        $backupTheme = $this->activeTheme->getName();
-        $this->activeTheme->setName($themeName);
-
-        $result = $function();
-
-        if (in_array($backupTheme, $this->activeTheme->getThemes())) {
-            $this->activeTheme->setName($backupTheme);
-        } else {
-            $this->activeTheme->setName('standard');
-        }
-
-        return $result;
     }
 }

--- a/src/CoreShop/Bundle/StoreBundle/Theme/ThemeHelperInterface.php
+++ b/src/CoreShop/Bundle/StoreBundle/Theme/ThemeHelperInterface.php
@@ -12,13 +12,16 @@
 
 namespace CoreShop\Bundle\StoreBundle\Theme;
 
-interface ThemeHelperInterface
-{
+use CoreShop\Bundle\ThemeBundle\Service\ThemeHelperInterface as NewThemeHelperInterface;
+
+if (interface_exists(NewThemeHelperInterface::class)) {
+    @trigger_error('Interface CoreShop\Bundle\StoreBundle\Theme\ThemeHelperInterface is deprecated since version 2.1.0 and will be removed in 3.0.0. Use CoreShop\Bundle\ThemeBundle\Service\ThemeHelperInterface class instead.', E_USER_DEPRECATED);
+} else {
     /**
-     * @param string   $themeName
-     * @param \Closure $function
-     *
-     * @return mixed
+     * @deprecated Interface CoreShop\Bundle\StoreBundle\Theme\ThemeHelperInterface is deprecated since version 2.1.0 and will be removed in 3.0.0. Use CoreShop\Bundle\ThemeBundle\Service\ThemeHelperInterface class instead.
      */
-    public function useTheme($themeName, \Closure $function);
+    interface ThemeHelperInterface
+    {
+
+    }
 }

--- a/src/CoreShop/Bundle/StoreBundle/Theme/ThemeResolver.php
+++ b/src/CoreShop/Bundle/StoreBundle/Theme/ThemeResolver.php
@@ -12,75 +12,16 @@
 
 namespace CoreShop\Bundle\StoreBundle\Theme;
 
-use CoreShop\Component\Resource\Repository\RepositoryInterface;
-use CoreShop\Component\Store\Context\StoreContextInterface;
-use CoreShop\Component\Store\Context\StoreNotFoundException;
-use CoreShop\Component\Store\Model\StoreInterface;
-use Liip\ThemeBundle\ActiveTheme;
+use CoreShop\Bundle\ThemeBundle\Service\ThemeResolver as NewThemeResolver;
 
-final class ThemeResolver implements ThemeResolverInterface
-{
+if (class_exists(NewThemeResolver::class)) {
+    @trigger_error('Class CoreShop\Bundle\StoreBundle\Theme\ThemeResolver is deprecated since version 2.1.0 and will be removed in 3.0.0. Use CoreShop\Bundle\ThemeBundle\Service\ThemeResolver class instead.', E_USER_DEPRECATED);
+} else {
     /**
-     * @var ActiveTheme
+     * @deprecated Class CoreShop\Bundle\StoreBundle\Theme\ThemeResolver is deprecated since version 2.1.0 and will be removed in 3.0.0. Use CoreShop\Bundle\ThemeBundle\Service\ThemeResolver class instead.
      */
-    private $activeTheme;
-
-    /**
-     * @var StoreContextInterface
-     */
-    private $storeContext;
-
-    /**
-     * @var RepositoryInterface
-     */
-    private $storeRepository;
-
-    /**
-     * @param ActiveTheme           $activeTheme
-     * @param StoreContextInterface $storeContext
-     * @param RepositoryInterface   $storeRepository
-     */
-    public function __construct(
-        ActiveTheme $activeTheme,
-        StoreContextInterface $storeContext,
-        RepositoryInterface $storeRepository
-    ) {
-        $this->activeTheme = $activeTheme;
-        $this->storeContext = $storeContext;
-        $this->storeRepository = $storeRepository;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function resolveTheme()
+    class ThemeResolver
     {
-        $themes = [];
 
-        /**
-         * @var StoreInterface $store
-         */
-        foreach ($this->storeRepository->findAll() as $store) {
-            $storeTheme = $store->getTemplate();
-
-            if ($storeTheme) {
-                $themes[] = $storeTheme;
-            }
-        }
-
-        if (!in_array('standard', $themes)) {
-            $themes[] = 'standard';
-        }
-
-        $this->activeTheme->setThemes($themes);
-
-        try {
-            $store = $this->storeContext->getStore();
-
-            if ($theme = $store->getTemplate()) {
-                $this->activeTheme->setName($theme);
-            }
-        } catch (StoreNotFoundException $exception) {
-        }
     }
 }

--- a/src/CoreShop/Bundle/StoreBundle/Theme/ThemeResolverInterface.php
+++ b/src/CoreShop/Bundle/StoreBundle/Theme/ThemeResolverInterface.php
@@ -12,10 +12,16 @@
 
 namespace CoreShop\Bundle\StoreBundle\Theme;
 
-interface ThemeResolverInterface
-{
+use CoreShop\Bundle\ThemeBundle\Service\ThemeResolverInterface as NewThemeResolverInterface;
+
+if (interface_exists(NewThemeResolverInterface::class)) {
+    @trigger_error('Interface CoreShop\Bundle\StoreBundle\Theme\ThemeResolverInterface is deprecated since version 2.1.0 and will be removed in 3.0.0. Use CoreShop\Bundle\ThemeBundle\Service\ThemeResolverInterface class instead.', E_USER_DEPRECATED);
+} else {
     /**
-     * Resolve Theme and set it to ThemeManager.
+     * @deprecated Interface CoreShop\Bundle\StoreBundle\Theme\ThemeResolverInterface is deprecated since version 2.1.0 and will be removed in 3.0.0. Use CoreShop\Bundle\ThemeBundle\Service\ThemeResolverInterface class instead.
      */
-    public function resolveTheme();
+    interface ThemeResolverInterface
+    {
+
+    }
 }

--- a/src/CoreShop/Bundle/ThemeBundle/CoreShopThemeBundle.php
+++ b/src/CoreShop/Bundle/ThemeBundle/CoreShopThemeBundle.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2019 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\ThemeBundle;
+
+use Liip\ThemeBundle\LiipThemeBundle;
+use Pimcore\Extension\Bundle\AbstractPimcoreBundle;
+use Pimcore\HttpKernel\Bundle\DependentBundleInterface;
+use Pimcore\HttpKernel\BundleCollection\BundleCollection;
+
+class CoreShopThemeBundle extends AbstractPimcoreBundle implements DependentBundleInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function registerDependentBundles(BundleCollection $collection)
+    {
+        $collection->addBundle(new LiipThemeBundle(), 1100);
+    }
+}

--- a/src/CoreShop/Bundle/ThemeBundle/DependencyInjection/CoreShopThemeExtension.php
+++ b/src/CoreShop/Bundle/ThemeBundle/DependencyInjection/CoreShopThemeExtension.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2019 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\ThemeBundle\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+class CoreShopThemeExtension extends Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.yml');
+    }
+}

--- a/src/CoreShop/Bundle/ThemeBundle/EventListener/ThemeRequestListener.php
+++ b/src/CoreShop/Bundle/ThemeBundle/EventListener/ThemeRequestListener.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2019 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\ThemeBundle\EventListener;
+
+use CoreShop\Bundle\ThemeBundle\Service\ThemeResolverInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+
+final class ThemeRequestListener
+{
+    /**
+     * @var ThemeResolverInterface
+     */
+    private $themeResolver;
+
+    /**
+     * @param ThemeResolverInterface $themeResolver
+     */
+    public function __construct(ThemeResolverInterface $themeResolver)
+    {
+        $this->themeResolver = $themeResolver;
+    }
+
+    /**
+     * @param GetResponseEvent $event
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        if (!$event->isMasterRequest()) {
+
+            $exception = $event->getRequest()->get('exception', null);
+
+            if (empty($exception)) {
+                return;
+            }
+        }
+
+        $this->themeResolver->resolveTheme();
+    }
+}

--- a/src/CoreShop/Bundle/ThemeBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/ThemeBundle/Resources/config/services.yml
@@ -14,6 +14,7 @@ services:
             - '@liip_theme.active_theme'
 
     coreshop.theme.listener:
+        class: CoreShop\Bundle\ThemeBundle\EventListener\ThemeRequestListener
         arguments:
             - '@coreshop.theme.resolver'
         tags:

--- a/src/CoreShop/Bundle/ThemeBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/ThemeBundle/Resources/config/services.yml
@@ -1,0 +1,20 @@
+services:
+    _defaults:
+        public: true
+
+    coreshop.theme.resolver:
+        class: CoreShop\Bundle\ThemeBundle\Service\ThemeResolver
+        arguments:
+            - '@liip_theme.active_theme'
+
+    coreshop.theme.helper:
+        class: CoreShop\Bundle\ThemeBundle\Service\ThemeHelper
+        arguments:
+            - '@coreshop.theme.resolver'
+            - '@liip_theme.active_theme'
+
+    coreshop.theme.listener:
+        arguments:
+            - '@coreshop.theme.resolver'
+        tags:
+            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }

--- a/src/CoreShop/Bundle/ThemeBundle/Resources/pimcore/config.yml
+++ b/src/CoreShop/Bundle/ThemeBundle/Resources/pimcore/config.yml
@@ -1,0 +1,2 @@
+liip_theme:
+    load_controllers: false

--- a/src/CoreShop/Bundle/ThemeBundle/Service/ThemeHelper.php
+++ b/src/CoreShop/Bundle/ThemeBundle/Service/ThemeHelper.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2019 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\ThemeBundle\Service;
+
+use Liip\ThemeBundle\ActiveTheme;
+
+final class ThemeHelper implements ThemeHelperInterface
+{
+    /**
+     * @var ThemeResolverInterface
+     */
+    private $themeResolver;
+
+    /**
+     * @var ActiveTheme
+     */
+    private $activeTheme;
+
+    /**
+     * @param ThemeResolverInterface $themeResolver
+     * @param ActiveTheme            $activeTheme
+     */
+    public function __construct(
+        ThemeResolverInterface $themeResolver,
+        ActiveTheme $activeTheme
+    ) {
+        $this->themeResolver = $themeResolver;
+        $this->activeTheme = $activeTheme;
+    }
+
+    /**
+     * @param          $themeName
+     * @param \Closure $function
+     * @return mixed
+     */
+    public function useTheme($themeName, \Closure $function)
+    {
+        $this->themeResolver->resolveTheme();
+
+        $backupTheme = $this->activeTheme->getName();
+        $this->activeTheme->setName($themeName);
+
+        $result = $function();
+
+        if (in_array($backupTheme, $this->activeTheme->getThemes())) {
+            $this->activeTheme->setName($backupTheme);
+        } else {
+            $this->activeTheme->setName('standard');
+        }
+
+        return $result;
+    }
+}
+
+class_alias(ThemeHelper::class, 'CoreShop\Bundle\StoreBundle\Theme\ThemeHelper');

--- a/src/CoreShop/Bundle/ThemeBundle/Service/ThemeHelperInterface.php
+++ b/src/CoreShop/Bundle/ThemeBundle/Service/ThemeHelperInterface.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2019 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\ThemeBundle\Service;
+
+interface ThemeHelperInterface
+{
+    /**
+     * @param          $themeName
+     * @param \Closure $function
+     * @return mixed
+     */
+    public function useTheme($themeName, \Closure $function);
+}
+
+class_alias(ThemeHelperInterface::class, 'CoreShop\Bundle\StoreBundle\Theme\ThemeHelperInterface');

--- a/src/CoreShop/Bundle/ThemeBundle/Service/ThemeHelperInterface.php
+++ b/src/CoreShop/Bundle/ThemeBundle/Service/ThemeHelperInterface.php
@@ -15,7 +15,7 @@ namespace CoreShop\Bundle\ThemeBundle\Service;
 interface ThemeHelperInterface
 {
     /**
-     * @param          $themeName
+     * @param string   $themeName
      * @param \Closure $function
      * @return mixed
      */

--- a/src/CoreShop/Bundle/ThemeBundle/Service/ThemeResolver.php
+++ b/src/CoreShop/Bundle/ThemeBundle/Service/ThemeResolver.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2019 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\ThemeBundle\Service;
+
+use Liip\ThemeBundle\ActiveTheme;
+use Pimcore\Model\Site;
+
+final class ThemeResolver implements ThemeResolverInterface
+{
+    /**
+     * @var ActiveTheme
+     */
+    private $activeTheme;
+
+    /**
+     * @param ActiveTheme $activeTheme
+     */
+    public function __construct(
+        ActiveTheme $activeTheme
+    ) {
+        $this->activeTheme = $activeTheme;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolveTheme()
+    {
+        $themes = [];
+        $list = new Site\Listing();
+        $list->load();
+        $sites = $list->getSites();
+
+        /**
+         * @var $site Site
+         */
+        foreach ($sites as $site) {
+            $themes[] = $site->getRootDocument()->getKey();
+        }
+
+        if (!in_array('standard', $themes)) {
+            $themes[] = 'standard';
+        }
+
+        $this->activeTheme->setThemes($themes);
+
+        try {
+            $currentSite = Site::getCurrentSite();
+
+            if ($theme = $currentSite->getRootDocument()->getKey()) {
+                $this->activeTheme->setName($theme);
+            }
+        } catch (\Exception $exception) {
+
+        }
+    }
+}
+
+class_alias(ThemeResolver::class, 'CoreShop\Bundle\StoreBundle\Theme\ThemeResolver');

--- a/src/CoreShop/Bundle/ThemeBundle/Service/ThemeResolver.php
+++ b/src/CoreShop/Bundle/ThemeBundle/Service/ThemeResolver.php
@@ -42,7 +42,7 @@ final class ThemeResolver implements ThemeResolverInterface
         $sites = $list->getSites();
 
         /**
-         * @var $site Site
+         * @var Site $site
          */
         foreach ($sites as $site) {
             $themes[] = $site->getRootDocument()->getKey();

--- a/src/CoreShop/Bundle/ThemeBundle/Service/ThemeResolverInterface.php
+++ b/src/CoreShop/Bundle/ThemeBundle/Service/ThemeResolverInterface.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2019 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\ThemeBundle\Service;
+
+interface ThemeResolverInterface
+{
+    /**
+     * Resolve Theme and set it to ThemeManager
+     */
+    public function resolveTheme();
+}
+
+class_alias(ThemeResolverInterface::class, 'CoreShop\Bundle\StoreBundle\Theme\ThemeResolverInterface');

--- a/src/CoreShop/Bundle/ThemeBundle/composer.json
+++ b/src/CoreShop/Bundle/ThemeBundle/composer.json
@@ -1,7 +1,7 @@
 {
-  "name": "coreshop/store-bundle",
+  "name": "coreshop/theme-bundle",
   "type": "pimcore-bundle",
-  "description": "CoreShop - Store Bundle",
+  "description": "CoreShop - Theme Bundle",
   "keywords": [
     "coreshop",
     "pimcore",
@@ -18,10 +18,7 @@
     }
   ],
   "require": {
-    "coreshop/store": "^2.0",
-    "coreshop/resource-bundle": "^2.0",
-    "coreshop/currency-bundle": "^2.0",
-    "coreshop/theme-bundle": "^2,0",
+    "liip/theme-bundle": "^1.4",
     "pimcore/pimcore": "^5.4.0"
   },
   "config": {
@@ -29,7 +26,7 @@
   },
   "autoload": {
     "psr-4": {
-      "CoreShop\\Bundle\\StoreBundle\\": ""
+      "CoreShop\\Bundle\\ThemeBundle\\": ""
     }
   },
   "minimum-stability": "dev",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes

The aim of this bundle is to help making theming in Pimcore easier.

Which uses pimcore-sites to define the themes. StoreBundle than decorates that and changes that to CoreShop stores. ThemeBundle can now be used for Multisite Projects that have to have multiple themes.

TODO:

 - [ ] Tests