### PR TITLE
Address Redirect Fix

### DIFF
--- a/src/CoreShop/Bundle/FrontendBundle/Controller/CustomerController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/CustomerController.php
@@ -178,7 +178,7 @@ class CustomerController extends FrontendController
 
                 $this->addFlash('success', $this->get('translator')->trans(sprintf('coreshop.ui.customer.address_successfully_%s', $eventType === 'add' ? 'added' : 'updated')));
 
-                return $this->redirect($handledForm->get('_redirect')->getData() ?: $this->generateCoreShopUrl($customer, 'coreshop_customer_addresses'));
+                return $this->redirect($request->get('_redirect', $this->generateCoreShopUrl($customer, 'coreshop_customer_addresses')));
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | yes/no
| Fixed tickets | --

This PR fixes the `_redirect` flag in address checkout which currently is bypassed due the `mapped`form configuration flag.