### PR TITLE
WIP: Exiting early in SessionAndStoreBasedContext in order not to start a …

### DIFF
--- a/src/CoreShop/Bundle/OrderBundle/Context/SessionAndStoreBasedCartContext.php
+++ b/src/CoreShop/Bundle/OrderBundle/Context/SessionAndStoreBasedCartContext.php
@@ -64,6 +64,10 @@ final class SessionAndStoreBasedCartContext implements CartContextInterface
      */
     public function getCart()
     {
+        if (!$this->session->isStarted()) {
+            throw new CartNotFoundException("Symfony session has not started yet");
+        }
+
         try {
             $store = $this->storeContext->getStore();
         } catch (StoreNotFoundException $exception) {


### PR DESCRIPTION
…session if has not already been started

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

In one of our projects we had to minimize the sections where a session is started in order to take full advantage of pimcore's page caching. I added a few lines to the `SessionAndStoreBasedContext` to exit early if a session hasn't already been started.