### PR TITLE
Fix missing coreshop.helper namespace

### DIFF
--- a/src/CoreShop/Bundle/ResourceBundle/Resources/public/pimcore/js/helpers.js
+++ b/src/CoreShop/Bundle/ResourceBundle/Resources/public/pimcore/js/helpers.js
@@ -10,6 +10,8 @@
  *
  */
 
+pimcore.registerNS('coreshop.helpers.x');
+
 coreshop.helpers.requestNicePathData = function (targets, responseHandler) {
     var elementData = Ext.encode(targets);
 


### PR DESCRIPTION
In some cases coreshop.helper might be missing, so this PR fixes this issue.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no


In some cases coreshop.helper might be missing, so this PR fixes this issue.
