### PR TITLE
Get Last Customer Cart in CartBlamer

### DIFF
--- a/docs/03_Development/04_Cart/06_Context.md
+++ b/docs/03_Development/04_Cart/06_Context.md
@@ -23,7 +23,6 @@ $cart = $cartContext->getCart();
 |------|----------|------------|
 | [FixedCartContext](https://github.com/coreshop/CoreShop/blob/master/src/CoreShop/Component/Order/Context/FixedCartContext.php) | -100 | Used for testing purposes or for backend order creation |
 | [SessionAndStoreBasedCartContext](https://github.com/coreshop/CoreShop/blob/master/src/CoreShop/Bundle/OrderBundle/Context/SessionAndStoreBasedCartContext.php) | -555 | Search for a valid session cart in given store context |
-| [CustomerAndStoreBasedCartContext](https://github.com/coreshop/CoreShop/blob/master/src/CoreShop/Bundle/OrderBundle/Context/CustomerAndStoreBasedCartContext.php) | -777 | Search for a cart based on a customer. **Note**: This context only triggers after a user has been successfully logged in. It searches for the last available cart a user may has left. |
 | [CartContext](https://github.com/coreshop/CoreShop/blob/master/src/CoreShop/Component/Order/Context/CartContext.php) | -999 | If all other context classes failed finally this context will create a fresh cart |
 
 

--- a/src/CoreShop/Bundle/CoreBundle/EventListener/CartBlamerListener.php
+++ b/src/CoreShop/Bundle/CoreBundle/EventListener/CartBlamerListener.php
@@ -126,6 +126,11 @@ final class CartBlamerListener
      */
     protected function getCart()
     {
+        $contextCart = $this->cartContext->getCart();
+        if ($contextCart instanceof CartInterface && !empty($contextCart->getId())) {
+            return $contextCart;
+        }
+
         $customerCart = $this->customerCartProvider->provide();
         if ($customerCart instanceof CartInterface) {
             $this->injectCustomerCartToSession($customerCart);

--- a/src/CoreShop/Bundle/CoreBundle/Provider/CustomerCartProvider.php
+++ b/src/CoreShop/Bundle/CoreBundle/Provider/CustomerCartProvider.php
@@ -10,84 +10,64 @@
  * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
  */
 
-namespace CoreShop\Bundle\OrderBundle\Context;
+namespace CoreShop\Bundle\CoreBundle\Provider;
 
 use CoreShop\Component\Customer\Context\CustomerContextInterface;
 use CoreShop\Component\Customer\Context\CustomerNotFoundException;
-use CoreShop\Component\Order\Context\CartContextInterface;
-use CoreShop\Component\Order\Context\CartNotFoundException;
 use CoreShop\Component\Order\Repository\CartRepositoryInterface;
 use CoreShop\Component\Store\Context\StoreContextInterface;
 use CoreShop\Component\Store\Context\StoreNotFoundException;
-use Pimcore\Http\RequestHelper;
 
-final class CustomerAndStoreBasedCartContext implements CartContextInterface
+final class CustomerCartProvider implements CustomerCartProviderInterface
 {
     /**
      * @var CustomerContextInterface
      */
-    private $customerContext;
+    protected $customerContext;
 
     /**
      * @var StoreContextInterface
      */
-    private $storeContext;
+    protected $storeContext;
 
     /**
      * @var CartRepositoryInterface
      */
-    private $cartRepository;
-
-    /**
-     * @var RequestHelper
-     */
-    private $pimcoreRequestHelper;
+    protected $cartRepository;
 
     /**
      * @param CustomerContextInterface $customerContext
      * @param StoreContextInterface    $storeContext
      * @param CartRepositoryInterface  $cartRepository
-     * @param RequestHelper            $pimcoreRequestHelper
      */
     public function __construct(
         CustomerContextInterface $customerContext,
         StoreContextInterface $storeContext,
-        CartRepositoryInterface $cartRepository,
-        RequestHelper $pimcoreRequestHelper
+        CartRepositoryInterface $cartRepository
     ) {
         $this->customerContext = $customerContext;
         $this->storeContext = $storeContext;
         $this->cartRepository = $cartRepository;
-        $this->pimcoreRequestHelper = $pimcoreRequestHelper;
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
-    public function getCart()
+    public function provide()
     {
-        if ($this->pimcoreRequestHelper->hasMasterRequest()) {
-            if ($this->pimcoreRequestHelper->getMasterRequest()->get('_route') !== 'coreshop_login_check') {
-                throw new CartNotFoundException('CustomerAndStoreBasedCartContext can only be applied in coreshop_login_check route.');
-            }
-        }
-
         try {
             $store = $this->storeContext->getStore();
         } catch (StoreNotFoundException $exception) {
-            throw new CartNotFoundException('CoreShop was not able to find the cart, as there is no current store.');
+            return null;
         }
 
         try {
             $customer = $this->customerContext->getCustomer();
         } catch (CustomerNotFoundException $exception) {
-            throw new CartNotFoundException('CoreShop was not able to find the cart, as there is no logged in user.');
+            return null;
         }
 
         $cart = $this->cartRepository->findLatestByStoreAndCustomer($store, $customer);
-        if (null === $cart) {
-            throw new CartNotFoundException('CoreShop was not able to find the cart for currently logged in user.');
-        }
 
         return $cart;
     }

--- a/src/CoreShop/Bundle/CoreBundle/Provider/CustomerCartProviderInterface.php
+++ b/src/CoreShop/Bundle/CoreBundle/Provider/CustomerCartProviderInterface.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2019 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\CoreBundle\Provider;
+
+use CoreShop\Component\Order\Model\CartInterface;
+
+interface CustomerCartProviderInterface
+{
+    /**
+     * @return CartInterface|null
+     */
+    public function provide();
+}

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services.yml
@@ -24,6 +24,7 @@ imports:
     - { resource: "services/payment.yml" }
     - { resource: "services/grid_config.yml" }
     - { resource: "services/routing.yml" }
+    - { resource: "services/provider.yml" }
 
 services:
     _defaults:

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services/listeners.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services/listeners.yml
@@ -5,8 +5,11 @@ services:
     coreshop.listener.cart_blamer:
         class: CoreShop\Bundle\CoreBundle\EventListener\CartBlamerListener
         arguments:
+            - '@request_stack'
             - '@coreshop.cart.manager'
             - '@coreshop.context.cart'
+            - '@coreshop.provider.cart.customer_cart'
+            - '%coreshop.session.cart%'
         tags:
             - { name: kernel.event_listener, event: security.interactive_login, method: onInteractiveLogin }
             - { name: kernel.event_listener, event: coreshop.customer.register, method: onRegisterEvent }

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services/provider.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services/provider.yml
@@ -1,0 +1,10 @@
+services:
+    _defaults:
+        public: true
+
+    coreshop.provider.cart.customer_cart:
+        class: CoreShop\Bundle\CoreBundle\Provider\CustomerCartProvider
+        arguments:
+            - '@coreshop.context.customer'
+            - '@coreshop.context.store'
+            - '@coreshop.repository.cart'

--- a/src/CoreShop/Bundle/OrderBundle/Resources/config/services/context.yml
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/config/services/context.yml
@@ -7,16 +7,6 @@ services:
         tags:
             - { name: coreshop.context.cart, priority: -100 }
 
-    coreshop.context.cart.customer_and_store_based:
-        class: CoreShop\Bundle\OrderBundle\Context\CustomerAndStoreBasedCartContext
-        arguments:
-            - '@coreshop.context.customer'
-            - '@coreshop.context.store'
-            - '@coreshop.repository.cart'
-            - '@pimcore.http.request_helper'
-        tags:
-            - { name: coreshop.context.cart, priority: -777 }
-
     coreshop.context.cart.session_based:
         class: CoreShop\Bundle\OrderBundle\Context\SessionAndStoreBasedCartContext
         arguments:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | --

This PR will resolve the customer cart context issue.

If a user logs in, the cart-blamer will check for a customer related cart from history by using the `CustomerCartProvider` service. If found, the cart will be injected into session, so the default cart context will return the "history cart" via `SessionAndStoreBasedCartContext`.