### PR TITLE
[Pimcore] introduce twig placeholder

### DIFF
--- a/docs/02_Components/Pimcore_Component.md
+++ b/docs/02_Components/Pimcore_Component.md
@@ -1,4 +1,4 @@
-# CoreShop Pimcore Component
+f# CoreShop Pimcore Component
 
 ## Features
 
@@ -157,6 +157,7 @@ SharedTranslation::add('key', 'en', 'value');
 ### Placeholder Features
 CoreShop also extends Pimcores Placeholder features with an additional feature to use the Symfony Expression Language.
 
+#### Expression Placeholder
 
 ```
 %Expression(expression, {'expression' : 'parameter(\'kernel.environment\')'});
@@ -173,6 +174,20 @@ CoreShop also extends Pimcores Placeholder features with an additional feature t
 ```
 %Expression(expression, {'expression' : 'service(\'coreshop.money_formatter\').format(100, \'EUR\', \'en\')'});
 ```
+
+#### Twig Placeholder
+
+```
+%Twig(keyOfParams, {'template' : ':Mail/includes:files.html.twig'});
+```
+
+This will render your twig view with following parameters:
+
+ - keyOfParams: valueForKeyOfParams
+ - value: valueForKeyOfParams
+ - config: Placeholder Config
+ - params: all params available in the mail
+ - placeholder: object for the placeholder
 
 ### Routing Features
 

--- a/src/CoreShop/Component/Pimcore/Placeholder/Twig.php
+++ b/src/CoreShop/Component/Pimcore/Placeholder/Twig.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2019 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Component\Pimcore\Placeholder;
+
+use Pimcore\Placeholder\AbstractPlaceholder;
+
+class Twig extends AbstractPlaceholder
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getTestValue()
+    {
+        return '<span class="testValue">Name of the Object</span>';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getReplacement()
+    {
+        $twig = \Pimcore::getContainer()->get('twig');
+        $config = $this->getPlaceholderConfig();
+        $template = $config->get('template');
+
+        return $twig->render($template, [
+            $this->getPlaceholderKey() => $this->getValue(),
+            'value' => $this->getValue(),
+            'key' => $this->getPlaceholderKey(),
+            'config' => $this->getPlaceholderConfig()->toArray(),
+            'params' => $this->getParams(),
+            'placeholder' => $this,
+        ]);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

Allows that in Mail Documents:

```
%Twig(files, {'template' : ':Mail/includes:files.html.twig'});
```

The corresponding template looks like that:

```twig
<ul>
    {% for file in files if file is asset %}
        <li><a href="{{ file }}">{{ file.getFilename }}</a></li>
    {% endfor %}
</ul>
```