### PR TITLE
Private member variables in PHP7 are only accessible via getters.

### DIFF
--- a/src/CoreShop/Bundle/PimcoreBundle/CoreExtension/EmbeddedClass.php
+++ b/src/CoreShop/Bundle/PimcoreBundle/CoreExtension/EmbeddedClass.php
@@ -72,6 +72,7 @@ final class EmbeddedClass extends DataObject\ClassDefinition\Data\ManyToManyRela
 
         $returnData = [];
 
+        $i = 0;
         foreach ($data as $embeddedObject) {
             if (!$embeddedObject instanceof DataObject\Concrete) {
                 continue;
@@ -88,10 +89,11 @@ final class EmbeddedClass extends DataObject\ClassDefinition\Data\ManyToManyRela
 
             $objectData['id'] = $embeddedObject->getId();
             $objectData['general'] = [
-                'index' => $embeddedObject->getIndex(),
+                'index' => ++$i,
+                'o_className' => $embeddedObject->getClassName(),
             ];
 
-            $allowedKeys = ['o_published', 'o_key', 'o_id', 'o_modificationDate', 'o_creationDate', 'o_classId', 'o_className', 'o_locked', 'o_type', 'o_parentId', 'o_userOwner', 'o_userModification'];
+            $allowedKeys = ['o_published', 'o_key', 'o_id', 'o_modificationDate', 'o_creationDate', 'o_classId', 'o_locked', 'o_type', 'o_parentId', 'o_userOwner', 'o_userModification'];
 
             foreach (get_object_vars($embeddedObject) as $key => $value) {
                 if (strstr($key, 'o_') && in_array($key, $allowedKeys)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no


<!--
Private member variables are not accessible via get_object_vars(). This resulted in the field o_className not be returned.
![EmbeddedClass](https://user-images.githubusercontent.com/32675/63013143-dd0f2680-be8b-11e9-80e0-1c764ad7f309.png)

-->
