### PR TITLE
[CoreBundle] don't persist the cart on user-login event

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/EventListener/CartBlamerListener.php
+++ b/src/CoreShop/Bundle/CoreBundle/EventListener/CartBlamerListener.php
@@ -17,14 +17,15 @@ use CoreShop\Component\Core\Model\CustomerInterface;
 use CoreShop\Component\Order\Context\CartContextInterface;
 use CoreShop\Component\Order\Manager\CartManagerInterface;
 use CoreShop\Component\Order\Model\CartInterface;
+use CoreShop\Component\Order\Processor\CartProcessorInterface;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 
 final class CartBlamerListener
 {
     /**
-     * @var CartManagerInterface
+     * @var CartProcessorInterface
      */
-    private $cartManager;
+    private $cartProcessor;
 
     /**
      * @var CartContextInterface
@@ -32,12 +33,12 @@ final class CartBlamerListener
     private $cartContext;
 
     /**
-     * @param CartManagerInterface $cartManager
+     * @param CartProcessorInterface $cartProcessor
      * @param CartContextInterface $cartContext
      */
-    public function __construct(CartManagerInterface $cartManager, CartContextInterface $cartContext)
+    public function __construct(CartProcessorInterface $cartProcessor, CartContextInterface $cartContext)
     {
-        $this->cartManager = $cartManager;
+        $this->cartProcessor = $cartProcessor;
         $this->cartContext = $cartContext;
     }
 
@@ -89,7 +90,7 @@ final class CartBlamerListener
             $cart->setInvoiceAddress($user->getDefaultAddress());
         }
 
-        $this->cartManager->persistCart($cart);
+        $this->cartProcessor->process($cart);
     }
 
     /**

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services/listeners.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services/listeners.yml
@@ -5,7 +5,7 @@ services:
     coreshop.listener.cart_blamer:
         class: CoreShop\Bundle\CoreBundle\EventListener\CartBlamerListener
         arguments:
-            - '@coreshop.cart.manager'
+            - '@coreshop.cart_processor'
             - '@coreshop.context.cart'
         tags:
             - { name: kernel.event_listener, event: security.interactive_login, method: onInteractiveLogin }


### PR DESCRIPTION
only recalculate it. Persist happens when customer adds items or goes into checkout anyway

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #920 

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->
