### PR TITLE
change db type for pricing fields to BIGINT

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Migrations/Version20190617082805.php
+++ b/src/CoreShop/Bundle/CoreBundle/Migrations/Version20190617082805.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace CoreShop\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\BigIntType;
+use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20190617082805 extends AbstractPimcoreMigration
+{
+    public function up(Schema $schema)
+    {
+        if ($schema->hasTable('coreshop_product_store_values')) {
+            $table = $schema->getTable('coreshop_product_store_values');
+            if ($table->hasColumn('price')) {
+                if (!$table->getColumn('price')->getType() instanceof BigIntType) {
+                    $this->addSql('ALTER TABLE coreshop_product_store_values CHANGE price price BIGINT NOT NULL;');
+                }
+            }
+        }
+
+        if ($schema->hasTable('coreshop_product_unit_definition_price')) {
+            $table = $schema->getTable('coreshop_product_unit_definition_price');
+            if ($table->hasColumn('price')) {
+                if (!$table->getColumn('price')->getType() instanceof BigIntType) {
+                    $this->addSql('ALTER TABLE coreshop_product_unit_definition_price CHANGE price price BIGINT NOT NULL;');
+                }
+            }
+        }
+
+        if ($schema->hasTable('coreshop_product_quantity_price_rule_range')) {
+            $table = $schema->getTable('coreshop_product_quantity_price_rule_range');
+            if ($table->hasColumn('amount')) {
+                if (!$table->getColumn('amount')->getType() instanceof BigIntType) {
+                    $this->addSql('ALTER TABLE coreshop_product_quantity_price_rule_range CHANGE amount amount BIGINT NOT NULL;');
+                }
+            }
+
+            if ($table->hasColumn('pseudo_price')) {
+                if (!$table->getColumn('pseudo_price')->getType() instanceof BigIntType) {
+                    $this->addSql('ALTER TABLE coreshop_product_quantity_price_rule_range CHANGE pseudo_price pseudo_price BIGINT NOT NULL;');
+                }
+            }
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+
+    }
+}

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/doctrine/model/ProductStoreValues.orm.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/doctrine/model/ProductStoreValues.orm.yml
@@ -13,7 +13,7 @@ CoreShop\Component\Core\Model\ProductStoreValues:
             type: pimcoreObject
         price:
             column: price
-            type: integer
+            type: bigint
     manyToOne:
         store:
             targetEntity: CoreShop\Component\Store\Model\StoreInterface

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/doctrine/model/QuantityRange.orm.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/doctrine/model/QuantityRange.orm.yml
@@ -4,10 +4,10 @@ CoreShop\Component\Core\Model\QuantityRange:
     fields:
         amount:
             column: amount
-            type: integer
+            type: bigint
         pseudoPrice:
             column: pseudo_price
-            type: integer
+            type: bigint
     manyToOne:
         currency:
             targetEntity: CoreShop\Component\Currency\Model\CurrencyInterface

--- a/src/CoreShop/Bundle/ProductBundle/Resources/config/doctrine/model/ProductUnitDefinitionPrice.orm.yml
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/config/doctrine/model/ProductUnitDefinitionPrice.orm.yml
@@ -10,7 +10,7 @@ CoreShop\Component\Product\Model\ProductUnitDefinitionPrice:
                 strategy: AUTO
         price:
             column: price
-            type: integer
+            type: bigint
     manyToOne:
         unitDefinition:
             targetEntity: CoreShop\Component\Product\Model\ProductUnitDefinitionInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | ---

Follow-Up for #1030. Use BIGINT type to allow crazy deep fraction digits.
