### PR TITLE
[Translations] allow some translations to be null

### DIFF
--- a/src/CoreShop/Bundle/AddressBundle/Resources/config/doctrine/model/CountryTranslation.orm.yml
+++ b/src/CoreShop/Bundle/AddressBundle/Resources/config/doctrine/model/CountryTranslation.orm.yml
@@ -11,6 +11,7 @@ CoreShop\Component\Address\Model\CountryTranslation:
         name:
             type: string
             column: name
+            nullable: true
         creationDate:
             type: date
             gedmo:

--- a/src/CoreShop/Bundle/AddressBundle/Resources/config/doctrine/model/StateTranslation.orm.yml
+++ b/src/CoreShop/Bundle/AddressBundle/Resources/config/doctrine/model/StateTranslation.orm.yml
@@ -11,6 +11,7 @@ CoreShop\Component\Address\Model\StateTranslation:
         name:
             type: string
             column: name
+            nullable: true
         creationDate:
             type: date
             gedmo:

--- a/src/CoreShop/Bundle/CoreBundle/Migrations/Version20190410183520.php
+++ b/src/CoreShop/Bundle/CoreBundle/Migrations/Version20190410183520.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2019 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+class Version20190410183520 extends AbstractPimcoreMigration implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql('
+            ALTER TABLE coreshop_country_translation CHANGE name name VARCHAR(255) DEFAULT NULL;
+            ALTER TABLE coreshop_state_translation CHANGE name name VARCHAR(255) DEFAULT NULL;
+            ALTER TABLE coreshop_tax_rate_translation CHANGE name name VARCHAR(255) DEFAULT NULL;
+        ');
+
+        $this->container->get('pimcore.cache.core.handler')->clearTag('doctrine_pimcore_cache');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+    }
+}

--- a/src/CoreShop/Bundle/TaxationBundle/Resources/config/doctrine/model/TaxRateTranslation.orm.yml
+++ b/src/CoreShop/Bundle/TaxationBundle/Resources/config/doctrine/model/TaxRateTranslation.orm.yml
@@ -11,6 +11,7 @@ CoreShop\Component\Taxation\Model\TaxRateTranslation:
         name:
             type: string
             column: name
+            nullable: true
         creationDate:
             type: datetime
             gedmo:


### PR DESCRIPTION
changed how translations are created if there is none -> CoreShop creates one but if you don't set any value, it might be null. This is not a problem per se, but it is when using relations to it where you have to have a translation cause null is not allowed. This is the case with the store->country relation

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #940 

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->
