### PR TITLE
Make FrontendBundle configuration work again

### DIFF
--- a/src/CoreShop/Bundle/FrontendBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/FrontendBundle/DependencyInjection/Configuration.php
@@ -39,7 +39,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('coreshop_frontend');
+        $rootNode = $treeBuilder->root('core_shop_frontend');
 
         $rootNode
             ->children()


### PR DESCRIPTION
Corrected the config tree's root node name in order to make configuration available to app

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

Fixed configuration root key. Currently it is not possible to configure the frontend-bundle without this fix.