### PR TITLE
allow one-step ranges

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Form/Extension/ProductQuantityRangeCollectionTypeExtension.php
+++ b/src/CoreShop/Bundle/CoreBundle/Form/Extension/ProductQuantityRangeCollectionTypeExtension.php
@@ -80,7 +80,7 @@ class ProductQuantityRangeCollectionTypeExtension extends AbstractTypeExtension
                     } elseif ((int) $from < 0) {
                         $form->addError(new FormError('Field "from" in row ' . $realRowIndex . '  needs to be greater or equal than 0'));
                         break;
-                    } elseif ((int) $from <= $lastEnd) {
+                    } elseif ((int) $from < $lastEnd) {
                         $form->addError(new FormError('Field "from" in row ' . $realRowIndex . '  needs to be greater than ' . $lastEnd));
                         break;
                     }
@@ -88,7 +88,7 @@ class ProductQuantityRangeCollectionTypeExtension extends AbstractTypeExtension
                     if (!is_numeric($to)) {
                         $form->addError(new FormError('Field "to" in row ' . $realRowIndex . ' needs to be numeric'));
                         break;
-                    } elseif ((int) $to <= $from) {
+                    } elseif ((int) $to < $from) {
                         $form->addError(new FormError('Field "to" in row ' . $realRowIndex . '  needs to be greater than ' . $from));
                         break;
                     }

--- a/src/CoreShop/Component/ProductQuantityPriceRules/Calculator/VolumeCalculator.php
+++ b/src/CoreShop/Component/ProductQuantityPriceRules/Calculator/VolumeCalculator.php
@@ -112,11 +112,17 @@ class VolumeCalculator implements CalculatorInterface
 
         $cheapestRangePrice = null;
         /** @var QuantityRangeInterface $range */
-        foreach ($ranges as $range) {
-            if ($range->getRangeFrom() > $quantity) {
+        foreach ($ranges as $index => $range) {
+            // if last range and quantity is greater: count!
+            if ($index + 1 === count($ranges) && $quantity > $range->getRangeTo()) {
+                $cheapestRangePrice = $range;
                 break;
             }
-            $cheapestRangePrice = $range;
+
+            if ($range->getRangeFrom() <= $quantity && $quantity <= $range->getRangeTo()) {
+                $cheapestRangePrice = $range;
+                break;
+            }
         }
 
         return $cheapestRangePrice;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | --

Currently, 1-Step Ranges are not possible (0-1, 1-2). This PR fixes that.