### PR TITLE
Fixing FrontendBundle Configuration

### DIFF
--- a/src/CoreShop/Bundle/AddressBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/AddressBundle/DependencyInjection/Configuration.php
@@ -50,7 +50,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('coreshop_address');
+        $rootNode = $treeBuilder->root('core_shop_address');
 
         $rootNode
             ->children()

--- a/src/CoreShop/Bundle/ConfigurationBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/ConfigurationBundle/DependencyInjection/Configuration.php
@@ -29,7 +29,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('coreshop_configuration');
+        $rootNode = $treeBuilder->root('core_shop_configuration');
 
         $rootNode
             ->children()

--- a/src/CoreShop/Bundle/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/CoreBundle/DependencyInjection/Configuration.php
@@ -29,7 +29,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('coreshop_core');
+        $rootNode = $treeBuilder->root('core_shop_core');
 
         $rootNode
             ->children()

--- a/src/CoreShop/Bundle/CurrencyBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/CurrencyBundle/DependencyInjection/Configuration.php
@@ -36,7 +36,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('coreshop_currency');
+        $rootNode = $treeBuilder->root('core_shop_currency');
 
         $rootNode
             ->children()

--- a/src/CoreShop/Bundle/CustomerBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/CustomerBundle/DependencyInjection/Configuration.php
@@ -29,7 +29,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('coreshop_customer');
+        $rootNode = $treeBuilder->root('core_shop_customer');
 
         $rootNode
             ->children()

--- a/src/CoreShop/Bundle/FixtureBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/FixtureBundle/DependencyInjection/Configuration.php
@@ -29,7 +29,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('coreshop_fixture');
+        $rootNode = $treeBuilder->root('core_shop_fixture');
 
         $rootNode
             ->children()

--- a/src/CoreShop/Bundle/FrontendBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/FrontendBundle/DependencyInjection/Configuration.php
@@ -39,7 +39,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('coreshop_frontend');
+        $rootNode = $treeBuilder->root('core_shop_frontend');
 
         $rootNode
             ->children()

--- a/src/CoreShop/Bundle/IndexBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/IndexBundle/DependencyInjection/Configuration.php
@@ -40,7 +40,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('coreshop_index');
+        $rootNode = $treeBuilder->root('core_shop_index');
 
         $rootNode
             ->children()

--- a/src/CoreShop/Bundle/InventoryBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/InventoryBundle/DependencyInjection/Configuration.php
@@ -23,7 +23,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('coreshop_inventory');
+        $rootNode = $treeBuilder->root('core_shop_inventory');
 
         $rootNode
             ->addDefaultsIfNotSet()

--- a/src/CoreShop/Bundle/MoneyBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/MoneyBundle/DependencyInjection/Configuration.php
@@ -24,7 +24,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('coreshop_money');
+        $rootNode = $treeBuilder->root('core_shop_money');
 
         $this->addPimcoreResourcesSection($rootNode);
 

--- a/src/CoreShop/Bundle/NotificationBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/NotificationBundle/DependencyInjection/Configuration.php
@@ -31,7 +31,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('coreshop_notification');
+        $rootNode = $treeBuilder->root('core_shop_notification');
 
         $rootNode
             ->children()

--- a/src/CoreShop/Bundle/OrderBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/OrderBundle/DependencyInjection/Configuration.php
@@ -61,7 +61,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('coreshop_order');
+        $rootNode = $treeBuilder->root('core_shop_order');
 
         $rootNode
             ->children()

--- a/src/CoreShop/Bundle/PaymentBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/PaymentBundle/DependencyInjection/Configuration.php
@@ -38,7 +38,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('coreshop_payment');
+        $rootNode = $treeBuilder->root('core_shop_payment');
 
         $rootNode
             ->children()

--- a/src/CoreShop/Bundle/PayumBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/PayumBundle/DependencyInjection/Configuration.php
@@ -29,7 +29,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('coreshop_payum');
+        $rootNode = $treeBuilder->root('core_shop_payum');
 
         $rootNode
             ->addDefaultsIfNotSet()

--- a/src/CoreShop/Bundle/PimcoreBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/PimcoreBundle/DependencyInjection/Configuration.php
@@ -24,7 +24,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('coreshop_pimcore');
+        $rootNode = $treeBuilder->root('core_shop_pimcore');
 
         $this->addPimcoreResourcesSection($rootNode);
 

--- a/src/CoreShop/Bundle/ProductBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/ProductBundle/DependencyInjection/Configuration.php
@@ -41,7 +41,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('coreshop_product');
+        $rootNode = $treeBuilder->root('core_shop_product');
 
         $rootNode
             ->children()

--- a/src/CoreShop/Bundle/ResourceBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/ResourceBundle/DependencyInjection/Configuration.php
@@ -27,7 +27,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('coreshop_resource');
+        $rootNode = $treeBuilder->root('core_shop_resource');
 
         $this->addResourcesSection($rootNode);
         $this->addTranslationsSection($rootNode);

--- a/src/CoreShop/Bundle/RuleBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/RuleBundle/DependencyInjection/Configuration.php
@@ -31,7 +31,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('coreshop_rule');
+        $rootNode = $treeBuilder->root('core_shop_rule');
 
         $rootNode
             ->children()

--- a/src/CoreShop/Bundle/SequenceBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/SequenceBundle/DependencyInjection/Configuration.php
@@ -30,7 +30,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('coreshop_sequence');
+        $rootNode = $treeBuilder->root('core_shop_sequence');
 
         $rootNode
             ->children()

--- a/src/CoreShop/Bundle/ShippingBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/ShippingBundle/DependencyInjection/Configuration.php
@@ -41,7 +41,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('coreshop_shipping');
+        $rootNode = $treeBuilder->root('core_shop_shipping');
 
         $rootNode
             ->children()

--- a/src/CoreShop/Bundle/StoreBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/StoreBundle/DependencyInjection/Configuration.php
@@ -30,7 +30,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('coreshop_store');
+        $rootNode = $treeBuilder->root('core_shop_store');
 
         $rootNode
             ->children()

--- a/src/CoreShop/Bundle/TaxationBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/TaxationBundle/DependencyInjection/Configuration.php
@@ -45,7 +45,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('coreshop_taxation');
+        $rootNode = $treeBuilder->root('core_shop_taxation');
 
         $rootNode
             ->children()

--- a/src/CoreShop/Bundle/TrackingBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/TrackingBundle/DependencyInjection/Configuration.php
@@ -24,7 +24,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('coreshop_tracking');
+        $rootNode = $treeBuilder->root('core_shop_tracking');
 
         $this->buildTrackingNode($rootNode);
 

--- a/src/CoreShop/Bundle/WorkflowBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/WorkflowBundle/DependencyInjection/Configuration.php
@@ -25,7 +25,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('coreshop_workflow');
+        $rootNode = $treeBuilder->root('core_shop_workflow');
 
         $smNode = $rootNode
             ->children()


### PR DESCRIPTION
Corrected the config tree's root node name in order to make configuration available to app

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

Fixed configuration root key. Currently it is not possible to configure the frontend-bundle without this fix.