### PR TITLE
[Pimcore] make coreshop compatible with Pimcore 5.8

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Form/Type/AddressChoiceType.php
+++ b/src/CoreShop/Bundle/CoreBundle/Form/Type/AddressChoiceType.php
@@ -65,7 +65,7 @@ final class AddressChoiceType extends AbstractType
                         });
 
                     },
-                    'choice_value' => 'o_id',
+                    'choice_value' => 'id',
                     'choice_label' => function ($address) {
                         if ($address instanceof AddressInterface) {
                             return sprintf('%s %s', $address->getStreet(), $address->getNumber());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Since DataObject Properties are not public anymore, Symfony throws an exception that the property is not accessable