### PR TITLE
[WIP] refactor pimcore object data-tags to use DI for dependencies

### DIFF
--- a/src/CoreShop/Bundle/AddressBundle/CoreExtension/AddressIdentifier.php
+++ b/src/CoreShop/Bundle/AddressBundle/CoreExtension/AddressIdentifier.php
@@ -12,30 +12,6 @@
 
 namespace CoreShop\Bundle\AddressBundle\CoreExtension;
 
-use CoreShop\Bundle\ResourceBundle\CoreExtension\Select;
+use CoreShop\Bundle\ResourceBundle\CoreExtension\DataObject\ResourceSelect;
 
-class AddressIdentifier extends Select
-{
-    /**
-     * Static type of this element.
-     *
-     * @var string
-     */
-    public $fieldtype = 'coreShopAddressIdentifier';
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getRepository()
-    {
-        return \Pimcore::getContainer()->get('coreshop.repository.address_identifier');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getModel()
-    {
-        return \Pimcore::getContainer()->getParameter('coreshop.model.address_identifier.class');
-    }
-}
+class_alias(ResourceSelect::class, 'CoreShop\Bundle\AddressBundle\CoreExtension\AddressIdentifier');

--- a/src/CoreShop/Bundle/AddressBundle/CoreExtension/Country.php
+++ b/src/CoreShop/Bundle/AddressBundle/CoreExtension/Country.php
@@ -12,30 +12,6 @@
 
 namespace CoreShop\Bundle\AddressBundle\CoreExtension;
 
-use CoreShop\Bundle\ResourceBundle\CoreExtension\Select;
+use CoreShop\Bundle\ResourceBundle\CoreExtension\DataObject\ResourceSelect;
 
-class Country extends Select
-{
-    /**
-     * Static type of this element.
-     *
-     * @var string
-     */
-    public $fieldtype = 'coreShopCountry';
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getRepository()
-    {
-        return \Pimcore::getContainer()->get('coreshop.repository.country');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getModel()
-    {
-        return \Pimcore::getContainer()->getParameter('coreshop.model.country.class');
-    }
-}
+class_alias(ResourceSelect::class, 'CoreShop\Bundle\AddressBundle\CoreExtension\Country');

--- a/src/CoreShop/Bundle/AddressBundle/CoreExtension/CountryMultiselect.php
+++ b/src/CoreShop/Bundle/AddressBundle/CoreExtension/CountryMultiselect.php
@@ -12,14 +12,6 @@
 
 namespace CoreShop\Bundle\AddressBundle\CoreExtension;
 
-use CoreShop\Bundle\ResourceBundle\CoreExtension\Multiselect;
+use CoreShop\Bundle\ResourceBundle\CoreExtension\DataObject\ResourceMultiselect;
 
-class CountryMultiselect extends Multiselect
-{
-    /**
-     * Static type of this element.
-     *
-     * @var string
-     */
-    public $fieldtype = 'coreShopCountryMultiselect';
-}
+class_alias(ResourceMultiselect::class, 'CoreShop\Bundle\AddressBundle\CoreExtension\CountryMultiselect');

--- a/src/CoreShop/Bundle/AddressBundle/CoreExtension/State.php
+++ b/src/CoreShop/Bundle/AddressBundle/CoreExtension/State.php
@@ -12,30 +12,6 @@
 
 namespace CoreShop\Bundle\AddressBundle\CoreExtension;
 
-use CoreShop\Bundle\ResourceBundle\CoreExtension\Select;
+use CoreShop\Bundle\ResourceBundle\CoreExtension\DataObject\ResourceSelect;
 
-class State extends Select
-{
-    /**
-     * Static type of this element.
-     *
-     * @var string
-     */
-    public $fieldtype = 'coreShopState';
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getRepository()
-    {
-        return \Pimcore::getContainer()->get('coreshop.repository.state');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getModel()
-    {
-        return \Pimcore::getContainer()->getParameter('coreshop.model.state.class');
-    }
-}
+class_alias(ResourceSelect::class, 'CoreShop\Bundle\AddressBundle\CoreExtension\State');

--- a/src/CoreShop/Bundle/AddressBundle/Resources/config/pimcore/config.yml
+++ b/src/CoreShop/Bundle/AddressBundle/Resources/config/pimcore/config.yml
@@ -1,16 +1,6 @@
 imports:
     - { resource: "admin.yml" }
 
-pimcore:
-    objects:
-        class_definitions:
-            data:
-                map:
-                    coreShopCountry: CoreShop\Bundle\AddressBundle\CoreExtension\Country
-                    coreShopState: CoreShop\Bundle\AddressBundle\CoreExtension\State
-                    coreShopCountryMultiselect: CoreShop\Bundle\AddressBundle\CoreExtension\CountryMultiselect
-                    coreShopAddressIdentifier: CoreShop\Bundle\AddressBundle\CoreExtension\AddressIdentifier
-
 jms_serializer:
     metadata:
         directories:

--- a/src/CoreShop/Bundle/AddressBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/AddressBundle/Resources/config/services.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: 'services/form.yml' }
     - { resource: 'services/profiler.yml' }
     - { resource: 'services/pimcore.yml' }
+    - { resource: 'services/core_extension.yml' }
 
 services:
     _defaults:

--- a/src/CoreShop/Bundle/AddressBundle/Resources/config/services/core_extension.yml
+++ b/src/CoreShop/Bundle/AddressBundle/Resources/config/services/core_extension.yml
@@ -1,0 +1,34 @@
+services:
+    coreshop.core_extension.address.address_identifier:
+        class: CoreShop\Component\Resource\Pimcore\ResourceSelectObjectTagFactory
+        arguments:
+            - '%coreshop.model.address_identifier.class%'
+            - '@coreshop.repository.address_identifier'
+        tags:
+            - { name: coreshop.pimcore.data_object.data, type: coreShopAddressIdentifier }
+
+
+    coreshop.core_extension.address.country:
+        class: CoreShop\Component\Resource\Pimcore\ResourceSelectObjectTagFactory
+        arguments:
+            - '%coreshop.model.country.class%'
+            - '@coreshop.repository.country'
+        tags:
+            - { name: coreshop.pimcore.data_object.data, type: coreShopCountry }
+
+    coreshop.core_extension.address.country_multiselect:
+        class: CoreShop\Component\Resource\Pimcore\ResourceMultiselectObjectTagFactory
+        arguments:
+            - '%coreshop.model.country.class%'
+            - '@coreshop.repository.country'
+        tags:
+            - { name: coreshop.pimcore.data_object.data, type: coreShopCountryMultiselect }
+
+
+    coreshop.core_extension.address.state:
+        class: CoreShop\Component\Resource\Pimcore\ResourceSelectObjectTagFactory
+        arguments:
+            - '%coreshop.model.state.class%'
+            - '@coreshop.repository.state'
+        tags:
+            - { name: coreshop.pimcore.data_object.data, type: coreShopState }

--- a/src/CoreShop/Bundle/AddressBundle/Resources/config/services/pimcore.yml
+++ b/src/CoreShop/Bundle/AddressBundle/Resources/config/services/pimcore.yml
@@ -3,28 +3,25 @@ services:
         public: true
 
     coreshop.pimcore.document.tag.country:
-        class: CoreShop\Component\Resource\Pimcore\ResourceDocumentTagFactory
+        class: CoreShop\Component\Resource\Pimcore\ResourceSelectDocumentTagFactory
         arguments:
-            - 'CoreShop\Bundle\ResourceBundle\CoreExtension\Document\Select'
-            - 'coreshop.repository.country'
+            - '@coreshop.repository.country'
             - 'name'
         tags:
             - { name: coreshop.pimcore.document.tag, type: coreshop_country }
 
     coreshop.pimcore.document.tag.state:
-        class: CoreShop\Component\Resource\Pimcore\ResourceDocumentTagFactory
+        class: CoreShop\Component\Resource\Pimcore\ResourceSelectDocumentTagFactory
         arguments:
-            - 'CoreShop\Bundle\ResourceBundle\CoreExtension\Document\Select'
-            - 'coreshop.repository.state'
+            - '@coreshop.repository.state'
             - 'name'
         tags:
             - { name: coreshop.pimcore.document.tag, type: coreshop_state }
 
     coreshop.pimcore.document.tag.zone:
-        class: CoreShop\Component\Resource\Pimcore\ResourceDocumentTagFactory
+        class: CoreShop\Component\Resource\Pimcore\ResourceSelectDocumentTagFactory
         arguments:
-            - 'CoreShop\Bundle\ResourceBundle\CoreExtension\Document\Select'
-            - 'coreshop.repository.zone'
+            - '@coreshop.repository.zone'
             - 'name'
         tags:
             - { name: coreshop.pimcore.document.tag, type: coreshop_zone }

--- a/src/CoreShop/Bundle/CoreBundle/CoreExtension/Factory/StorePriceFactory.php
+++ b/src/CoreShop/Bundle/CoreBundle/CoreExtension/Factory/StorePriceFactory.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2019 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\CoreBundle\CoreExtension\Factory;
+
+use CoreShop\Bundle\CoreBundle\CoreExtension\StorePrice;
+use CoreShop\Component\Core\Repository\ProductStorePriceRepositoryInterface;
+use CoreShop\Component\Pimcore\DataObject\ObjectDataFactoryInterface;
+use CoreShop\Component\Resource\Factory\FactoryInterface;
+use CoreShop\Component\Store\Repository\StoreRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+
+class StorePriceFactory implements ObjectDataFactoryInterface
+{
+    /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    /**
+     * @var FactoryInterface
+     */
+    private $factory;
+
+    /**
+     * @var StoreRepositoryInterface
+     */
+    private $storeRepository;
+
+    /**
+     * @var ProductStorePriceRepositoryInterface
+     */
+    private $productStorePriceRepository;
+
+    /**
+     * @param EntityManagerInterface               $entityManager
+     * @param FactoryInterface                     $factory
+     * @param StoreRepositoryInterface             $storeRepository
+     * @param ProductStorePriceRepositoryInterface $productStorePriceRepository
+     */
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        FactoryInterface $factory,
+        StoreRepositoryInterface $storeRepository,
+        ProductStorePriceRepositoryInterface $productStorePriceRepository
+    ) {
+        $this->entityManager = $entityManager;
+        $this->factory = $factory;
+        $this->storeRepository = $storeRepository;
+        $this->productStorePriceRepository = $productStorePriceRepository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create($type, $params)
+    {
+        return new StorePrice(
+            $this->entityManager,
+            $this->factory,
+            $this->storeRepository,
+            $this->productStorePriceRepository
+        );
+    }
+}

--- a/src/CoreShop/Bundle/CoreBundle/CoreExtension/Factory/StoreValuesFactory.php
+++ b/src/CoreShop/Bundle/CoreBundle/CoreExtension/Factory/StoreValuesFactory.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2019 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\CoreBundle\CoreExtension\Factory;
+
+use CoreShop\Bundle\CoreBundle\CoreExtension\StoreValues;
+use CoreShop\Component\Core\Repository\ProductStoreValuesRepositoryInterface;
+use CoreShop\Component\Pimcore\DataObject\ObjectDataFactoryInterface;
+use CoreShop\Component\Resource\Factory\FactoryInterface;
+use CoreShop\Component\Store\Repository\StoreRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use JMS\Serializer\SerializerInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+
+class StoreValuesFactory implements ObjectDataFactoryInterface
+{
+    /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    /**
+     * @var FactoryInterface
+     */
+    private $factory;
+
+    /**
+     * @var StoreRepositoryInterface
+     */
+    private $storeRepository;
+
+    /**
+     * @var ProductStoreValuesRepositoryInterface
+     */
+    private $productStoreValuesRepository;
+
+    /**
+     * @var FormFactoryInterface
+     */
+    private $formFactory;
+
+    /**
+     * @var SerializerInterface
+     */
+    private $serializer;
+
+    /**
+     * @param EntityManagerInterface                $entityManager
+     * @param FactoryInterface                      $factory
+     * @param StoreRepositoryInterface              $storeRepository
+     * @param ProductStoreValuesRepositoryInterface $productStoreValuesRepository
+     * @param FormFactoryInterface                  $formFactory
+     * @param SerializerInterface                   $serializer
+     */
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        FactoryInterface $factory,
+        StoreRepositoryInterface $storeRepository,
+        ProductStoreValuesRepositoryInterface $productStoreValuesRepository,
+        FormFactoryInterface $formFactory,
+        SerializerInterface $serializer
+    ) {
+        $this->entityManager = $entityManager;
+        $this->factory = $factory;
+        $this->storeRepository = $storeRepository;
+        $this->productStoreValuesRepository = $productStoreValuesRepository;
+        $this->formFactory = $formFactory;
+        $this->serializer = $serializer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create($type, $params)
+    {
+        return new StoreValues(
+            $this->entityManager,
+            $this->factory,
+            $this->storeRepository,
+            $this->productStoreValuesRepository,
+            $this->formFactory,
+            $this->serializer
+        );
+    }
+}

--- a/src/CoreShop/Bundle/CoreBundle/CoreExtension/StorePrice.php
+++ b/src/CoreShop/Bundle/CoreBundle/CoreExtension/StorePrice.php
@@ -12,14 +12,19 @@
 
 namespace CoreShop\Bundle\CoreBundle\CoreExtension;
 
+use CoreShop\Bundle\ResourceBundle\CoreExtension\DataObject\DISetStateTrait;
 use CoreShop\Component\Core\Model\ProductStorePriceInterface;
 use CoreShop\Component\Core\Model\StoreInterface;
 use CoreShop\Component\Core\Repository\ProductStorePriceRepositoryInterface;
+use CoreShop\Component\Resource\Factory\FactoryInterface;
 use CoreShop\Component\Store\Repository\StoreRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
 use Pimcore\Model;
 
 class StorePrice extends Model\DataObject\ClassDefinition\Data implements Model\DataObject\ClassDefinition\Data\CustomResourcePersistingInterface
 {
+    use DISetStateTrait;
+
     /**
      * Static type of this element.
      *
@@ -53,6 +58,68 @@ class StorePrice extends Model\DataObject\ClassDefinition\Data implements Model\
      * @var float
      */
     public $maxValue;
+
+    /**
+     * @param EntityManagerInterface               $entityManager
+     * @param FactoryInterface                     $factory
+     * @param StoreRepositoryInterface             $storeRepository
+     * @param ProductStorePriceRepositoryInterface $productStorePriceRepository
+     */
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        FactoryInterface $factory,
+        StoreRepositoryInterface $storeRepository,
+        ProductStorePriceRepositoryInterface $productStorePriceRepository
+    ) {
+        $this->entityManager($entityManager);
+        $this->factory($factory);
+        $this->storeRepository($storeRepository);
+        $this->productStorePriceRepository($productStorePriceRepository);
+    }
+
+    private function entityManager(EntityManagerInterface $newValue = null)
+    {
+        static $value;
+
+        if ($newValue !== null) {
+            $value = $newValue;
+        }
+
+        return $value;
+    }
+
+    private function factory(FactoryInterface $newValue = null)
+    {
+        static $value;
+
+        if ($newValue !== null) {
+            $value = $newValue;
+        }
+
+        return $value;
+    }
+
+    private function storeRepository(StoreRepositoryInterface $newValue = null)
+    {
+        static $value;
+
+        if ($newValue !== null) {
+            $value = $newValue;
+        }
+
+        return $value;
+    }
+
+    private function productStorePriceRepository(ProductStorePriceRepositoryInterface $newValue = null)
+    {
+        static $value;
+
+        if ($newValue !== null) {
+            $value = $newValue;
+        }
+
+        return $value;
+    }
 
     /**
      * @return int
@@ -252,7 +319,7 @@ class StorePrice extends Model\DataObject\ClassDefinition\Data implements Model\
     public function load($object, $params = [])
     {
         if (isset($params['force']) && $params['force']) {
-            $prices = $this->getProductStorePriceRepository()->findForProductAndProperty($object, $this->getName());
+            $prices = $this->productStorePriceRepository()->findForProductAndProperty($object, $this->getName());
             $data = [];
 
             /**
@@ -273,10 +340,10 @@ class StorePrice extends Model\DataObject\ClassDefinition\Data implements Model\
      */
     public function save($object, $params = [])
     {
-        $em = \Pimcore::getContainer()->get('coreshop.manager.product_store_price');
-        $factory = \Pimcore::getContainer()->get('coreshop.factory.product_store_price');
-        $repo = $this->getProductStorePriceRepository();
-        $storeRepo = $this->getStoreRepository();
+        $em = $this->entityManager();
+        $factory = $this->factory();
+        $repo = $this->productStorePriceRepository();
+        $storeRepo = $this->storeRepository();
 
         $data = $this->getDataFromObjectParam($object, $params);
 
@@ -327,8 +394,8 @@ class StorePrice extends Model\DataObject\ClassDefinition\Data implements Model\
      */
     public function delete($object, $params = [])
     {
-        $em = \Pimcore::getContainer()->get('coreshop.manager.product_store_price');
-        $repo = $this->getProductStorePriceRepository();
+        $em = $this->entityManager();
+        $repo = $this->productStorePriceRepository();
 
         $storePrices = $repo->findForProductAndProperty($object, $this->getName());
 
@@ -346,8 +413,8 @@ class StorePrice extends Model\DataObject\ClassDefinition\Data implements Model\
      */
     public function getDataForEditmode($data, $object = null, $params = [])
     {
-        $stores = $this->getStoreRepository()->findAll();
-        $prices = $this->getProductStorePriceRepository()->findForProductAndProperty($object, $this->getName());
+        $stores = $this->storeRepository()->findAll();
+        $prices = $this->productStorePriceRepository()->findForProductAndProperty($object, $this->getName());
         $storeData = [];
 
         /**
@@ -470,8 +537,8 @@ class StorePrice extends Model\DataObject\ClassDefinition\Data implements Model\
         if (!$object) {
             throw new \Exception('This version of Pimcore is not supported for storePrice import.');
         }
-        $repo = $this->getProductStorePriceRepository();
-        $storeRepo = $this->getStoreRepository();
+        $repo = $this->productStorePriceRepository();
+        $storeRepo = $this->storeRepository();
 
         $data = $importValue == '' ? [] : json_decode($importValue, true);
 
@@ -574,21 +641,5 @@ class StorePrice extends Model\DataObject\ClassDefinition\Data implements Model\
         }
 
         return (float) $value;
-    }
-
-    /**
-     * @return StoreRepositoryInterface
-     */
-    protected function getStoreRepository()
-    {
-        return \Pimcore::getContainer()->get('coreshop.repository.store');
-    }
-
-    /**
-     * @return ProductStorePriceRepositoryInterface
-     */
-    protected function getProductStorePriceRepository()
-    {
-        return \Pimcore::getContainer()->get('coreshop.repository.product_store_price');
     }
 }

--- a/src/CoreShop/Bundle/CoreBundle/CoreExtension/StoreValues.php
+++ b/src/CoreShop/Bundle/CoreBundle/CoreExtension/StoreValues.php
@@ -13,20 +13,24 @@
 namespace CoreShop\Bundle\CoreBundle\CoreExtension;
 
 use CoreShop\Bundle\CoreBundle\Form\Type\Product\ProductStoreValuesType;
+use CoreShop\Bundle\ResourceBundle\CoreExtension\DataObject\DISetStateTrait;
 use CoreShop\Component\Core\Model\ProductInterface;
 use CoreShop\Component\Core\Model\ProductStoreValuesInterface;
 use CoreShop\Component\Core\Model\StoreInterface;
 use CoreShop\Component\Core\Repository\ProductStoreValuesRepositoryInterface;
 use CoreShop\Component\Pimcore\BCLayer\CustomResourcePersistingInterface;
-use CoreShop\Component\Product\Repository\ProductUnitRepositoryInterface;
 use CoreShop\Component\Resource\Factory\FactoryInterface;
 use CoreShop\Component\Store\Repository\StoreRepositoryInterface;
-use Doctrine\ORM\UnitOfWork;
+use Doctrine\ORM\EntityManagerInterface;
 use JMS\Serializer\SerializationContext;
+use JMS\Serializer\SerializerInterface;
 use Pimcore\Model;
+use Symfony\Component\Form\FormFactoryInterface;
 
 class StoreValues extends Model\DataObject\ClassDefinition\Data implements CustomResourcePersistingInterface
 {
+    use DISetStateTrait;
+
     /**
      * @var string
      */
@@ -56,6 +60,96 @@ class StoreValues extends Model\DataObject\ClassDefinition\Data implements Custo
      * @var float
      */
     public $maxValue;
+
+    /**
+     * @param EntityManagerInterface                $entityManager
+     * @param FactoryInterface                      $factory
+     * @param StoreRepositoryInterface              $storeRepository
+     * @param ProductStoreValuesRepositoryInterface $productStoreValuesRepository
+     * @param FormFactoryInterface                  $formFactory
+     * @param SerializerInterface                   $serializer
+     */
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        FactoryInterface $factory,
+        StoreRepositoryInterface $storeRepository,
+        ProductStoreValuesRepositoryInterface $productStoreValuesRepository,
+        FormFactoryInterface $formFactory,
+        SerializerInterface $serializer
+    ) {
+        $this->entityManager($entityManager);
+        $this->factory($factory);
+        $this->storeRepository($storeRepository);
+        $this->productStoreValuesRepository($productStoreValuesRepository);
+        $this->formFactory($formFactory);
+        $this->serializer($serializer);
+    }
+
+    private function entityManager(EntityManagerInterface $newValue = null)
+    {
+        static $value;
+
+        if ($newValue !== null) {
+            $value = $newValue;
+        }
+
+        return $value;
+    }
+
+    private function factory(FactoryInterface $newValue = null)
+    {
+        static $value;
+
+        if ($newValue !== null) {
+            $value = $newValue;
+        }
+
+        return $value;
+    }
+
+    private function storeRepository(StoreRepositoryInterface $newValue = null)
+    {
+        static $value;
+
+        if ($newValue !== null) {
+            $value = $newValue;
+        }
+
+        return $value;
+    }
+
+    private function productStoreValuesRepository(ProductStoreValuesRepositoryInterface $newValue = null)
+    {
+        static $value;
+
+        if ($newValue !== null) {
+            $value = $newValue;
+        }
+
+        return $value;
+    }
+
+    private function formFactory(FormFactoryInterface $newValue = null)
+    {
+        static $value;
+
+        if ($newValue !== null) {
+            $value = $newValue;
+        }
+
+        return $value;
+    }
+
+    private function serializer(SerializerInterface $newValue = null)
+    {
+        static $value;
+
+        if ($newValue !== null) {
+            $value = $newValue;
+        }
+
+        return $value;
+    }
 
     /**
      * @return int
@@ -157,51 +251,53 @@ class StoreValues extends Model\DataObject\ClassDefinition\Data implements Custo
     public function getGetterCode($class)
     {
         $key = $this->getName();
-        $code = '/**' . "\n";
-        $code .= '* Get ' . str_replace(['/**', '*/', '//'], '', $this->getName()) . ' - ' . str_replace(['/**', '*/', '//'], '', $this->getTitle()) . "\n";
-        $code .= '*' . "\n";
-        $code .= '* @param \CoreShop\Component\Store\Model\StoreInterface $store' . "\n";
-        $code .= '*' . "\n";
-        $code .= '* @return null|' . $this->getPhpdocType() . '|\CoreShop\Component\Core\Model\ProductStoreValuesInterface' . "\n";
-        $code .= '*/' . "\n";
-        $code .= 'public function get' . ucfirst($key) . ' (\CoreShop\Component\Store\Model\StoreInterface $store = null) {' . "\n";
-        $code .= "\t" . '$this->' . $key . ' = $this->getClass()->getFieldDefinition("' . $key . '")->preGetData($this);' . "\n";
-        $code .= "\t" . 'if (is_null($store)) {' . "\n";
-        $code .= "\t\t" . 'return $this->' . $key . ";\n";
-        $code .= "\t" . '}' . "\n";
-        $code .= "\t" . '$data = $this->' . $key . ";\n\n";
-        $code .= "\t" . 'if (\Pimcore\Model\DataObject::doGetInheritedValues() && $this->getClass()->getFieldDefinition("' . $key . '")->isEmpty($data)) {' . "\n";
-        $code .= "\t\t" . 'return $this->getValueFromParent("' . $key . '", $store);' . "\n";
-        $code .= "\t" . '}' . "\n\n";
-        $code .= "\t" . 'if (is_array($data)) {' . "\n";
-        $code .= "\t\t" . '/** @var \CoreShop\Component\Core\Model\ProductStoreValuesInterface $storeValuesBlock */' . "\n";
-        $code .= "\t\t" . 'foreach ($data as $storeValuesBlock) {' . "\n";
-        $code .= "\t\t\t" . 'if ($storeValuesBlock->getStore()->getId() === $store->getId()) {' . "\n";
-        $code .= "\t\t\t\t" . 'return $storeValuesBlock;' . "\n";
-        $code .= "\t\t\t" . '}' . "\n";
-        $code .= "\t\t" . '}' . "\n";
-        $code .= "\t" . '}' . "\n";
-        $code .= "\treturn null;" . "\n";
+        $code = '/**'."\n";
+        $code .= '* Get '.str_replace(['/**', '*/', '//'], '', $this->getName()).' - '.str_replace(['/**', '*/', '//'],
+                '', $this->getTitle())."\n";
+        $code .= '*'."\n";
+        $code .= '* @param \CoreShop\Component\Store\Model\StoreInterface $store'."\n";
+        $code .= '*'."\n";
+        $code .= '* @return null|'.$this->getPhpdocType().'|\CoreShop\Component\Core\Model\ProductStoreValuesInterface'."\n";
+        $code .= '*/'."\n";
+        $code .= 'public function get'.ucfirst($key).' (\CoreShop\Component\Store\Model\StoreInterface $store = null) {'."\n";
+        $code .= "\t".'$this->'.$key.' = $this->getClass()->getFieldDefinition("'.$key.'")->preGetData($this);'."\n";
+        $code .= "\t".'if (is_null($store)) {'."\n";
+        $code .= "\t\t".'return $this->'.$key.";\n";
+        $code .= "\t".'}'."\n";
+        $code .= "\t".'$data = $this->'.$key.";\n\n";
+        $code .= "\t".'if (\Pimcore\Model\DataObject::doGetInheritedValues() && $this->getClass()->getFieldDefinition("'.$key.'")->isEmpty($data)) {'."\n";
+        $code .= "\t\t".'return $this->getValueFromParent("'.$key.'", $store);'."\n";
+        $code .= "\t".'}'."\n\n";
+        $code .= "\t".'if (is_array($data)) {'."\n";
+        $code .= "\t\t".'/** @var \CoreShop\Component\Core\Model\ProductStoreValuesInterface $storeValuesBlock */'."\n";
+        $code .= "\t\t".'foreach ($data as $storeValuesBlock) {'."\n";
+        $code .= "\t\t\t".'if ($storeValuesBlock->getStore()->getId() === $store->getId()) {'."\n";
+        $code .= "\t\t\t\t".'return $storeValuesBlock;'."\n";
+        $code .= "\t\t\t".'}'."\n";
+        $code .= "\t\t".'}'."\n";
+        $code .= "\t".'}'."\n";
+        $code .= "\treturn null;"."\n";
         $code .= "}\n\n";
 
-        $code .= '/**' . "\n";
-        $code .= '* Get ' . str_replace(['/**', '*/', '//'], '', $this->getName()) . ' - ' . str_replace(['/**', '*/', '//'], '', $this->getTitle()) . "\n";
-        $code .= '*' . "\n";
-        $code .= '* @param string $type' . "\n";
-        $code .= '* @param \CoreShop\Component\Store\Model\StoreInterface $store' . "\n";
-        $code .= '*' . "\n";
-        $code .= '* @return mixed' . "\n";
-        $code .= '*/' . "\n";
-        $code .= 'public function get' . ucfirst($key) . 'OfType (string $type, \CoreShop\Component\Store\Model\StoreInterface $store) {' . "\n";
-        $code .= "\t" . '$storeValue = $this->get'.ucfirst($key).'($store);' . "\n";
-        $code .= "\t" . 'if ($storeValue instanceof \CoreShop\Component\Core\Model\ProductStoreValuesInterface) {' . "\n";
-        $code .= "\t\t" . '$getter = sprintf(\'get%s\', ucfirst($type));' . "\n";
-        $code .= "\t\t" . 'if (method_exists($storeValue, $getter)) {' . "\n";
-        $code .= "\t\t\t" . 'return $storeValue->$getter();' . "\n";
-        $code .= "\t\t" . '}' . "\n";
-        $code .= "\t" . '}' . "\n";
-        $code .= "\t" . "\n";
-        $code .= "\t" . 'return null;' . "\n";
+        $code .= '/**'."\n";
+        $code .= '* Get '.str_replace(['/**', '*/', '//'], '', $this->getName()).' - '.str_replace(['/**', '*/', '//'],
+                '', $this->getTitle())."\n";
+        $code .= '*'."\n";
+        $code .= '* @param string $type'."\n";
+        $code .= '* @param \CoreShop\Component\Store\Model\StoreInterface $store'."\n";
+        $code .= '*'."\n";
+        $code .= '* @return mixed'."\n";
+        $code .= '*/'."\n";
+        $code .= 'public function get'.ucfirst($key).'OfType (string $type, \CoreShop\Component\Store\Model\StoreInterface $store) {'."\n";
+        $code .= "\t".'$storeValue = $this->get'.ucfirst($key).'($store);'."\n";
+        $code .= "\t".'if ($storeValue instanceof \CoreShop\Component\Core\Model\ProductStoreValuesInterface) {'."\n";
+        $code .= "\t\t".'$getter = sprintf(\'get%s\', ucfirst($type));'."\n";
+        $code .= "\t\t".'if (method_exists($storeValue, $getter)) {'."\n";
+        $code .= "\t\t\t".'return $storeValue->$getter();'."\n";
+        $code .= "\t\t".'}'."\n";
+        $code .= "\t".'}'."\n";
+        $code .= "\t"."\n";
+        $code .= "\t".'return null;'."\n";
         $code .= "}\n\n";
 
         return $code;
@@ -210,50 +306,52 @@ class StoreValues extends Model\DataObject\ClassDefinition\Data implements Custo
     public function getSetterCode($class)
     {
         $key = $this->getName();
-        $code = '/**' . "\n";
-        $code .= '* Set ' . str_replace(['/**', '*/', '//'], '', $key) . ' - ' . str_replace(['/**', '*/', '//'], '', $this->getTitle()) . "\n";
-        $code .= '*' . "\n";
-        $code .= '* @param array|\CoreShop\Component\Core\Model\ProductStoreValuesInterface $storeValues' . "\n";
-        $code .= '* @param null|\CoreShop\Component\Store\Model\StoreInterface $store' . "\n";
-        $code .= '*' . "\n";
-        $code .= '* @return static' . "\n";
-        $code .= '*/' . "\n";
-        $code .= 'public function set' . ucfirst($key) . ' ($storeValues, \CoreShop\Component\Store\Model\StoreInterface $store = null) {' . "\n";
-        $code .= "\t" . "\n";
-        $code .= "\t" . 'if (is_array($' . $key . ')) {' . "\n";
-        $code .= "\t\t" . '$this->' . $key . ' = $' . $key . ';' . "\n";
-        $code .= "\t" . '} else if (!is_null($store)) {' . "\n";
-        $code .= "\t\t" . '$this->' . $key . '[$store->getId()] = $' . $key . ';' . "\n";
-        $code .= "\t" . '}' . "\n\n";
-        $code .= "\t" . '$this->' . $key . ' = ' . '$this->getClass()->getFieldDefinition("' . $key . '")->preSetData($this, $this->' . $key . ');' . "\n";
-        $code .= "\t" . 'return $this;' . "\n";
+        $code = '/**'."\n";
+        $code .= '* Set '.str_replace(['/**', '*/', '//'], '', $key).' - '.str_replace(['/**', '*/', '//'], '',
+                $this->getTitle())."\n";
+        $code .= '*'."\n";
+        $code .= '* @param array|\CoreShop\Component\Core\Model\ProductStoreValuesInterface $storeValues'."\n";
+        $code .= '* @param null|\CoreShop\Component\Store\Model\StoreInterface $store'."\n";
+        $code .= '*'."\n";
+        $code .= '* @return static'."\n";
+        $code .= '*/'."\n";
+        $code .= 'public function set'.ucfirst($key).' ($storeValues, \CoreShop\Component\Store\Model\StoreInterface $store = null) {'."\n";
+        $code .= "\t"."\n";
+        $code .= "\t".'if (is_array($'.$key.')) {'."\n";
+        $code .= "\t\t".'$this->'.$key.' = $'.$key.';'."\n";
+        $code .= "\t".'} else if (!is_null($store)) {'."\n";
+        $code .= "\t\t".'$this->'.$key.'[$store->getId()] = $'.$key.';'."\n";
+        $code .= "\t".'}'."\n\n";
+        $code .= "\t".'$this->'.$key.' = '.'$this->getClass()->getFieldDefinition("'.$key.'")->preSetData($this, $this->'.$key.');'."\n";
+        $code .= "\t".'return $this;'."\n";
         $code .= "}\n\n";
 
-        $code .= '/**' . "\n";
-        $code .= '* Set ' . str_replace(['/**', '*/', '//'], '', $key) . ' - ' . str_replace(['/**', '*/', '//'], '', $this->getTitle()) . "\n";
-        $code .= '*' . "\n";
-        $code .= '* @param string $type' . "\n";
-        $code .= '* @param mixed $value' . "\n";
-        $code .= '* @param \CoreShop\Component\Store\Model\StoreInterface $store' . "\n";
-        $code .= '*' . "\n";
-        $code .= '* @return static' . "\n";
-        $code .= '*/' . "\n";
-        $code .= 'public function set' . ucfirst($key) . 'OfType (string $type, $value, \CoreShop\Component\Store\Model\StoreInterface $store) {' . "\n";
-        $code .= "\t" . '$storeValue = $this->get'.ucfirst($key).'($store);' . "\n";
-        $code .= "\t" . "\n";
-        $code .= "\t" . 'if (!$storeValue instanceof \CoreShop\Component\Core\Model\ProductStoreValuesInterface) {' . "\n";
-        $code .= "\t\t" . '$storeValue = ' . '$this->getClass()->getFieldDefinition("' . $key . '")->createNew($this, $store);' . "\n";
-        $code .= "\t" . '}' . "\n";
-        $code .= "\t" . "\n";
-        $code .= "\t" . '$setter = sprintf(\'set%s\', ucfirst($type));' . "\n";
-        $code .= "\t" . "\n";
-        $code .= "\t" . 'if (method_exists($storeValue, $setter)) {' . "\n";
-        $code .= "\t\t" . '$storeValue->$setter($value);' . "\n";
-        $code .= "\t" . '}' . "\n";
-        $code .= "\t" . "\n";
-        $code .= "\t" . '$this->set'.ucfirst($key).'($storeValue, $store);' . "\n";
-        $code .= "\t" . "\n";
-        $code .= "\t" . 'return $this;' . "\n";
+        $code .= '/**'."\n";
+        $code .= '* Set '.str_replace(['/**', '*/', '//'], '', $key).' - '.str_replace(['/**', '*/', '//'], '',
+                $this->getTitle())."\n";
+        $code .= '*'."\n";
+        $code .= '* @param string $type'."\n";
+        $code .= '* @param mixed $value'."\n";
+        $code .= '* @param \CoreShop\Component\Store\Model\StoreInterface $store'."\n";
+        $code .= '*'."\n";
+        $code .= '* @return static'."\n";
+        $code .= '*/'."\n";
+        $code .= 'public function set'.ucfirst($key).'OfType (string $type, $value, \CoreShop\Component\Store\Model\StoreInterface $store) {'."\n";
+        $code .= "\t".'$storeValue = $this->get'.ucfirst($key).'($store);'."\n";
+        $code .= "\t"."\n";
+        $code .= "\t".'if (!$storeValue instanceof \CoreShop\Component\Core\Model\ProductStoreValuesInterface) {'."\n";
+        $code .= "\t\t".'$storeValue = '.'$this->getClass()->getFieldDefinition("'.$key.'")->createNew($this, $store);'."\n";
+        $code .= "\t".'}'."\n";
+        $code .= "\t"."\n";
+        $code .= "\t".'$setter = sprintf(\'set%s\', ucfirst($type));'."\n";
+        $code .= "\t"."\n";
+        $code .= "\t".'if (method_exists($storeValue, $setter)) {'."\n";
+        $code .= "\t\t".'$storeValue->$setter($value);'."\n";
+        $code .= "\t".'}'."\n";
+        $code .= "\t"."\n";
+        $code .= "\t".'$this->set'.ucfirst($key).'($storeValue, $store);'."\n";
+        $code .= "\t"."\n";
+        $code .= "\t".'return $this;'."\n";
         $code .= "}\n\n";
 
         return $code;
@@ -281,7 +379,7 @@ class StoreValues extends Model\DataObject\ClassDefinition\Data implements Custo
         if (!$object->isLazyKeyLoaded($this->getName())) {
             $data = $this->load($object, ['force' => true]);
 
-            $setter = 'set' . ucfirst($this->getName());
+            $setter = 'set'.ucfirst($this->getName());
             if (method_exists($object, $setter)) {
                 $object->$setter($data);
             }
@@ -293,7 +391,7 @@ class StoreValues extends Model\DataObject\ClassDefinition\Data implements Custo
 
         foreach ($data as &$storeEntry) {
             if ($storeEntry instanceof ProductStoreValuesInterface) {
-                $storeEntry = $this->getEntityManager()->merge($storeEntry);
+                $storeEntry = $this->entityManager()->merge($storeEntry);
                 $storeEntry->setProduct($object);
             }
         }
@@ -325,7 +423,7 @@ class StoreValues extends Model\DataObject\ClassDefinition\Data implements Custo
     public function load($object, $params = [])
     {
         if (isset($params['force']) && $params['force']) {
-            return $this->getProductStoreValuesRepository()->findForProduct($object);
+            return $this->productStoreValuesRepository()->findForProduct($object);
         }
 
         return null;
@@ -358,7 +456,7 @@ class StoreValues extends Model\DataObject\ClassDefinition\Data implements Custo
          */
         foreach ($productStoreValues as $storeId => $storeData) {
             $storeData->setProduct($object);
-            $this->getEntityManager()->persist($storeData);
+            $this->entityManager()->persist($storeData);
 
             if ($storeData->getId()) {
                 $validStoreValues[] = $storeData->getId();
@@ -367,11 +465,11 @@ class StoreValues extends Model\DataObject\ClassDefinition\Data implements Custo
 
         foreach ($availableStoreValues as $availableStoreValuesEntity) {
             if (!in_array($availableStoreValuesEntity->getId(), $validStoreValues)) {
-                $this->getEntityManager()->remove($availableStoreValuesEntity);
+                $this->entityManager()->remove($availableStoreValuesEntity);
             }
         }
 
-        $this->getEntityManager()->flush();
+        $this->entityManager()->flush();
     }
 
     /**
@@ -385,10 +483,10 @@ class StoreValues extends Model\DataObject\ClassDefinition\Data implements Custo
 
         $availableStoreValues = $this->load($object, ['force' => true]);
         foreach ($availableStoreValues as $availableStoreValuesEntity) {
-            $this->getEntityManager()->remove($availableStoreValuesEntity);
+            $this->entityManager()->remove($availableStoreValuesEntity);
         }
 
-        $this->getEntityManager()->flush();
+        $this->entityManager()->flush();
     }
 
     /**
@@ -396,8 +494,8 @@ class StoreValues extends Model\DataObject\ClassDefinition\Data implements Custo
      */
     public function getDataForEditmode($data, $object = null, $params = [])
     {
-        $stores = $this->getStoreRepository()->findAll();
-        $storeValues = $this->getProductStoreValuesRepository()->findForProduct($object);
+        $stores = $this->storeRepository()->findAll();
+        $storeValues = $this->productStoreValuesRepository()->findForProduct($object);
         $storeData = [];
 
         if (!$object instanceof ProductInterface) {
@@ -408,13 +506,13 @@ class StoreValues extends Model\DataObject\ClassDefinition\Data implements Custo
             $context = SerializationContext::create();
             $context->setSerializeNull(true);
             $context->setGroups(['Default', 'Detailed']);
-            $serializedData = $this->getSerializer()->serialize($storeValuesEntity, 'json', $context);
+            $serializedData = $this->serializer()->serialize($storeValuesEntity, 'json', $context);
             $values = json_decode($serializedData, true);
 
             $storeData[$storeValuesEntity->getStore()->getId()] = [
-                'name'           => $storeValuesEntity->getStore()->getName(),
+                'name' => $storeValuesEntity->getStore()->getName(),
                 'currencySymbol' => $storeValuesEntity->getStore()->getCurrency()->getSymbol(),
-                'values'         => $values
+                'values' => $values,
             ];
         }
 
@@ -429,9 +527,9 @@ class StoreValues extends Model\DataObject\ClassDefinition\Data implements Custo
 
             //Fill missing stores with empty values
             $storeData[$store->getId()] = [
-                'name'           => $store->getName(),
+                'name' => $store->getName(),
                 'currencySymbol' => $store->getCurrency()->getSymbol(),
-                'values'         => ['price' => 0],
+                'values' => ['price' => 0],
             ];
         }
 
@@ -455,10 +553,10 @@ class StoreValues extends Model\DataObject\ClassDefinition\Data implements Custo
             $storeValuesId = isset($storeData['id']) && is_numeric($storeData['id']) ? $storeData['id'] : null;
 
             if ($storeValuesId !== null) {
-                $storeValuesEntity = $this->getProductStoreValuesRepository()->find($storeValuesId);
+                $storeValuesEntity = $this->productStoreValuesRepository()->find($storeValuesId);
             }
 
-            $form = $this->getFormFactory()->createNamed('', ProductStoreValuesType::class, $storeValuesEntity);
+            $form = $this->formFactory()->createNamed('', ProductStoreValuesType::class, $storeValuesEntity);
 
             $parsedData = $this->expandDotNotationKeys($storeData);
             $parsedData['store'] = $storeId;
@@ -495,7 +593,7 @@ class StoreValues extends Model\DataObject\ClassDefinition\Data implements Custo
 
         $preview = [];
         foreach ($data as $element) {
-            $preview[] = (string) $element;
+            $preview[] = (string)$element;
         }
 
         return join(', ', $preview);
@@ -527,19 +625,20 @@ class StoreValues extends Model\DataObject\ClassDefinition\Data implements Custo
         $data = $importValue == '' ? [] : json_decode($importValue, true);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new \InvalidArgumentException(sprintf('Error decoding Store Price JSON `%s`: %s', $importValue, json_last_error_msg()));
+            throw new \InvalidArgumentException(sprintf('Error decoding Store Price JSON `%s`: %s', $importValue,
+                json_last_error_msg()));
         }
 
         if (is_array($data) && !empty($data)) {
             foreach ($data as $storeId => $newPrice) {
-                $store = $this->getStoreRepository()->find($storeId);
+                $store = $this->storeRepository()->find($storeId);
                 if (!$store instanceof StoreInterface) {
                     throw new \InvalidArgumentException(sprintf('Store with ID %s not found', $storeId));
                 }
             }
         }
 
-        $oldStoreValues = $this->getProductStoreValuesRepository()->findForProduct($object);
+        $oldStoreValues = $this->productStoreValuesRepository()->findForProduct($object);
 
         if (is_array($oldStoreValues)) {
             foreach ($oldStoreValues as $oldStoreValuesEntity) {
@@ -556,7 +655,7 @@ class StoreValues extends Model\DataObject\ClassDefinition\Data implements Custo
 
     /**
      * @param ProductInterface $object
-     * @param StoreInterface $store
+     * @param StoreInterface   $store
      * @return ProductStoreValuesInterface
      */
     public function createNew($object, StoreInterface $store)
@@ -564,7 +663,7 @@ class StoreValues extends Model\DataObject\ClassDefinition\Data implements Custo
         /**
          * @var ProductStoreValuesInterface $newObject
          */
-        $newObject = $this->getFactory()->createNew();
+        $newObject = $this->factory()->createNew();
         $newObject->setStore($store);
         $newObject->setProduct($object);
 
@@ -594,11 +693,11 @@ class StoreValues extends Model\DataObject\ClassDefinition\Data implements Custo
      */
     protected function toNumeric($value)
     {
-        if (strpos((string) $value, '.') === false) {
-            return (int) $value;
+        if (strpos((string)$value, '.') === false) {
+            return (int)$value;
         }
 
-        return (float) $value;
+        return (float)$value;
     }
 
     /**
@@ -630,61 +729,4 @@ class StoreValues extends Model\DataObject\ClassDefinition\Data implements Custo
 
         return $result;
     }
-
-    /**
-     * @return \Doctrine\ORM\EntityManager
-     */
-    private function getEntityManager()
-    {
-        return \Pimcore::getContainer()->get('doctrine.orm.entity_manager');
-    }
-
-    /**
-     * @return \Symfony\Component\Form\FormFactoryInterface
-     */
-    private function getFormFactory()
-    {
-        return \Pimcore::getContainer()->get('form.factory');
-    }
-
-    /**
-     * @return StoreRepositoryInterface
-     */
-    protected function getStoreRepository()
-    {
-        return \Pimcore::getContainer()->get('coreshop.repository.store');
-    }
-
-    /**
-     * @return FactoryInterface
-     */
-    protected function getFactory()
-    {
-        return \Pimcore::getContainer()->get('coreshop.factory.product_store_values');
-    }
-
-    /**
-     * @return ProductStoreValuesRepositoryInterface
-     */
-    protected function getProductStoreValuesRepository()
-    {
-        return \Pimcore::getContainer()->get('coreshop.repository.product_store_values');
-    }
-
-    /**
-     * @return ProductUnitRepositoryInterface
-     */
-    protected function getProductUnitRepository()
-    {
-        return \Pimcore::getContainer()->get('coreshop.repository.product_unit');
-    }
-
-    /**
-     * @return \JMS\Serializer\SerializerInterface
-     */
-    private function getSerializer()
-    {
-        return \Pimcore::getContainer()->get('jms_serializer');
-    }
-
 }

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/pimcore/config.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/pimcore/config.yml
@@ -16,11 +16,3 @@ jms_serializer:
 twig:
     globals:
         coreshop: "@coreshop.context.shopper"
-
-pimcore:
-    objects:
-        class_definitions:
-            data:
-                map:
-                    coreShopStorePrice: CoreShop\Bundle\CoreBundle\CoreExtension\StorePrice
-                    coreShopStoreValues: CoreShop\Bundle\CoreBundle\CoreExtension\StoreValues

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services.yml
@@ -28,6 +28,7 @@ imports:
     - { resource: "services/validators.yml" }
     - { resource: "services/product-store-values.yml" }
     - { resource: "services/menu.yml" }
+    - { resource: "services/core_extension.yml" }
 
 services:
     _defaults:

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services/core_extension.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services/core_extension.yml
@@ -13,7 +13,7 @@ services:
         class: CoreShop\Bundle\CoreBundle\CoreExtension\Factory\StoreValuesFactory
         arguments:
             - '@doctrine.orm.entity_manager'
-            - '@coreshop.factory.product_store_price'
+            - '@coreshop.factory.product_store_values'
             - '@coreshop.repository.store'
             - '@coreshop.repository.product_store_values'
             - '@form.factory'

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services/core_extension.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services/core_extension.yml
@@ -1,0 +1,22 @@
+services:
+    coreshop.core_extension.core.store_price:
+        class: CoreShop\Bundle\CoreBundle\CoreExtension\Factory\StorePriceFactory
+        arguments:
+            - '@doctrine.orm.entity_manager'
+            - '@coreshop.factory.product_store_price'
+            - '@coreshop.repository.store'
+            - '@coreshop.repository.product_store_price'
+        tags:
+            - { name: coreshop.pimcore.data_object.data, type: coreShopStorePrice }
+
+    coreshop.core_extension.core.store_values:
+        class: CoreShop\Bundle\CoreBundle\CoreExtension\Factory\StoreValuesFactory
+        arguments:
+            - '@doctrine.orm.entity_manager'
+            - '@coreshop.factory.product_store_price'
+            - '@coreshop.repository.store'
+            - '@coreshop.repository.product_store_values'
+            - '@form.factory'
+            - '@jms_serializer'
+        tags:
+            - { name: coreshop.pimcore.data_object.data, type: coreShopStoreValues }

--- a/src/CoreShop/Bundle/CurrencyBundle/CoreExtension/Currency.php
+++ b/src/CoreShop/Bundle/CurrencyBundle/CoreExtension/Currency.php
@@ -12,30 +12,6 @@
 
 namespace CoreShop\Bundle\CurrencyBundle\CoreExtension;
 
-use CoreShop\Bundle\ResourceBundle\CoreExtension\Select;
+use CoreShop\Bundle\ResourceBundle\CoreExtension\DataObject\ResourceSelect;
 
-class Currency extends Select
-{
-    /**
-     * Static type of this element.
-     *
-     * @var string
-     */
-    public $fieldtype = 'coreShopCurrency';
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getRepository()
-    {
-        return \Pimcore::getContainer()->get('coreshop.repository.currency');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getModel()
-    {
-        return \Pimcore::getContainer()->getParameter('coreshop.model.currency.class');
-    }
-}
+class_alias(ResourceSelect::class, 'CoreShop\Bundle\CurrencyBundle\CoreExtension\Currency');

--- a/src/CoreShop/Bundle/CurrencyBundle/CoreExtension/Factory/MoneyCurrencyFactory.php
+++ b/src/CoreShop/Bundle/CurrencyBundle/CoreExtension/Factory/MoneyCurrencyFactory.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2019 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\CurrencyBundle\CoreExtension\Factory;
+
+use CoreShop\Bundle\CurrencyBundle\CoreExtension\MoneyCurrency;
+use CoreShop\Component\Currency\Repository\CurrencyRepositoryInterface;
+use CoreShop\Component\Pimcore\DataObject\ObjectDataFactoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+
+class MoneyCurrencyFactory implements ObjectDataFactoryInterface
+{
+    /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    /**
+     * @var CurrencyRepositoryInterface
+     */
+    private $repository;
+
+    /**
+     * @param EntityManagerInterface      $entityManager
+     * @param CurrencyRepositoryInterface $repository
+     */
+    public function __construct(EntityManagerInterface $entityManager, CurrencyRepositoryInterface $repository)
+    {
+        $this->entityManager = $entityManager;
+        $this->repository = $repository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create($type, $params)
+    {
+        return new MoneyCurrency(
+            $this->entityManager,
+            $this->repository
+        );
+    }
+}

--- a/src/CoreShop/Bundle/CurrencyBundle/Resources/config/pimcore/config.yml
+++ b/src/CoreShop/Bundle/CurrencyBundle/Resources/config/pimcore/config.yml
@@ -1,15 +1,6 @@
 imports:
     - { resource: "admin.yml" }
 
-pimcore:
-    objects:
-        class_definitions:
-            data:
-                map:
-                    coreShopCurrency: CoreShop\Bundle\CurrencyBundle\CoreExtension\Currency
-                    coreShopCurrencyMultiselect: CoreShop\Bundle\CurrencyBundle\CoreExtension\CurrencyMultiselect
-                    coreShopMoneyCurrency: CoreShop\Bundle\CurrencyBundle\CoreExtension\MoneyCurrency
-
 jms_serializer:
     metadata:
         directories:

--- a/src/CoreShop/Bundle/CurrencyBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/CurrencyBundle/Resources/config/services.yml
@@ -1,6 +1,7 @@
 imports:
     - { resource: "services/form.yml" }
     - { resource: "services/pimcore.yml" }
+    - { resource: "services/core_extension.yml" }
 
 services:
     _defaults:

--- a/src/CoreShop/Bundle/CurrencyBundle/Resources/config/services/core_extension.yml
+++ b/src/CoreShop/Bundle/CurrencyBundle/Resources/config/services/core_extension.yml
@@ -1,0 +1,24 @@
+services:
+    coreshop.core_extension.currency.currency:
+        class: CoreShop\Component\Resource\Pimcore\ResourceSelectObjectTagFactory
+        arguments:
+            - '%coreshop.model.currency.class%'
+            - '@coreshop.repository.currency'
+        tags:
+            - { name: coreshop.pimcore.data_object.data, type: coreShopCurrency }
+
+    coreshop.core_extension.currency.currency_multiselect:
+        class: CoreShop\Component\Resource\Pimcore\ResourceMultiselectObjectTagFactory
+        arguments:
+            - '%coreshop.model.currency.class%'
+            - '@coreshop.repository.currency'
+        tags:
+            - { name: coreshop.pimcore.data_object.data, type: coreShopCurrencyMultiselect }
+
+    coreshop.core_extension.currency.money_currency:
+        class: CoreShop\Bundle\CurrencyBundle\CoreExtension\Factory\MoneyCurrencyFactory
+        arguments:
+            - '@doctrine.orm.entity_manager'
+            - '@coreshop.repository.currency'
+        tags:
+            - { name: coreshop.pimcore.data_object.data, type: coreShopMoneyCurrency }

--- a/src/CoreShop/Bundle/CurrencyBundle/Resources/config/services/pimcore.yml
+++ b/src/CoreShop/Bundle/CurrencyBundle/Resources/config/services/pimcore.yml
@@ -3,10 +3,9 @@ services:
         public: true
 
     coreshop.pimcore.document.tag.currency:
-        class: CoreShop\Component\Resource\Pimcore\ResourceDocumentTagFactory
+        class: CoreShop\Component\Resource\Pimcore\ResourceSelectDocumentTagFactory
         arguments:
-            - 'CoreShop\Bundle\ResourceBundle\CoreExtension\Document\Select'
-            - 'coreshop.repository.currency'
+            - '@coreshop.repository.currency'
             - 'name'
         tags:
             - { name: coreshop.pimcore.document.tag, type: coreshop_currency }

--- a/src/CoreShop/Bundle/IndexBundle/CoreExtension/Filter.php
+++ b/src/CoreShop/Bundle/IndexBundle/CoreExtension/Filter.php
@@ -12,37 +12,6 @@
 
 namespace CoreShop\Bundle\IndexBundle\CoreExtension;
 
-use CoreShop\Bundle\ResourceBundle\CoreExtension\Select;
+use CoreShop\Bundle\ResourceBundle\CoreExtension\DataObject\ResourceSelect;
 
-class Filter extends Select
-{
-    /**
-     * Static type of this element.
-     *
-     * @var string
-     */
-    public $fieldtype = 'coreShopFilter';
-
-    /**
-     * Type for the generated phpdoc.
-     *
-     * @var string
-     */
-    public $phpdocType = \CoreShop\Component\Index\Model\Filter::class;
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getRepository()
-    {
-        return \Pimcore::getContainer()->get('coreshop.repository.filter');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getModel()
-    {
-        return \Pimcore::getContainer()->getParameter('coreshop.model.filter.class');
-    }
-}
+class_alias(ResourceSelect::class, 'CoreShop\Bundle\IndexBundle\CoreExtension\Filter');

--- a/src/CoreShop/Bundle/IndexBundle/Resources/config/pimcore/config.yml
+++ b/src/CoreShop/Bundle/IndexBundle/Resources/config/pimcore/config.yml
@@ -1,13 +1,6 @@
 imports:
     - { resource: "admin.yml" }
 
-pimcore:
-    objects:
-        class_definitions:
-            data:
-                map:
-                    coreShopFilter: CoreShop\Bundle\IndexBundle\CoreExtension\Filter
-
 core_shop_index:
     mapping_types:
         INTEGER: ~

--- a/src/CoreShop/Bundle/IndexBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/IndexBundle/Resources/config/services.yml
@@ -5,6 +5,7 @@ imports:
     - { resource: "services/pimcore.yml" }
     - { resource: "services/condition_renderer.yml" }
     - { resource: "services/order_renderer.yml" }
+    - { resource: "services/core_extension.yml" }
 
 services:
     _defaults:

--- a/src/CoreShop/Bundle/IndexBundle/Resources/config/services/core_extension.yml
+++ b/src/CoreShop/Bundle/IndexBundle/Resources/config/services/core_extension.yml
@@ -1,0 +1,9 @@
+services:
+    coreshop.core_extension.index-filter:
+        class: CoreShop\Component\Resource\Pimcore\ResourceSelectObjectTagFactory
+        arguments:
+            - '%coreshop.model.filter.class%'
+            - '@coreshop.repository.filter'
+        tags:
+            - { name: coreshop.pimcore.data_object.data, type: coreShopFilter }
+

--- a/src/CoreShop/Bundle/IndexBundle/Resources/config/services/pimcore.yml
+++ b/src/CoreShop/Bundle/IndexBundle/Resources/config/services/pimcore.yml
@@ -3,19 +3,17 @@ services:
         public: true
 
     coreshop.pimcore.document.tag.filter:
-        class: CoreShop\Component\Resource\Pimcore\ResourceDocumentTagFactory
+        class: CoreShop\Component\Resource\Pimcore\ResourceSelectDocumentTagFactory
         arguments:
-            - 'CoreShop\Bundle\ResourceBundle\CoreExtension\Document\Select'
-            - 'coreshop.repository.filter'
+            - '@coreshop.repository.filter'
             - 'name'
         tags:
             - { name: coreshop.pimcore.document.tag, type: coreshop_filter }
 
     coreshop.pimcore.document.tag.index:
-        class: CoreShop\Component\Resource\Pimcore\ResourceDocumentTagFactory
+        class: CoreShop\Component\Resource\Pimcore\ResourceSelectDocumentTagFactory
         arguments:
-            - 'CoreShop\Bundle\ResourceBundle\CoreExtension\Document\Select'
-            - 'coreshop.repository.index'
+            - '@coreshop.repository.index'
             - 'name'
         tags:
             - { name: coreshop.pimcore.document.tag, type: coreshop_index }

--- a/src/CoreShop/Bundle/OrderBundle/CoreExtension/CartPriceRule.php
+++ b/src/CoreShop/Bundle/OrderBundle/CoreExtension/CartPriceRule.php
@@ -12,37 +12,6 @@
 
 namespace CoreShop\Bundle\OrderBundle\CoreExtension;
 
-use CoreShop\Bundle\ResourceBundle\CoreExtension\Select;
+use CoreShop\Bundle\ResourceBundle\CoreExtension\DataObject\ResourceSelect;
 
-class CartPriceRule extends Select
-{
-    /**
-     * Static type of this element.
-     *
-     * @var string
-     */
-    public $fieldtype = 'coreShopCartPriceRule';
-
-    /**
-     * Type for the generated phpdoc.
-     *
-     * @var string
-     */
-    public $phpdocType = \CoreShop\Component\Order\Model\CartPriceRule::class;
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getRepository()
-    {
-        return \Pimcore::getContainer()->get('coreshop.repository.cart_price_rule');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getModel()
-    {
-        return \Pimcore::getContainer()->getParameter('coreshop.model.cart_price_rule.class');
-    }
-}
+class_alias(ResourceSelect::class, 'CoreShop\Bundle\OrderBundle\CoreExtension\CartPriceRule');

--- a/src/CoreShop/Bundle/OrderBundle/Resources/config/pimcore/config.yml
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/config/pimcore/config.yml
@@ -2,13 +2,6 @@ imports:
     - { resource: "admin.yml" }
     - { resource: "workflow.yml" }
 
-pimcore:
-    objects:
-        class_definitions:
-            data:
-                map:
-                    coreShopCartPriceRule: CoreShop\Bundle\OrderBundle\CoreExtension\CartPriceRule
-
 jms_serializer:
     metadata:
         directories:

--- a/src/CoreShop/Bundle/OrderBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/config/services.yml
@@ -16,6 +16,8 @@ imports:
     - { resource: "services/grid_config.yml" }
     - { resource: "services/payment.yml" }
     - { resource: "services/forms.yml" }
+    - { resource: "services/cart-price-rules.yml" }
+    - { resource: "services/core_extension.yml" }
 
 services:
     _defaults:

--- a/src/CoreShop/Bundle/OrderBundle/Resources/config/services/core_extension.yml
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/config/services/core_extension.yml
@@ -1,0 +1,8 @@
+services:
+    coreshop.core_extension.order.cart_price_rule:
+        class: CoreShop\Component\Resource\Pimcore\ResourceSelectObjectTagFactory
+        arguments:
+            - '%coreshop.model.cart_price_rule.class%'
+            - '@coreshop.repository.cart_price_rule'
+        tags:
+            - { name: coreshop.pimcore.data_object.data, type: coreShopCartPriceRule }

--- a/src/CoreShop/Bundle/PaymentBundle/CoreExtension/PaymentProvider.php
+++ b/src/CoreShop/Bundle/PaymentBundle/CoreExtension/PaymentProvider.php
@@ -12,37 +12,6 @@
 
 namespace CoreShop\Bundle\PaymentBundle\CoreExtension;
 
-use CoreShop\Bundle\ResourceBundle\CoreExtension\Select;
+use CoreShop\Bundle\ResourceBundle\CoreExtension\DataObject\ResourceSelect;
 
-class PaymentProvider extends Select
-{
-    /**
-     * Static type of this element.
-     *
-     * @var string
-     */
-    public $fieldtype = 'coreShopPaymentProvider';
-
-    /**
-     * Type for the generated phpdoc.
-     *
-     * @var string
-     */
-    public $phpdocType = \CoreShop\Component\Payment\Model\PaymentProvider::class;
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getRepository()
-    {
-        return \Pimcore::getContainer()->get('coreshop.repository.payment_provider');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getModel()
-    {
-        return \Pimcore::getContainer()->getParameter('coreshop.model.payment_provider.class');
-    }
-}
+class_alias(ResourceSelect::class, 'CoreShop\Bundle\PaymentBundle\CoreExtension\PaymentProvider');

--- a/src/CoreShop/Bundle/PaymentBundle/Resources/config/pimcore/config.yml
+++ b/src/CoreShop/Bundle/PaymentBundle/Resources/config/pimcore/config.yml
@@ -2,14 +2,6 @@ imports:
     - { resource: "workflow.yml" }
     - { resource: "admin.yml" }
 
-pimcore:
-    objects:
-        class_definitions:
-            data:
-                map:
-                  coreShopPaymentProvider: CoreShop\Bundle\PaymentBundle\CoreExtension\PaymentProvider
-
-
 jms_serializer:
     metadata:
         directories:

--- a/src/CoreShop/Bundle/PaymentBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/PaymentBundle/Resources/config/services.yml
@@ -3,3 +3,4 @@ imports:
     - { resource: "services/workflow.yml" }
     - { resource: "services/resolver.yml" }
     - { resource: "services/pimcore.yml" }
+    - { resource: "services/core_extension.yml" }

--- a/src/CoreShop/Bundle/PaymentBundle/Resources/config/services/core_extension.yml
+++ b/src/CoreShop/Bundle/PaymentBundle/Resources/config/services/core_extension.yml
@@ -1,0 +1,8 @@
+services:
+    coreshop.core_extension.payment.payment_provider:
+        class: CoreShop\Component\Resource\Pimcore\ResourceSelectObjectTagFactory
+        arguments:
+            - '%coreshop.model.payment_provider.class%'
+            - '@coreshop.repository.payment_provider'
+        tags:
+            - { name: coreshop.pimcore.data_object.data, type: coreShopPaymentProvider }

--- a/src/CoreShop/Bundle/PaymentBundle/Resources/config/services/pimcore.yml
+++ b/src/CoreShop/Bundle/PaymentBundle/Resources/config/services/pimcore.yml
@@ -1,9 +1,8 @@
 services:
     coreshop.pimcore.document.tag.payment_provider:
-        class: CoreShop\Component\Resource\Pimcore\ResourceDocumentTagFactory
+        class: CoreShop\Component\Resource\Pimcore\ResourceSelectDocumentTagFactory
         arguments:
-            - 'CoreShop\Bundle\ResourceBundle\CoreExtension\Document\Select'
-            - 'coreshop.repository.payment_provider'
+            - '@coreshop.repository.payment_provider'
             - 'name'
         tags:
             - { name: coreshop.pimcore.document.tag, type: coreshop_payment_provider }

--- a/src/CoreShop/Bundle/PimcoreBundle/CoreShopPimcoreBundle.php
+++ b/src/CoreShop/Bundle/PimcoreBundle/CoreShopPimcoreBundle.php
@@ -15,6 +15,8 @@ namespace CoreShop\Bundle\PimcoreBundle;
 use CoreShop\Bundle\PimcoreBundle\DependencyInjection\Compiler\ExpressionLanguageServicePass;
 use CoreShop\Bundle\PimcoreBundle\DependencyInjection\Compiler\RegisterGridActionPass;
 use CoreShop\Bundle\PimcoreBundle\DependencyInjection\Compiler\RegisterGridFilterPass;
+use CoreShop\Bundle\PimcoreBundle\DependencyInjection\Compiler\RegisterPimcoreDataObjectDataImplementationLoaderPass;
+use CoreShop\Bundle\PimcoreBundle\DependencyInjection\Compiler\RegisterPimcoreDataObjectDataPass;
 use CoreShop\Bundle\PimcoreBundle\DependencyInjection\Compiler\RegisterPimcoreDocumentTagImplementationLoaderPass;
 use CoreShop\Bundle\PimcoreBundle\DependencyInjection\Compiler\RegisterPimcoreDocumentTagPass;
 use PackageVersions\Versions;
@@ -77,6 +79,8 @@ final class CoreShopPimcoreBundle extends AbstractPimcoreBundle
         $container->addCompilerPass(new RegisterPimcoreDocumentTagImplementationLoaderPass());
         $container->addCompilerPass(new RegisterPimcoreDocumentTagPass());
         $container->addCompilerPass(new ExpressionLanguageServicePass());
+        $container->addCompilerPass(new RegisterPimcoreDataObjectDataImplementationLoaderPass());
+        $container->addCompilerPass(new RegisterPimcoreDataObjectDataPass());
     }
 
     /**

--- a/src/CoreShop/Bundle/PimcoreBundle/DependencyInjection/Compiler/RegisterPimcoreDataObjectDataImplementationLoaderPass.php
+++ b/src/CoreShop/Bundle/PimcoreBundle/DependencyInjection/Compiler/RegisterPimcoreDataObjectDataImplementationLoaderPass.php
@@ -10,16 +10,15 @@
  * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
  */
 
-namespace CoreShop\Bundle\ShippingBundle\CoreExtension;
+namespace CoreShop\Bundle\PimcoreBundle\DependencyInjection\Compiler;
 
-use CoreShop\Bundle\ResourceBundle\CoreExtension\Multiselect;
-
-class CarrierMultiselect extends Multiselect
+final class RegisterPimcoreDataObjectDataImplementationLoaderPass extends RegisterImplementationLoaderPass
 {
-    /**
-     * Static type of this element.
-     *
-     * @var string
-     */
-    public $fieldtype = 'coreShopCarrierMultiselect';
+    public function __construct()
+    {
+        parent::__construct(
+            'pimcore.implementation_loader.object.data',
+            'coreshop.pimcore.implementation_loader.data_object.data'
+        );
+    }
 }

--- a/src/CoreShop/Bundle/PimcoreBundle/DependencyInjection/Compiler/RegisterPimcoreDataObjectDataPass.php
+++ b/src/CoreShop/Bundle/PimcoreBundle/DependencyInjection/Compiler/RegisterPimcoreDataObjectDataPass.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2019 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\PimcoreBundle\DependencyInjection\Compiler;
+
+final class RegisterPimcoreDataObjectDataPass extends RegisterSimpleRegistryTypePass
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'coreshop.registry.pimcore.data_object.data',
+            'coreshop.registry.pimcore.data_object.data',
+            'coreshop.pimcore.data_object.data'
+        );
+    }
+}

--- a/src/CoreShop/Bundle/PimcoreBundle/Resources/config/services/pimcore.yml
+++ b/src/CoreShop/Bundle/PimcoreBundle/Resources/config/services/pimcore.yml
@@ -14,3 +14,16 @@ services:
             - '@coreshop.registry.pimcore.document.tag'
         tags:
             - { name: coreshop.pimcore.implementation_loader.document.tag }
+
+    coreshop.registry.pimcore.data_object.data:
+        class: CoreShop\Component\Registry\ServiceRegistry
+        arguments:
+            - CoreShop\Component\Pimcore\DataObject\ObjectDataFactoryInterface
+            - data-object-tag-factories
+
+    coreshop.pimcore.implementation_loader.object.tag.di:
+        class: CoreShop\Bundle\PimcoreBundle\Loader\DependencyInjectionImplementationLoader
+        arguments:
+            - '@coreshop.registry.pimcore.data_object.data'
+        tags:
+            - { name: coreshop.pimcore.implementation_loader.data_object.data }

--- a/src/CoreShop/Bundle/ProductBundle/CoreExtension/Factory/ProductSpecificPriceRulesFactory.php
+++ b/src/CoreShop/Bundle/ProductBundle/CoreExtension/Factory/ProductSpecificPriceRulesFactory.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2019 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\ProductBundle\CoreExtension\Factory;
+
+use CoreShop\Bundle\ProductBundle\CoreExtension\ProductSpecificPriceRules;
+use CoreShop\Component\Pimcore\DataObject\ObjectDataFactoryInterface;
+use CoreShop\Component\Product\Repository\ProductSpecificPriceRuleRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use JMS\Serializer\SerializerInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+
+class ProductSpecificPriceRulesFactory implements ObjectDataFactoryInterface
+{
+    /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    /**
+     * @var FormFactoryInterface
+     */
+    private $formFactory;
+
+    /**
+     * @var ProductSpecificPriceRuleRepositoryInterface
+     */
+    private $repository;
+
+    /**
+     * @var SerializerInterface
+     */
+    private $serializer;
+
+    /**
+     * @var array
+     */
+    private $configConditions;
+
+    /**
+     * @var array
+     */
+    private $configActions;
+
+    /**
+     * @param EntityManagerInterface                      $entityManager
+     * @param FormFactoryInterface                        $formFactory
+     * @param ProductSpecificPriceRuleRepositoryInterface $repository
+     * @param SerializerInterface                         $serializer
+     * @param array                                       $configConditions
+     * @param array                                       $configActions
+     */
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        FormFactoryInterface $formFactory,
+        ProductSpecificPriceRuleRepositoryInterface $repository,
+        SerializerInterface $serializer,
+        array $configConditions,
+        array $configActions
+    ) {
+        $this->entityManager = $entityManager;
+        $this->formFactory = $formFactory;
+        $this->repository = $repository;
+        $this->serializer = $serializer;
+        $this->configConditions = $configConditions;
+        $this->configActions = $configActions;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create($type, $params)
+    {
+        return new ProductSpecificPriceRules(
+            $this->entityManager,
+            $this->formFactory,
+            $this->repository,
+            $this->serializer,
+            $this->configActions,
+            $this->configConditions
+        );
+    }
+}

--- a/src/CoreShop/Bundle/ProductBundle/CoreExtension/Factory/ProductUnitDefinitionFactory.php
+++ b/src/CoreShop/Bundle/ProductBundle/CoreExtension/Factory/ProductUnitDefinitionFactory.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2019 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\ProductBundle\CoreExtension\Factory;
+
+use CoreShop\Bundle\ProductBundle\CoreExtension\ProductUnitDefinition;
+use CoreShop\Component\Pimcore\DataObject\ObjectDataFactoryInterface;
+use CoreShop\Component\Resource\Repository\RepositoryInterface;
+
+class ProductUnitDefinitionFactory implements ObjectDataFactoryInterface
+{
+    /**
+     * @var RepositoryInterface
+     */
+    private $repository;
+
+    /**
+     * @param RepositoryInterface $repository
+     */
+    public function __construct(RepositoryInterface $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create($type, $params)
+    {
+        return new ProductUnitDefinition($this->repository);
+    }
+}

--- a/src/CoreShop/Bundle/ProductBundle/CoreExtension/Factory/ProductUnitDefinitionsFactory.php
+++ b/src/CoreShop/Bundle/ProductBundle/CoreExtension/Factory/ProductUnitDefinitionsFactory.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2019 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\ProductBundle\CoreExtension\Factory;
+
+use CoreShop\Bundle\ProductBundle\CoreExtension\ProductSpecificPriceRules;
+use CoreShop\Bundle\ProductBundle\CoreExtension\ProductUnitDefinitions;
+use CoreShop\Component\Pimcore\DataObject\ObjectDataFactoryInterface;
+use CoreShop\Component\Product\Repository\ProductSpecificPriceRuleRepositoryInterface;
+use CoreShop\Component\Product\Repository\ProductUnitDefinitionsRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use JMS\Serializer\SerializerInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+
+class ProductUnitDefinitionsFactory implements ObjectDataFactoryInterface
+{
+    /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    /**
+     * @var FormFactoryInterface
+     */
+    private $formFactory;
+
+    /**
+     * @var ProductUnitDefinitionsRepositoryInterface
+     */
+    private $repository;
+
+    /**
+     * @var SerializerInterface
+     */
+    private $serializer;
+
+    /**
+     * @param EntityManagerInterface                      $entityManager
+     * @param FormFactoryInterface                        $formFactory
+     * @param ProductUnitDefinitionsRepositoryInterface $repository
+     * @param SerializerInterface                         $serializer
+     */
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        FormFactoryInterface $formFactory,
+        ProductUnitDefinitionsRepositoryInterface $repository,
+        SerializerInterface $serializer
+    ) {
+        $this->entityManager = $entityManager;
+        $this->formFactory = $formFactory;
+        $this->repository = $repository;
+        $this->serializer = $serializer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create($type, $params)
+    {
+        return new ProductUnitDefinitions(
+            $this->entityManager,
+            $this->formFactory,
+            $this->repository,
+            $this->serializer
+        );
+    }
+}

--- a/src/CoreShop/Bundle/ProductBundle/CoreExtension/ProductUnit.php
+++ b/src/CoreShop/Bundle/ProductBundle/CoreExtension/ProductUnit.php
@@ -12,30 +12,6 @@
 
 namespace CoreShop\Bundle\ProductBundle\CoreExtension;
 
-use CoreShop\Bundle\ResourceBundle\CoreExtension\Select;
+use CoreShop\Bundle\ResourceBundle\CoreExtension\DataObject\ResourceSelect;
 
-class ProductUnit extends Select
-{
-    /**
-     * Static type of this element.
-     *
-     * @var string
-     */
-    public $fieldtype = 'coreShopProductUnit';
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getRepository()
-    {
-        return \Pimcore::getContainer()->get('coreshop.repository.product_unit');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getModel()
-    {
-        return \Pimcore::getContainer()->getParameter('coreshop.model.product_unit.class');
-    }
-}
+class_alias(ResourceSelect::class, 'CoreShop\Bundle\ProductBundle\CoreExtension\ProductUnit');

--- a/src/CoreShop/Bundle/ProductBundle/CoreExtension/ProductUnitDefinition.php
+++ b/src/CoreShop/Bundle/ProductBundle/CoreExtension/ProductUnitDefinition.php
@@ -12,6 +12,7 @@
 
 namespace CoreShop\Bundle\ProductBundle\CoreExtension;
 
+use CoreShop\Bundle\ResourceBundle\CoreExtension\DataObject\DISetStateTrait;
 use CoreShop\Component\Pimcore\BCLayer\QueryResourcePersistenceAwareInterface;
 use CoreShop\Component\Pimcore\BCLayer\ResourcePersistenceAwareInterface;
 use CoreShop\Component\Product\Model\ProductUnitDefinitionInterface;
@@ -21,6 +22,8 @@ use Pimcore\Model\DataObject\ClassDefinition\Data;
 
 class ProductUnitDefinition extends Data implements ResourcePersistenceAwareInterface, QueryResourcePersistenceAwareInterface
 {
+    use DISetStateTrait;
+
     /**
      * Static type of this element.
      *
@@ -39,6 +42,25 @@ class ProductUnitDefinition extends Data implements ResourcePersistenceAwareInte
      * @var bool
      */
     public $allowEmpty = false;
+
+    /**
+     * @param RepositoryInterface $repository
+     */
+    public function __construct(RepositoryInterface $repository)
+    {
+        $this->repository($repository);
+    }
+
+    private function repository(RepositoryInterface $newValue = null)
+    {
+        static $value;
+
+        if ($newValue !== null) {
+            $value = $newValue;
+        }
+
+        return $value;
+    }
 
     /**
      * @return string | array
@@ -84,7 +106,7 @@ class ProductUnitDefinition extends Data implements ResourcePersistenceAwareInte
 
         if ($data instanceof ResourceInterface) {
             //Reload from Database, but only if available
-            $tmpData = $this->getRepository()->find($data->getId());
+            $tmpData = $this->repository()->find($data->getId());
 
             if ($tmpData instanceof ResourceInterface) {
                 //Dirty Fix, Pimcore sometimes calls properties without getter
@@ -117,7 +139,7 @@ class ProductUnitDefinition extends Data implements ResourcePersistenceAwareInte
     public function getDataFromResource($data, $object = null, $params = [])
     {
         if ((int) $data > 0) {
-            return $this->getRepository()->find($data);
+            return $this->repository()->find($data);
         }
 
         return null;
@@ -183,13 +205,5 @@ class ProductUnitDefinition extends Data implements ResourcePersistenceAwareInte
     public function getVersionPreview($data, $object = null, $params = [])
     {
         return $data;
-    }
-
-    /**
-     * @return RepositoryInterface
-     */
-    protected function getRepository()
-    {
-        return \Pimcore::getContainer()->get('coreshop.repository.product_unit_definition');
     }
 }

--- a/src/CoreShop/Bundle/ProductBundle/Resources/config/pimcore/config.yml
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/config/pimcore/config.yml
@@ -1,16 +1,6 @@
 imports:
     - { resource: "admin.yml" }
 
-pimcore:
-    objects:
-        class_definitions:
-            data:
-                map:
-                    coreShopProductSpecificPriceRules: CoreShop\Bundle\ProductBundle\CoreExtension\ProductSpecificPriceRules
-                    coreShopProductUnitDefinitions: CoreShop\Bundle\ProductBundle\CoreExtension\ProductUnitDefinitions
-                    coreShopProductUnitDefinition: CoreShop\Bundle\ProductBundle\CoreExtension\ProductUnitDefinition
-                    coreShopProductUnit: CoreShop\Bundle\ProductBundle\CoreExtension\ProductUnit
-
 jms_serializer:
     metadata:
         directories:

--- a/src/CoreShop/Bundle/ProductBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/config/services.yml
@@ -4,6 +4,7 @@ imports:
     - { resource: "services/price-rules.yml" }
     - { resource: "services/specific-price-rules.yml" }
     - { resource: "services/units.yml" }
+    - { resource: "services/core_extension.yml" }
 
 services:
     _defaults:

--- a/src/CoreShop/Bundle/ProductBundle/Resources/config/services/core_extension.yml
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/config/services/core_extension.yml
@@ -1,0 +1,37 @@
+services:
+    coreshop.core_extension.product.product_unit:
+        class: CoreShop\Component\Resource\Pimcore\ResourceSelectObjectTagFactory
+        arguments:
+            - '%coreshop.model.product_unit.class%'
+            - '@coreshop.repository.product_unit'
+        tags:
+            - { name: coreshop.pimcore.data_object.data, type: coreShopProductUnit }
+
+    coreshop.core_extension.product.specific_price_rules:
+        class: CoreShop\Bundle\ProductBundle\CoreExtension\Factory\ProductSpecificPriceRulesFactory
+        arguments:
+            - '@doctrine.orm.entity_manager'
+            - '@form.factory'
+            - '@coreshop.repository.product_specific_price_rule'
+            - '@jms_serializer'
+            - '%coreshop.product_specific_price_rule.conditions%'
+            - '%coreshop.product_specific_price_rule.actions%'
+        tags:
+            - { name: coreshop.pimcore.data_object.data, type: coreShopProductSpecificPriceRules }
+
+    coreshop.core_extension.product.product_unit_definition:
+        class: CoreShop\Bundle\ProductBundle\CoreExtension\Factory\ProductUnitDefinitionFactory
+        arguments:
+            - '@coreshop.repository.product_unit_definition'
+        tags:
+            - { name: coreshop.pimcore.data_object.data, type: coreShopProductUnitDefinition }
+
+    coreshop.core_extension.product.product_unit_definitions:
+        class: CoreShop\Bundle\ProductBundle\CoreExtension\Factory\ProductUnitDefinitionsFactory
+        arguments:
+            - '@doctrine.orm.entity_manager'
+            - '@form.factory'
+            - '@coreshop.repository.product_unit_definitions'
+            - '@jms_serializer'
+        tags:
+            - { name: coreshop.pimcore.data_object.data, type: coreShopProductUnitDefinitions }

--- a/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/CoreExtension/Factory/ProductQuantityPriceRulesFactory.php
+++ b/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/CoreExtension/Factory/ProductQuantityPriceRulesFactory.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2019 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\ProductQuantityPriceRulesBundle\CoreExtension\Factory;
+
+use CoreShop\Bundle\ProductBundle\CoreExtension\ProductSpecificPriceRules;
+use CoreShop\Bundle\ProductQuantityPriceRulesBundle\CoreExtension\ProductQuantityPriceRules;
+use CoreShop\Component\Pimcore\DataObject\ObjectDataFactoryInterface;
+use CoreShop\Component\Product\Repository\ProductSpecificPriceRuleRepositoryInterface;
+use CoreShop\Component\ProductQuantityPriceRules\Repository\ProductQuantityPriceRuleRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use JMS\Serializer\SerializerInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+
+class ProductQuantityPriceRulesFactory implements ObjectDataFactoryInterface
+{
+    /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    /**
+     * @var FormFactoryInterface
+     */
+    private $formFactory;
+
+    /**
+     * @var ProductQuantityPriceRuleRepositoryInterface
+     */
+    private $repository;
+
+    /**
+     * @var SerializerInterface
+     */
+    private $serializer;
+
+    /**
+     * @var array
+     */
+    private $configConditions;
+
+    /**
+     * @var array
+     */
+    private $configActions;
+
+    /**
+     * @var array
+     */
+    private $configCalculators;
+
+    /**
+     * @param EntityManagerInterface                      $entityManager
+     * @param FormFactoryInterface                        $formFactory
+     * @param ProductQuantityPriceRuleRepositoryInterface $repository
+     * @param SerializerInterface                         $serializer
+     * @param array                                       $configConditions
+     * @param array                                       $configActions
+     * @param array                                       $configCalculators
+     */
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        FormFactoryInterface $formFactory,
+        ProductQuantityPriceRuleRepositoryInterface $repository,
+        SerializerInterface $serializer,
+        array $configConditions,
+        array $configActions,
+        array $configCalculators
+    ) {
+        $this->entityManager = $entityManager;
+        $this->formFactory = $formFactory;
+        $this->repository = $repository;
+        $this->serializer = $serializer;
+        $this->configConditions = $configConditions;
+        $this->configActions = $configActions;
+        $this->configCalculators = $configCalculators;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create($type, $params)
+    {
+        return new ProductQuantityPriceRules(
+            $this->entityManager,
+            $this->formFactory,
+            $this->repository,
+            $this->serializer,
+            $this->configConditions,
+            $this->configActions,
+            $this->configCalculators
+        );
+    }
+}

--- a/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/config/pimcore/config.yml
+++ b/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/config/pimcore/config.yml
@@ -1,13 +1,6 @@
 imports:
     - { resource: "admin.yml" }
 
-pimcore:
-    objects:
-        class_definitions:
-            data:
-                map:
-                    coreShopProductQuantityPriceRules: CoreShop\Bundle\ProductQuantityPriceRulesBundle\CoreExtension\ProductQuantityPriceRules
-
 jms_serializer:
     metadata:
         directories:

--- a/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/config/services.yml
@@ -3,6 +3,7 @@ imports:
     - { resource: 'services/product-quantity-price-rules.yml' }
     - { resource: 'services/actions.yml' }
     - { resource: 'services/calculator.yml' }
+    - { resource: 'services/core_extension.yml' }
 
 services:
     coreshop.templating.helper.product_quantity_price:

--- a/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/config/services/core_extension.yml
+++ b/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/config/services/core_extension.yml
@@ -1,0 +1,13 @@
+services:
+    coreshop.core_extension.product_quantity_price_rules:
+        class: CoreShop\Bundle\ProductQuantityPriceRulesBundle\CoreExtension\Factory\ProductQuantityPriceRulesFactory
+        arguments:
+            - '@doctrine.orm.entity_manager'
+            - '@form.factory'
+            - '@coreshop.repository.product_quantity_price_rule'
+            - '@jms_serializer'
+            - '%coreshop.product_quantity_price_rules.conditions%'
+            - '%coreshop.product_quantity_price_rules.actions%'
+            - '%coreshop.product_quantity_price_rules.calculators%'
+        tags:
+            - { name: coreshop.pimcore.data_object.data, type: coreShopProductQuantityPriceRules }

--- a/src/CoreShop/Bundle/ResourceBundle/CoreExtension/DataObject/DISetStateTrait.php
+++ b/src/CoreShop/Bundle/ResourceBundle/CoreExtension/DataObject/DISetStateTrait.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2019 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\ResourceBundle\CoreExtension\DataObject;
+
+trait DISetStateTrait
+{
+    public static function __set_state($data)
+    {
+        $thing = \Pimcore::getContainer()->get('pimcore.implementation_loader.object.data')->build($data['fieldtype'], $data);
+        $thing->setValues($data);
+
+        return $thing;
+    }
+}

--- a/src/CoreShop/Bundle/ResourceBundle/CoreExtension/DataObject/ResourceMultiselect.php
+++ b/src/CoreShop/Bundle/ResourceBundle/CoreExtension/DataObject/ResourceMultiselect.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2019 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\ResourceBundle\CoreExtension\DataObject;
+
+use CoreShop\Component\Resource\Repository\RepositoryInterface;
+use Pimcore\Model;
+
+class ResourceMultiselect extends Model\DataObject\ClassDefinition\Data\Multiselect
+{
+    use DISetStateTrait;
+
+    /**
+     * @param string              $type
+     * @param string              $model
+     * @param RepositoryInterface $repository
+     * @param array               $params
+     */
+    public function __construct(string $type, string $model, RepositoryInterface $repository, array $params = [])
+    {
+        $this->fieldtype = $type;
+        $this->phpdocType = $model;
+    }
+
+    /**
+     * @param mixed $object
+     * @param array $params
+     *
+     * @return mixed
+     */
+    public function preGetData($object, $params = [])
+    {
+        if (!$object instanceof Model\AbstractModel) {
+            return null;
+        }
+
+        $data = $object->getObjectVar($this->getName());
+
+        if (null === $data) {
+            $data = [];
+        }
+
+        return $data;
+    }
+
+}

--- a/src/CoreShop/Bundle/ResourceBundle/CoreExtension/DataObject/ResourceSelect.php
+++ b/src/CoreShop/Bundle/ResourceBundle/CoreExtension/DataObject/ResourceSelect.php
@@ -18,6 +18,8 @@ use Pimcore\Model;
 
 class ResourceSelect extends Model\DataObject\ClassDefinition\Data\Select
 {
+    private static $hiddenVarMap = [];
+
     use DISetStateTrait;
 
     /**
@@ -53,10 +55,11 @@ class ResourceSelect extends Model\DataObject\ClassDefinition\Data\Select
 
     private function repository(RepositoryInterface $newValue = null)
     {
-        static $value;
+        $value = static::$hiddenVarMap[$this->fieldtype];
 
         if ($newValue !== null) {
             $value = $newValue;
+            static::$hiddenVarMap[$this->fieldtype] = $value;
         }
 
         return $value;

--- a/src/CoreShop/Bundle/ResourceBundle/CoreExtension/DataObject/ResourceSelect.php
+++ b/src/CoreShop/Bundle/ResourceBundle/CoreExtension/DataObject/ResourceSelect.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2019 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\ResourceBundle\CoreExtension\DataObject;
+
+use CoreShop\Component\Resource\Model\ResourceInterface;
+use CoreShop\Component\Resource\Repository\RepositoryInterface;
+use Pimcore\Model;
+
+class ResourceSelect extends Model\DataObject\ClassDefinition\Data\Select
+{
+    use DISetStateTrait;
+
+    /**
+     * @var bool
+     */
+    public $allowEmpty = false;
+
+    /**
+     * @var string
+     */
+    private $model;
+
+    /**
+     * @var array
+     */
+    private $params = [];
+
+    /**
+     * @param string              $type
+     * @param string              $model
+     * @param RepositoryInterface $repository
+     * @param array               $params
+     */
+    public function __construct(string $type, string $model, RepositoryInterface $repository, array $params = [])
+    {
+        $this->fieldtype = $type;
+        $this->phpdocType = $model;
+        $this->model = $model;
+        $this->params = $params;
+
+        $this->repository($repository);
+    }
+
+    private function repository(RepositoryInterface $newValue = null)
+    {
+        static $value;
+
+        if ($newValue !== null) {
+            $value = $newValue;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return string | array
+     */
+    public function getQueryColumnType()
+    {
+        return 'int(11)';
+    }
+
+    /**
+     * @return string | array
+     */
+    public function getColumnType()
+    {
+        return 'int(11)';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function preSetData($object, $data, $params = [])
+    {
+        if (is_int($data) || is_string($data)) {
+            if ((int)$data) {
+                return $this->getDataFromResource($data, $object, $params);
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function preGetData($object, $params = [])
+    {
+        if (!$object instanceof Model\AbstractModel) {
+            return null;
+        }
+
+        $data = $object->getObjectVar($this->getName());
+
+        if ($data instanceof ResourceInterface) {
+            //Reload from Database, but only if available
+            $tmpData = $this->repository()->find($data->getId());
+
+            if ($tmpData instanceof ResourceInterface) {
+                //Dirty Fix, Pimcore sometimes calls properties without getter
+                //This could cause Problems with translations, therefore, we need to set
+                //the value here
+                $object->setValue($this->getName(), $tmpData);
+
+                return $tmpData;
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDataForResource($data, $object = null, $params = [])
+    {
+        if (is_a($data, $this->model)) {
+            return $data->getId();
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDataFromResource($data, $object = null, $params = [])
+    {
+        if ((int)$data > 0) {
+            return $this->repository()->find($data);
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDataForQueryResource($data, $object = null, $params = [])
+    {
+        if (is_a($data, $this->model)) {
+            return $data->getId();
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDataForEditmode($data, $object = null, $params = [])
+    {
+        return $this->getDataForResource($data, $object, $params);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDataFromEditmode($data, $object = null, $params = [])
+    {
+        return $this->getDataFromResource($data, $object, $params);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isEmpty($data)
+    {
+        return !$data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDataForSearchIndex($object, $params = [])
+    {
+        if ($object instanceof ResourceInterface) {
+            return $object->getId();
+        }
+
+        return parent::getDataForSearchIndex($object, $params);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getForWebserviceExport($object, $params = [])
+    {
+        if ($object instanceof ResourceInterface) {
+            return $object->getId();
+        }
+
+        return parent::getForWebserviceExport($object, $params);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFromWebserviceImport($value, $object = null, $params = [], $idMapper = null)
+    {
+        return $this->repository()->find($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isAllowEmpty()
+    {
+        return $this->allowEmpty;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setAllowEmpty($allowEmpty)
+    {
+        $this->allowEmpty = $allowEmpty;
+    }
+
+}

--- a/src/CoreShop/Bundle/ResourceBundle/CoreExtension/Document/ResourceSelect.php
+++ b/src/CoreShop/Bundle/ResourceBundle/CoreExtension/Document/ResourceSelect.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2019 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\ResourceBundle\CoreExtension\Document;
+
+use CoreShop\Component\Resource\Model\ResourceInterface;
+use CoreShop\Component\Resource\Repository\RepositoryInterface;
+use Pimcore\Model\Document\Tag;
+
+class ResourceSelect extends Tag
+{
+    /**
+     * @var ResourceInterface|null
+     */
+    public $resource;
+
+    /**
+     * @var RepositoryInterface
+     */
+    protected $repository;
+
+    /**
+     * @var string
+     */
+    protected $nameProperty;
+
+    /**
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * @var array
+     */
+    protected $params;
+
+    /**
+     * @param RepositoryInterface $repository
+     * @param string $nameProperty
+     * @param string $type
+     * @param array $params
+     */
+    public function __construct(RepositoryInterface $repository, string $nameProperty, string $type, array $params = [])
+    {
+        $this->repository = $repository;
+        $this->nameProperty = $nameProperty;
+        $this->type = $type;
+        $this->params = $params;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function frontend()
+    {
+        return '';
+    }
+
+    public function getData()
+    {
+        return $this->resource;
+    }
+
+    /**
+     * @return null|ResourceInterface
+     */
+    public function getResourceObject()
+    {
+        if ($this->resource) {
+            return $this->repository->find($this->resource);
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOptions()
+    {
+        $data = $this->repository->findAll();
+        $result = [];
+
+        foreach ($data as $resource) {
+            if (!$resource instanceof ResourceInterface) {
+                throw new \InvalidArgumentException('Only ResourceInterface is allowed');
+            }
+
+            $result[] = [
+                $resource->getId(),
+                $this->getResourceName($resource),
+            ];
+        }
+
+        return [
+            'store' => $result,
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDataFromEditmode($data)
+    {
+        $this->resource = $data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDataFromResource($data)
+    {
+        $this->resource = $data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getForWebserviceExport($document = null, $params = [])
+    {
+        return [
+            'id' => $this->resource->getId(),
+        ];
+    }
+
+    /**
+     * @param ResourceInterface $resource
+     *
+     * @return mixed
+     */
+    protected function getResourceName(ResourceInterface $resource)
+    {
+        $getter = 'get' . ucfirst($this->nameProperty);
+
+        if (!method_exists($resource, $getter)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Property with Name %s does not exist in resource %s',
+                    $this->nameProperty,
+                    get_class($resource)
+                )
+            );
+        }
+
+        return $resource->$getter();
+    }
+}

--- a/src/CoreShop/Bundle/ShippingBundle/CoreExtension/Carrier.php
+++ b/src/CoreShop/Bundle/ShippingBundle/CoreExtension/Carrier.php
@@ -12,38 +12,6 @@
 
 namespace CoreShop\Bundle\ShippingBundle\CoreExtension;
 
-use CoreShop\Bundle\ResourceBundle\CoreExtension\Select;
-use CoreShop\Component\Shipping\Model\CarrierInterface;
+use CoreShop\Bundle\ResourceBundle\CoreExtension\DataObject\ResourceSelect;
 
-class Carrier extends Select
-{
-    /**
-     * Static type of this element.
-     *
-     * @var string
-     */
-    public $fieldtype = 'coreShopCarrier';
-
-    /**
-     * Type for the generated phpdoc.
-     *
-     * @var string
-     */
-    public $phpdocType = CarrierInterface::class;
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getRepository()
-    {
-        return \Pimcore::getContainer()->get('coreshop.repository.carrier');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getModel()
-    {
-        return \Pimcore::getContainer()->getParameter('coreshop.model.carrier.class');
-    }
-}
+class_alias(ResourceSelect::class, 'CoreShop\Bundle\ShippingBundle\CoreExtension\Carrier');

--- a/src/CoreShop/Bundle/ShippingBundle/Resources/config/pimcore/config.yml
+++ b/src/CoreShop/Bundle/ShippingBundle/Resources/config/pimcore/config.yml
@@ -1,14 +1,6 @@
 imports:
     - { resource: "admin.yml" }
 
-pimcore:
-    objects:
-        class_definitions:
-            data:
-                map:
-                    coreShopCarrier: CoreShop\Bundle\ShippingBundle\CoreExtension\Carrier
-                    coreShopCarrierMultiselect: CoreShop\Bundle\ShippingBundle\CoreExtension\CarrierMultiselect
-
 jms_serializer:
     metadata:
         directories:

--- a/src/CoreShop/Bundle/ShippingBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/ShippingBundle/Resources/config/services.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: "services/form.yml" }
     - { resource: "services/shipping-rules.yml" }
     - { resource: "services/pimcore.yml" }
+    - { resource: "services/core_extension.yml" }
 
 services:
     _defaults:

--- a/src/CoreShop/Bundle/ShippingBundle/Resources/config/services/core_extension.yml
+++ b/src/CoreShop/Bundle/ShippingBundle/Resources/config/services/core_extension.yml
@@ -1,0 +1,16 @@
+services:
+    coreshop.core_extension.shipping.carrier:
+        class: CoreShop\Component\Resource\Pimcore\ResourceSelectObjectTagFactory
+        arguments:
+            - '%coreshop.model.carrier.class%'
+            - '@coreshop.repository.carrier'
+        tags:
+            - { name: coreshop.pimcore.data_object.data, type: coreShopCarrier }
+
+    coreshop.core_extension.shipping.carrier_multiselect:
+        class: CoreShop\Component\Resource\Pimcore\ResourceMultiselectObjectTagFactory
+        arguments:
+            - '%coreshop.model.carrier.class%'
+            - '@coreshop.repository.carrier'
+        tags:
+            - { name: coreshop.pimcore.data_object.data, type: coreShopCarrierMultiselect }

--- a/src/CoreShop/Bundle/ShippingBundle/Resources/config/services/pimcore.yml
+++ b/src/CoreShop/Bundle/ShippingBundle/Resources/config/services/pimcore.yml
@@ -3,10 +3,9 @@ services:
         public: true
 
     coreshop.pimcore.document.tag.carrier:
-        class: CoreShop\Component\Resource\Pimcore\ResourceDocumentTagFactory
+        class: CoreShop\Component\Resource\Pimcore\ResourceSelectDocumentTagFactory
         arguments:
-            - 'CoreShop\Bundle\ResourceBundle\CoreExtension\Document\Select'
-            - 'coreshop.repository.carrier'
+            - '@coreshop.repository.carrier'
             - 'name'
         tags:
             - { name: coreshop.pimcore.document.tag, type: coreshop_carrier }

--- a/src/CoreShop/Bundle/StoreBundle/CoreExtension/Store.php
+++ b/src/CoreShop/Bundle/StoreBundle/CoreExtension/Store.php
@@ -12,30 +12,6 @@
 
 namespace CoreShop\Bundle\StoreBundle\CoreExtension;
 
-use CoreShop\Bundle\ResourceBundle\CoreExtension\Select;
+use CoreShop\Bundle\ResourceBundle\CoreExtension\DataObject\ResourceSelect;
 
-class Store extends Select
-{
-    /**
-     * Static type of this element.
-     *
-     * @var string
-     */
-    public $fieldtype = 'coreShopStore';
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getRepository()
-    {
-        return \Pimcore::getContainer()->get('coreshop.repository.store');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getModel()
-    {
-        return \Pimcore::getContainer()->getParameter('coreshop.model.store.class');
-    }
-}
+class_alias(ResourceSelect::class, 'CoreShop\Bundle\StoreBundle\CoreExtension\Store');

--- a/src/CoreShop/Bundle/StoreBundle/CoreExtension/StoreMultiselect.php
+++ b/src/CoreShop/Bundle/StoreBundle/CoreExtension/StoreMultiselect.php
@@ -12,14 +12,6 @@
 
 namespace CoreShop\Bundle\StoreBundle\CoreExtension;
 
-use CoreShop\Bundle\ResourceBundle\CoreExtension\Multiselect;
+use CoreShop\Bundle\ResourceBundle\CoreExtension\DataObject\ResourceMultiselect;
 
-class StoreMultiselect extends Multiselect
-{
-    /**
-     * Static type of this element.
-     *
-     * @var string
-     */
-    public $fieldtype = 'coreShopStoreMultiselect';
-}
+class_alias(ResourceMultiselect::class, 'CoreShop\Bundle\StoreBundle\CoreExtension\StoreMultiselect');

--- a/src/CoreShop/Bundle/StoreBundle/Resources/config/pimcore/config.yml
+++ b/src/CoreShop/Bundle/StoreBundle/Resources/config/pimcore/config.yml
@@ -1,14 +1,6 @@
 imports:
     - { resource: "admin.yml" }
 
-pimcore:
-    objects:
-        class_definitions:
-            data:
-                map:
-                    coreShopStore: CoreShop\Bundle\StoreBundle\CoreExtension\Store
-                    coreShopStoreMultiselect: CoreShop\Bundle\StoreBundle\CoreExtension\StoreMultiselect
-
 jms_serializer:
     metadata:
         directories:

--- a/src/CoreShop/Bundle/StoreBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/StoreBundle/Resources/config/services.yml
@@ -3,6 +3,7 @@ imports:
     - { resource: "services/profiler.yml" }
     - { resource: "services/theme.yml" }
     - { resource: "services/pimcore.yml" }
+    - { resource: "services/core_extension.yml" }
 
 services:
     _defaults:

--- a/src/CoreShop/Bundle/StoreBundle/Resources/config/services/core_extension.yml
+++ b/src/CoreShop/Bundle/StoreBundle/Resources/config/services/core_extension.yml
@@ -1,0 +1,16 @@
+services:
+    coreshop.core_extension.store.store:
+        class: CoreShop\Component\Resource\Pimcore\ResourceSelectObjectTagFactory
+        arguments:
+            - '%coreshop.model.store.class%'
+            - '@coreshop.repository.store'
+        tags:
+            - { name: coreshop.pimcore.data_object.data, type: coreShopStore }
+
+    coreshop.core_extension.store.store_multiselect:
+        class: CoreShop\Component\Resource\Pimcore\ResourceMultiselectObjectTagFactory
+        arguments:
+            - '%coreshop.model.store.class%'
+            - '@coreshop.repository.store'
+        tags:
+            - { name: coreshop.pimcore.data_object.data, type: coreShopStoreMultiselect }

--- a/src/CoreShop/Bundle/StoreBundle/Resources/config/services/pimcore.yml
+++ b/src/CoreShop/Bundle/StoreBundle/Resources/config/services/pimcore.yml
@@ -3,10 +3,9 @@ services:
         public: true
 
     coreshop.pimcore.document.tag.store:
-        class: CoreShop\Component\Resource\Pimcore\ResourceDocumentTagFactory
+        class: CoreShop\Component\Resource\Pimcore\ResourceSelectDocumentTagFactory
         arguments:
-            - 'CoreShop\Bundle\ResourceBundle\CoreExtension\Document\Select'
-            - 'coreshop.repository.store'
+            - '@coreshop.repository.store'
             - 'name'
         tags:
             - { name: coreshop.pimcore.document.tag, type: coreshop_store }

--- a/src/CoreShop/Bundle/TaxationBundle/CoreExtension/TaxRuleGroup.php
+++ b/src/CoreShop/Bundle/TaxationBundle/CoreExtension/TaxRuleGroup.php
@@ -12,38 +12,6 @@
 
 namespace CoreShop\Bundle\TaxationBundle\CoreExtension;
 
-use CoreShop\Bundle\ResourceBundle\CoreExtension\Select;
-use CoreShop\Component\Taxation\Model\TaxRuleGroupInterface;
+use CoreShop\Bundle\ResourceBundle\CoreExtension\DataObject\ResourceSelect;
 
-class TaxRuleGroup extends Select
-{
-    /**
-     * Static type of this element.
-     *
-     * @var string
-     */
-    public $fieldtype = 'coreShopTaxRuleGroup';
-
-    /**
-     * Type for the generated phpdoc.
-     *
-     * @var string
-     */
-    public $phpdocType = TaxRuleGroupInterface::class;
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getRepository()
-    {
-        return \Pimcore::getContainer()->get('coreshop.repository.tax_rule_group');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getModel()
-    {
-        return \Pimcore::getContainer()->getParameter('coreshop.model.tax_rule_group.class');
-    }
-}
+class_alias(ResourceSelect::class, 'CoreShop\Bundle\TaxationBundle\CoreExtension\TaxRuleGroup');

--- a/src/CoreShop/Bundle/TaxationBundle/Resources/config/pimcore/config.yml
+++ b/src/CoreShop/Bundle/TaxationBundle/Resources/config/pimcore/config.yml
@@ -1,13 +1,6 @@
 imports:
     - { resource: "admin.yml" }
 
-pimcore:
-    objects:
-        class_definitions:
-            data:
-                map:
-                    coreShopTaxRuleGroup: CoreShop\Bundle\TaxationBundle\CoreExtension\TaxRuleGroup
-
 jms_serializer:
     metadata:
         directories:

--- a/src/CoreShop/Bundle/TaxationBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/TaxationBundle/Resources/config/services.yml
@@ -1,6 +1,7 @@
 imports:
     - { resource: "services/form.yml" }
     - { resource: "services/pimcore.yml" }
+    - { resource: "services/core_extension.yml" }
 
 services:
     _defaults:

--- a/src/CoreShop/Bundle/TaxationBundle/Resources/config/services/core_extension.yml
+++ b/src/CoreShop/Bundle/TaxationBundle/Resources/config/services/core_extension.yml
@@ -1,0 +1,8 @@
+services:
+    coreshop.core_extension.taxation.tax_rule_group:
+        class: CoreShop\Component\Resource\Pimcore\ResourceSelectObjectTagFactory
+        arguments:
+            - '%coreshop.model.tax_rule_group.class%'
+            - '@coreshop.repository.tax_rule_group'
+        tags:
+            - { name: coreshop.pimcore.data_object.data, type: coreShopTaxRuleGroup }

--- a/src/CoreShop/Bundle/TaxationBundle/Resources/config/services/pimcore.yml
+++ b/src/CoreShop/Bundle/TaxationBundle/Resources/config/services/pimcore.yml
@@ -3,19 +3,17 @@ services:
         public: true
 
     coreshop.pimcore.document.tag.tax_rate:
-        class: CoreShop\Component\Resource\Pimcore\ResourceDocumentTagFactory
+        class: CoreShop\Component\Resource\Pimcore\ResourceSelectDocumentTagFactory
         arguments:
-            - 'CoreShop\Bundle\ResourceBundle\CoreExtension\Document\Select'
-            - 'coreshop.repository.tax_rate'
+            - '@coreshop.repository.tax_rate'
             - 'name'
         tags:
             - { name: coreshop.pimcore.document.tag, type: coreshop_tax_rate }
 
     coreshop.pimcore.document.tag.tax_rule_group:
-        class: CoreShop\Component\Resource\Pimcore\ResourceDocumentTagFactory
+        class: CoreShop\Component\Resource\Pimcore\ResourceSelectDocumentTagFactory
         arguments:
-            - 'CoreShop\Bundle\ResourceBundle\CoreExtension\Document\Select'
-            - 'coreshop.repository.tax_rule_group'
+            - '@coreshop.repository.tax_rule_group'
             - 'name'
         tags:
             - { name: coreshop.pimcore.document.tag, type: coreshop_tax_rule_group }

--- a/src/CoreShop/Component/Pimcore/DataObject/ObjectDataFactoryInterface.php
+++ b/src/CoreShop/Component/Pimcore/DataObject/ObjectDataFactoryInterface.php
@@ -10,16 +10,17 @@
  * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
  */
 
-namespace CoreShop\Bundle\CurrencyBundle\CoreExtension;
+namespace CoreShop\Component\Pimcore\DataObject;
 
-use CoreShop\Bundle\ResourceBundle\CoreExtension\Multiselect;
+use Pimcore\Model\DataObject\ClassDefinition\Data;
 
-class CurrencyMultiselect extends Multiselect
+interface ObjectDataFactoryInterface
 {
     /**
-     * Static type of this element.
+     * @param string $type
+     * @param array  $params
      *
-     * @var string
+     * @return Data
      */
-    public $fieldtype = 'coreShopCurrencyMultiselect';
+    public function create($type, $params);
 }

--- a/src/CoreShop/Component/Resource/Pimcore/ResourceMultiselectObjectTagFactory.php
+++ b/src/CoreShop/Component/Resource/Pimcore/ResourceMultiselectObjectTagFactory.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2019 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Component\Resource\Pimcore;
+
+use CoreShop\Bundle\ResourceBundle\CoreExtension\DataObject\ResourceMultiselect;
+use CoreShop\Component\Pimcore\DataObject\ObjectDataFactoryInterface;
+use CoreShop\Component\Resource\Repository\RepositoryInterface;
+
+class ResourceMultiselectObjectTagFactory implements ObjectDataFactoryInterface
+{
+    /**
+     * @var string
+     */
+    private $model;
+
+    /**
+     * @var RepositoryInterface
+     */
+    private $repository;
+
+    /**
+     * @param string $model
+     * @param RepositoryInterface $repository
+     */
+    public function __construct(string $model, RepositoryInterface $repository)
+    {
+        $this->model = $model;
+        $this->repository = $repository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create($type, $params)
+    {
+        return new ResourceMultiselect($type, $this->model, $this->repository, $params);
+    }
+}

--- a/src/CoreShop/Component/Resource/Pimcore/ResourceSelectDocumentTagFactory.php
+++ b/src/CoreShop/Component/Resource/Pimcore/ResourceSelectDocumentTagFactory.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2019 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Component\Resource\Pimcore;
+
+use CoreShop\Bundle\ResourceBundle\CoreExtension\Document\ResourceSelect;
+use CoreShop\Component\Pimcore\Document\DocumentTagFactoryInterface;
+use CoreShop\Component\Resource\Repository\RepositoryInterface;
+
+class ResourceSelectDocumentTagFactory implements DocumentTagFactoryInterface
+{
+    /**
+     * @var RepositoryInterface
+     */
+    private $repository;
+
+    /**
+     * @var string
+     */
+    private $nameProperty;
+
+    /**
+     * @param RepositoryInterface $repository
+     * @param string $nameProperty
+     */
+    public function __construct(RepositoryInterface $repository, string $nameProperty)
+    {
+        $this->repository = $repository;
+        $this->nameProperty = $nameProperty;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create($type, $params)
+    {
+        return new ResourceSelect($this->repository, $this->nameProperty, $type, $params);
+    }
+}

--- a/src/CoreShop/Component/Resource/Pimcore/ResourceSelectObjectTagFactory.php
+++ b/src/CoreShop/Component/Resource/Pimcore/ResourceSelectObjectTagFactory.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2019 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Component\Resource\Pimcore;
+
+use CoreShop\Bundle\ResourceBundle\CoreExtension\DataObject\ResourceSelect;
+use CoreShop\Component\Pimcore\DataObject\ObjectDataFactoryInterface;
+use CoreShop\Component\Resource\Repository\RepositoryInterface;
+
+class ResourceSelectObjectTagFactory implements ObjectDataFactoryInterface
+{
+    /**
+     * @var string
+     */
+    private $model;
+
+    /**
+     * @var RepositoryInterface
+     */
+    private $repository;
+
+    /**
+     * @param string $model
+     * @param RepositoryInterface $repository
+     */
+    public function __construct(string $model, RepositoryInterface $repository)
+    {
+        $this->model = $model;
+        $this->repository = $repository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create($type, $params)
+    {
+        return new ResourceSelect($type, $this->model, $this->repository, $params);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes

This PR takes use of the Pimcore Implementation Loader to load Custom Object Data Tags. This reduces the usage of `Pimcore::getContainer` and thus the risk of using private services.

Since Pimcore doesn't really 100% support this, it is a bit tricky. We cannot store properties directly in the Data Class, since Pimcore uses `var_export` to store definition files, this also exports the dependencies and that will fail with the entity manager. So, we use a private static variable to handle that.