### PR TITLE
Update CompositeTracker::trackCheckoutStep

### DIFF
--- a/src/CoreShop/Component/Tracking/Tracker/CompositeTracker.php
+++ b/src/CoreShop/Component/Tracking/Tracker/CompositeTracker.php
@@ -97,7 +97,7 @@ class CompositeTracker implements TrackerInterface
     {
         $cart = $this->extractTrackingData($cart);
 
-        $this->compositeTrackerCall('trackCartRemove', [$cart, $stepIdentifier, $isFirstStep, $checkoutOption]);
+        $this->compositeTrackerCall('trackCheckoutStep', [$cart, $stepIdentifier, $isFirstStep, $checkoutOption]);
     }
 
     /**


### PR DESCRIPTION
- Fixed `trackCheckoutStep` to call `compositeTrackerCall('trackCheckoutStep'...)`  instead of `'trackCartRemove'`

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
