### PR TITLE
Fixed not passing full configuration for Store based Mail.

### DIFF
--- a/src/CoreShop/Component/Core/Notification/Rule/Action/Order/StoreMailActionProcessor.php
+++ b/src/CoreShop/Component/Core/Notification/Rule/Action/Order/StoreMailActionProcessor.php
@@ -55,9 +55,10 @@ class StoreMailActionProcessor implements NotificationRuleProcessorInterface
         }
 
         if (array_key_exists($store->getId(), $mails)) {
-            $this->mailActionProcessor->apply($subject, $rule, [
-                'mails' => $mails[$store->getId()],
-            ], $params);
+            $subConfiguration          = $configuration;
+            $subConfiguration['mails'] = $mails[$store->getId()];
+
+            $this->mailActionProcessor->apply($subject, $rule, $subConfiguration, $params);
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

'Do not send to designated recipient' option is ignored for 'Store based Mail'.
This PR should fix this.

