### PR TITLE
[MoneyBundle] add fallback in money-bundle for decimal precision

### DIFF
--- a/src/CoreShop/Bundle/MoneyBundle/DependencyInjection/CoreShopMoneyExtension.php
+++ b/src/CoreShop/Bundle/MoneyBundle/DependencyInjection/CoreShopMoneyExtension.php
@@ -29,6 +29,14 @@ final class CoreShopMoneyExtension extends AbstractPimcoreExtension
 
         $this->registerPimcoreResources('coreshop', $config['pimcore_admin'], $container);
 
+        if (!$container->hasParameter('coreshop.currency.decimal_factor')) {
+            $container->setParameter('coreshop.currency.decimal_factor', 100);
+        }
+
+        if (!$container->hasParameter('coreshop.currency.decimal_precision')) {
+            $container->setParameter('coreshop.currency.decimal_precision', 2);
+        }
+
         $bundles = $container->getParameter('kernel.bundles');
 
         if (array_key_exists('PimcoreDataHubBundle', $bundles)) {


### PR DESCRIPTION
 in case currency-bundle is not installed.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? |no

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->
