### PR TITLE
fix layout crash if price rule is inactive

### DIFF
--- a/src/CoreShop/Bundle/ProductBundle/Resources/public/pimcore/js/specificprice/object/item.js
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/public/pimcore/js/specificprice/object/item.js
@@ -24,10 +24,8 @@ coreshop.product.specificprice.object.item = Class.create(coreshop.rules.item, {
             forceLayout: true,
             iconCls: this.iconCls,
             items: this.getItems(),
-            listeners: {
-                added: function (panel) {
-                    panel.setTitle(this.generatePanelTitle(this.data.name, this.data.active));
-                }.bind(this)
+            tabConfig: {
+                html: this.generatePanelTitle(this.data.name, this.data.active)
             }
         });
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | --

This has been fixed in 2.1 but not in 2.0.x. 
