### PR TITLE
always load product unit definitions

### DIFF
--- a/src/CoreShop/Bundle/ProductBundle/Resources/config/doctrine/model/ProductUnitDefinitions.orm.yml
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/config/doctrine/model/ProductUnitDefinitions.orm.yml
@@ -15,6 +15,7 @@ CoreShop\Component\Product\Model\ProductUnitDefinitions:
     oneToOne:
         defaultUnitDefinition:
             targetEntity: CoreShop\Component\Product\Model\ProductUnitDefinitionInterface
+            fetch: EAGER
             cascade:
                 - 'persist'
                 - 'merge'
@@ -24,6 +25,7 @@ CoreShop\Component\Product\Model\ProductUnitDefinitions:
                 onDelete: 'SET NULL'
     oneToMany:
         unitDefinitions:
+            fetch: EAGER
             targetEntity: CoreShop\Component\Product\Model\ProductUnitDefinitionInterface
             mappedBy: productUnitDefinitions
             orphanRemoval: true

--- a/src/CoreShop/Component/Product/Model/ProductUnitDefinitions.php
+++ b/src/CoreShop/Component/Product/Model/ProductUnitDefinitions.php
@@ -205,7 +205,9 @@ class ProductUnitDefinitions extends AbstractResource implements ProductUnitDefi
      */
     public function __toString()
     {
-        $defaultUnit = $this->getDefaultUnitDefinition() instanceof ProductUnitDefinitionInterface ? $this->getDefaultUnitDefinition()->getUnit()->getName() : '--';
+        $defaultUnit = $this->getDefaultUnitDefinition() instanceof ProductUnitDefinitionInterface
+        && $this->getDefaultUnitDefinition()->getUnit() instanceof ProductUnitInterface ? $this->getDefaultUnitDefinition()->getUnit()->getName() : '--';
+
         return sprintf('Default Unit: %s, additional units: %d', $defaultUnit, $this->getAdditionalUnitDefinitions()->count());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | ---

Do not lazy load `defaultUnitDefinition` and `unitDefinitions`  in `ProductUnitDefinitions`. Otherwise the pimcore version preview will throw an exception. 
