### PR TITLE
[Pimcore] add object_method twig function

### DIFF
--- a/src/CoreShop/Component/Pimcore/Twig/Extension/ObjectHelperExtensions.php
+++ b/src/CoreShop/Component/Pimcore/Twig/Extension/ObjectHelperExtensions.php
@@ -49,6 +49,9 @@ final class ObjectHelperExtensions extends \Twig_Extension
     public function getFunctions()
     {
         return [
+            new \Twig_Function('object_method', function ($object, $methodName) {
+                return is_object($object) && method_exists($object, $methodName);
+            }),
             new \Twig_Function('object_select_options', function ($object, $field) {
                 return DataObject\Service::getOptionsForSelectField($object, $field);
             }),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

Allows to check if object method exists. Native twig implementation `{{ attribute(object, method) is defined }}` sometimes fails and returns `true`, although the method doesn't exist.