### PR TITLE
[AutoWire] improvement: allow service registries to be autowired 

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services/reports.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services/reports.yml
@@ -7,12 +7,16 @@ services:
         arguments:
             - 'CoreShop\Component\Core\Report\ReportInterface'
             - 'coreshop-reports'
+        tags:
+            - { name: coreshop.registry, type_hint: reports }
 
     coreshop.registry.portlets:
         class: CoreShop\Component\Registry\ServiceRegistry
         arguments:
             - 'CoreShop\Component\Core\Portlet\PortletInterface'
             - 'coreshop-portlets'
+        tags:
+            - { name: coreshop.registry, type_hint: portlets }
 
     coreshop.report.products: '@CoreShop\Bundle\CoreBundle\Report\ProductsReport'
     CoreShop\Bundle\CoreBundle\Report\ProductsReport:

--- a/src/CoreShop/Bundle/IndexBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/IndexBundle/Resources/config/services.yml
@@ -36,6 +36,8 @@ services:
         arguments:
             - Symfony\Component\Form\FormTypeInterface
             - index-column-types
+        tags:
+            - { name: coreshop.registry, type_hint: indexColumnTypes }
 
     coreshop.form_registry.index_column_types:
         class: CoreShop\Bundle\ResourceBundle\Form\Registry\FormTypeRegistry
@@ -46,6 +48,8 @@ services:
         arguments:
             - CoreShop\Component\Index\Worker\WorkerInterface
             - index-workers
+        tags:
+            - { name: coreshop.registry, type_hint: indexWorkers }
 
     coreshop.form_registry.index.worker:
         class: CoreShop\Bundle\ResourceBundle\Form\Registry\FormTypeRegistry
@@ -56,6 +60,8 @@ services:
         arguments:
             - CoreShop\Component\Index\Extension\IndexExtensionInterface
             - index-extensions
+        tags:
+            - { name: coreshop.registry, type_hint: indexExtensions }
 
     # Filter Registry
     coreshop.registry.filter.pre_condition_types:
@@ -63,6 +69,8 @@ services:
         arguments:
             - CoreShop\Component\Index\Filter\FilterConditionProcessorInterface
             - filter-processor
+        tags:
+            - { name: coreshop.registry, type_hint: filterPreConditionProcessors }
 
     coreshop.form_registry.filter.pre_condition_types:
         class: CoreShop\Bundle\ResourceBundle\Form\Registry\FormTypeRegistry
@@ -72,6 +80,8 @@ services:
         arguments:
             - CoreShop\Component\Index\Filter\FilterConditionProcessorInterface
             - filter-processor
+        tags:
+            - { name: coreshop.registry, type_hint: filterConditionProcessors }
 
     coreshop.form_registry.filter.user_condition_types:
         class: CoreShop\Bundle\ResourceBundle\Form\Registry\FormTypeRegistry
@@ -82,6 +92,8 @@ services:
         arguments:
             - CoreShop\Component\Index\Getter\GetterInterface
             - index-getters
+        tags:
+            - { name: coreshop.registry, type_hint: indexGetters }
 
     coreshop.form_registry.index.getter:
         class: CoreShop\Bundle\ResourceBundle\Form\Registry\FormTypeRegistry
@@ -92,6 +104,8 @@ services:
         arguments:
             - CoreShop\Component\Index\Interpreter\InterpreterInterface
             - index-interpreters
+        tags:
+            - { name: coreshop.registry, type_hint: indexInterpreters }
 
     coreshop.form_registry.index.interpreter:
         class: CoreShop\Bundle\ResourceBundle\Form\Registry\FormTypeRegistry

--- a/src/CoreShop/Bundle/IndexBundle/Resources/config/services/condition_renderer.yml
+++ b/src/CoreShop/Bundle/IndexBundle/Resources/config/services/condition_renderer.yml
@@ -4,6 +4,8 @@ services:
         arguments:
             - CoreShop\Component\Index\Condition\DynamicRendererInterface
             - condition-renderers
+        tags:
+            - { name: coreshop.registry, type_hint: indexConditionRenderers }
 
     ## Renderer
     coreshop.index.condition.renderer: '@CoreShop\Component\Index\Condition\ConditionRenderer'

--- a/src/CoreShop/Bundle/IndexBundle/Resources/config/services/order_renderer.yml
+++ b/src/CoreShop/Bundle/IndexBundle/Resources/config/services/order_renderer.yml
@@ -4,6 +4,8 @@ services:
         arguments:
             - CoreShop\Component\Index\Order\DynamicOrderRendererInterface
             - order-renderers
+        tags:
+            - { name: coreshop.registry, type_hint: indexOrderRenderers }
 
     ## Renderer
     coreshop.index.order.renderer: '@CoreShop\Component\Index\Order\OrderRenderer'

--- a/src/CoreShop/Bundle/MenuBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/MenuBundle/Resources/config/services.yml
@@ -10,6 +10,8 @@ services:
         arguments:
             - 'CoreShop\Bundle\MenuBundle\Builder\MenuBuilder'
             - 'menu-builder'
+        tags:
+            - { name: coreshop.registry, type_hint: menues }
 
     coreshop.menu.renderer.json: '@CoreShop\Bundle\MenuBundle\Renderer\JsonRenderer'
     CoreShop\Bundle\MenuBundle\Renderer\JsonRenderer:

--- a/src/CoreShop/Bundle/NotificationBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/NotificationBundle/Resources/config/services.yml
@@ -39,6 +39,8 @@ services:
         arguments:
             - CoreShop\Component\Rule\Condition\ConditionCheckerInterface
             - notification-rule-conditions
+        tags:
+            - { name: coreshop.registry, type_hint: notificationRuleConditions }
 
     coreshop.form_registry.notification_rule.conditions:
         class: CoreShop\Bundle\ResourceBundle\Form\Registry\FormTypeRegistry
@@ -48,6 +50,8 @@ services:
         arguments:
             - CoreShop\Component\Notification\Rule\Action\NotificationRuleProcessorInterface
             - notification-rule-actions
+        tags:
+            - { name: coreshop.registry, type_hint: notificationRuleActions }
 
     coreshop.form_registry.notification_rule.actions:
         class: CoreShop\Bundle\ResourceBundle\Form\Registry\FormTypeRegistry

--- a/src/CoreShop/Bundle/OrderBundle/Resources/config/services/cart-price-rules.yml
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/config/services/cart-price-rules.yml
@@ -91,7 +91,9 @@ services:
         class: CoreShop\Component\Registry\ServiceRegistry
         arguments:
             - CoreShop\Component\Rule\Condition\ConditionCheckerInterface
-            - product-price-rule-conditions
+            - cart-price-rule-conditions
+        tags:
+            - { name: coreshop.registry, type_hint: cartPriceRuleConditions }
 
     coreshop.form_registry.cart_price_rule.conditions:
         class: CoreShop\Bundle\ResourceBundle\Form\Registry\FormTypeRegistry
@@ -100,7 +102,9 @@ services:
         class: CoreShop\Component\Registry\ServiceRegistry
         arguments:
             - CoreShop\Component\Order\Cart\Rule\Action\CartPriceRuleActionProcessorInterface
-            - product-price-rule-actions
+            - cart-price-rule-actions
+        tags:
+            - { name: coreshop.registry, type_hint: cartPriceRuleActions }
 
     coreshop.form_registry.cart_price_rule.actions:
         class: CoreShop\Bundle\ResourceBundle\Form\Registry\FormTypeRegistry

--- a/src/CoreShop/Bundle/OrderBundle/Resources/config/services/purchasable.yml
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/config/services/purchasable.yml
@@ -7,6 +7,8 @@ services:
         arguments:
             - CoreShop\Component\Order\Calculator\PurchasableRetailPriceCalculatorInterface
             - purchasable-retail-price-calculators
+        tags:
+            - { name: coreshop.registry, type_hint: purchaseableRetailPriceCalculators }
 
     coreshop.order.purchasable.retail_price_calculator: '@CoreShop\Component\Order\Calculator\CompositePurchasableRetailPriceCalculator'
     CoreShop\Component\Order\Calculator\PurchasableRetailPriceCalculatorInterface: '@CoreShop\Component\Order\Calculator\CompositePurchasableRetailPriceCalculator'
@@ -19,6 +21,8 @@ services:
         arguments:
             - CoreShop\Component\Order\Calculator\PurchasableDiscountCalculatorInterface
             - purchasable-discount-calculators
+        tags:
+            - { name: coreshop.registry, type_hint: purchaseableDiscountCalculators }
 
     coreshop.order.purchasable.discount_calculator.no_discount: '@CoreShop\Component\Order\Calculator\NoDiscountPurchasableCalculator'
     CoreShop\Component\Order\Calculator\NoDiscountPurchasableCalculator:
@@ -36,6 +40,8 @@ services:
         arguments:
             - CoreShop\Component\Order\Calculator\PurchasableDiscountPriceCalculatorInterface
             - purchasable-discount-price-calculators
+        tags:
+            - { name: coreshop.registry, type_hint: purchaseableDiscountPriceCalculators }
 
     coreshop.order.purchasable.price_discount_calculator: '@CoreShop\Component\Order\Calculator\CompositePurchasableDiscountPriceCalculator'
     CoreShop\Component\Order\Calculator\PurchasableDiscountPriceCalculatorInterface: '@CoreShop\Component\Order\Calculator\CompositePurchasableDiscountPriceCalculator'
@@ -48,12 +54,16 @@ services:
         arguments:
             - CoreShop\Component\Order\Calculator\PurchasablePriceCalculatorInterface
             - purchasable-price-calculators
+        tags:
+            - { name: coreshop.registry, type_hint: purchaseablePriceCalculators }
 
     coreshop.registry.order.purchasable.wholesale_price_calculators:
         class: CoreShop\Component\Registry\PrioritizedServiceRegistry
         arguments:
             - CoreShop\Component\Order\Calculator\PurchasableWholesalePriceCalculatorInterface
             - purchasable-wholesale-price-calculators
+        tags:
+            - { name: coreshop.registry, type_hint: purchaseableWholesalePriceCalculators }
 
     coreshop.order.purchasable.price_calculator: '@CoreShop\Component\Order\Calculator\CompositePurchasablePriceCalculator'
     CoreShop\Component\Order\Calculator\PurchasablePriceCalculatorInterface: '@CoreShop\Component\Order\Calculator\CompositePurchasablePriceCalculator'

--- a/src/CoreShop/Bundle/PimcoreBundle/CoreShopPimcoreBundle.php
+++ b/src/CoreShop/Bundle/PimcoreBundle/CoreShopPimcoreBundle.php
@@ -17,6 +17,7 @@ use CoreShop\Bundle\PimcoreBundle\DependencyInjection\Compiler\RegisterGridActio
 use CoreShop\Bundle\PimcoreBundle\DependencyInjection\Compiler\RegisterGridFilterPass;
 use CoreShop\Bundle\PimcoreBundle\DependencyInjection\Compiler\RegisterPimcoreDocumentTagImplementationLoaderPass;
 use CoreShop\Bundle\PimcoreBundle\DependencyInjection\Compiler\RegisterPimcoreDocumentTagPass;
+use CoreShop\Bundle\PimcoreBundle\DependencyInjection\Compiler\RegisterTypeHintRegistriesPass;
 use PackageVersions\Versions;
 use Pimcore\Extension\Bundle\AbstractPimcoreBundle;
 use Pimcore\Extension\Bundle\Traits\PackageVersionTrait;
@@ -77,6 +78,7 @@ final class CoreShopPimcoreBundle extends AbstractPimcoreBundle
         $container->addCompilerPass(new RegisterPimcoreDocumentTagImplementationLoaderPass());
         $container->addCompilerPass(new RegisterPimcoreDocumentTagPass());
         $container->addCompilerPass(new ExpressionLanguageServicePass());
+        $container->addCompilerPass(new RegisterTypeHintRegistriesPass());
     }
 
     /**

--- a/src/CoreShop/Bundle/PimcoreBundle/DependencyInjection/Compiler/RegisterTypeHintRegistriesPass.php
+++ b/src/CoreShop/Bundle/PimcoreBundle/DependencyInjection/Compiler/RegisterTypeHintRegistriesPass.php
@@ -25,6 +25,10 @@ final class RegisterTypeHintRegistriesPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
+        if (!method_exists($container, 'registerAliasForArgument')) {
+            return;
+        }
+
         foreach ($container->findTaggedServiceIds('coreshop.registry') as $id => $attributes) {
             if (!isset($attributes[0]['type_hint'])) {
                 throw new \InvalidArgumentException('Tagged Repository `'.$id.'` needs to have `type_hint` attributes');

--- a/src/CoreShop/Bundle/PimcoreBundle/DependencyInjection/Compiler/RegisterTypeHintRegistriesPass.php
+++ b/src/CoreShop/Bundle/PimcoreBundle/DependencyInjection/Compiler/RegisterTypeHintRegistriesPass.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2019 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\PimcoreBundle\DependencyInjection\Compiler;
+
+use CoreShop\Component\Registry\PrioritizedServiceRegistryInterface;
+use CoreShop\Component\Registry\ServiceRegistry;
+use CoreShop\Component\Registry\ServiceRegistryInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class RegisterTypeHintRegistriesPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        foreach ($container->findTaggedServiceIds('coreshop.registry') as $id => $attributes) {
+            if (!isset($attributes[0]['type_hint'])) {
+                throw new \InvalidArgumentException('Tagged Repository `'.$id.'` needs to have `type_hint` attributes');
+            }
+
+            $definition = $container->findDefinition($id);
+
+            $implements = class_implements($definition->getClass());
+
+            if (
+                !in_array(ServiceRegistryInterface::class, $implements) &&
+                !in_array(PrioritizedServiceRegistryInterface::class, $implements)
+            ) {
+                throw new \InvalidArgumentException(
+                    sprintf(
+                        'Registry needs to implement interface %s or %s, given %s',
+                        ServiceRegistryInterface::class,
+                        PrioritizedServiceRegistryInterface::class,
+                        implode(', ', $implements)
+                    )
+                );
+            }
+
+            $container->registerAliasForArgument(
+                $id,
+                ServiceRegistryInterface::class,
+                strtolower(trim(preg_replace(['/([A-Z])/', '/[_\s]+/'], ['_$1', ' '],
+                    $attributes[0]['type_hint']))).'Registry'
+            );
+
+            $container->registerAliasForArgument(
+                $id,
+                ServiceRegistry::class,
+                strtolower(trim(preg_replace(['/([A-Z])/', '/[_\s]+/'], ['_$1', ' '],
+                    $attributes[0]['type_hint']))).'Registry'
+            );
+        }
+    }
+}

--- a/src/CoreShop/Bundle/PimcoreBundle/Resources/config/pimcore/routing.yml
+++ b/src/CoreShop/Bundle/PimcoreBundle/Resources/config/pimcore/routing.yml
@@ -1,33 +1,32 @@
 coreshop_pimcore_embedded_class_get_custom_layouts:
     path: /%coreshop.admin.route.base%/embedded-class/get-custom-layouts
-    defaults: { _controller: 'CoreShop\Bundle\PimcoreBundle\Controller\Admin\EmbeddedClassController::getCustomLayoutsAction'}
+    defaults: { _controller: CoreShop\Bundle\PimcoreBundle\Controller\Admin\EmbeddedClassController::getCustomLayoutsAction }
 
 coreshop_pimcore_embedded_class_get_layout_configuration:
     path: /%coreshop.admin.route.base%/embedded-class/get-layout-configuration
-    defaults: { _controller: 'CoreShop\Bundle\PimcoreBundle\Controller\Admin\EmbeddedClassController::getClassLayoutAction'}
+    defaults: { _controller: CoreShop\Bundle\PimcoreBundle\Controller\Admin\EmbeddedClassController::getClassLayoutAction }
 
-##### GRID
 coreshop_pimcore_grid_get_filters:
     path: /%coreshop.admin.route.base%/grid/filters/{listType}
     methods: [GET]
-    defaults:  { _controller: coreshop.pimcore_controller.grid:getGridFiltersAction}
+    defaults:  { _controller: CoreShop\Bundle\PimcoreBundle\Controller\Admin\GridController:getGridFiltersAction }
 
 coreshop_pimcore_grid_get_actions:
     path: /%coreshop.admin.route.base%/grid/actions/{listType}
     methods: [GET]
-    defaults:  { _controller: coreshop.pimcore_controller.grid:getGridActionsAction}
+    defaults:  { _controller: CoreShop\Bundle\PimcoreBundle\Controller\Admin\GridController:getGridActionsAction }
 
 coreshop_pimcore_grid_apply_action:
     path: /%coreshop.admin.route.base%/grid/apply-action
     methods: [POST]
-    defaults:  { _controller: coreshop.pimcore_controller.grid:applyGridAction}
+    defaults:  { _controller: CoreShop\Bundle\PimcoreBundle\Controller\Admin\GridController:applyGridAction }
 
 coreshop_dynamic_dropdown_options:
     path: /%coreshop.admin.route.base%/dynamic-dropdown/options
-    defaults: { _controller: coreshop.pimcore_controller.dynamic_dropdown:optionsAction }
+    defaults: { _controller: CoreShop\Bundle\PimcoreBundle\Controller\Admin\DynamicDropdownController:optionsAction }
     methods:  [GET, POST]
 
 coreshop_dynamic_dropdown_methods:
     path: /%coreshop.admin.route.base%/dynamic-dropdown/methods
-    defaults: { _controller: coreshop.pimcore_controller.dynamic_dropdown:methodsAction }
+    defaults: { _controller: CoreShop\Bundle\PimcoreBundle\Controller\Admin\DynamicDropdownController:methodsAction }
     methods:  [GET, POST]

--- a/src/CoreShop/Bundle/PimcoreBundle/Resources/config/services/dynamic_dropdown.yml
+++ b/src/CoreShop/Bundle/PimcoreBundle/Resources/config/services/dynamic_dropdown.yml
@@ -1,5 +1,8 @@
 services:
-    coreshop.pimcore_controller.dynamic_dropdown: '@CoreShop\Bundle\PimcoreBundle\Controller\Admin\DynamicDropdownController'
+    coreshop.pimcore_controller.dynamic_dropdown:
+        alias: 'CoreShop\Bundle\PimcoreBundle\Controller\Admin\DynamicDropdownController'
+        public: true
+
     CoreShop\Bundle\PimcoreBundle\Controller\Admin\DynamicDropdownController:
         tags:
             - { name: controller.service_arguments }

--- a/src/CoreShop/Bundle/PimcoreBundle/Resources/config/services/grid.yml
+++ b/src/CoreShop/Bundle/PimcoreBundle/Resources/config/services/grid.yml
@@ -2,7 +2,10 @@ services:
     _defaults:
         public: true
 
-    coreshop.pimcore_controller.grid: '@CoreShop\Bundle\PimcoreBundle\Controller\Admin\GridController'
+    coreshop.pimcore_controller.grid:
+        alias: 'CoreShop\Bundle\PimcoreBundle\Controller\Admin\GridController'
+        public: true
+
     CoreShop\Bundle\PimcoreBundle\Controller\Admin\GridController:
         tags:
             - { name: controller.service_arguments }
@@ -19,6 +22,8 @@ services:
         arguments:
             - 'CoreShop\Component\Pimcore\DataObject\Grid\GridFilterInterface'
             - 'coreshop-grid-filter'
+        tags:
+            - { name: coreshop.registry, type_hint: gridFilters }
 
     coreshop.registry.grid.action:
         class: CoreShop\Component\Registry\ServiceRegistry
@@ -26,3 +31,5 @@ services:
         arguments:
             - 'CoreShop\Component\Pimcore\DataObject\Grid\GridActionInterface'
             - 'coreshop-grid-action'
+        tags:
+            - { name: coreshop.registry, type_hint: gridActions }

--- a/src/CoreShop/Bundle/PimcoreBundle/Resources/config/services/pimcore.yml
+++ b/src/CoreShop/Bundle/PimcoreBundle/Resources/config/services/pimcore.yml
@@ -7,6 +7,8 @@ services:
         arguments:
             - CoreShop\Component\Pimcore\Document\DocumentTagFactoryInterface
             - document-tag-factories
+        tags:
+            - { name: coreshop.registry, type_hint: pimcoreDocumentTags }
 
     CoreShop\Bundle\PimcoreBundle\Loader\DependencyInjectionImplementationLoader:
         arguments:

--- a/src/CoreShop/Bundle/ProductBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/config/services.yml
@@ -14,18 +14,24 @@ services:
         arguments:
             - CoreShop\Component\Product\Calculator\ProductRetailPriceCalculatorInterface
             - product-retail-price-calculators
+        tags:
+            - { name: coreshop.registry, type_hint: productRetailPriceCalculators }
 
     coreshop.registry.product.discount_price_calculators:
         class: CoreShop\Component\Registry\PrioritizedServiceRegistry
         arguments:
             - CoreShop\Component\Product\Calculator\ProductDiscountPriceCalculatorInterface
             - product-discount-price-calculators
+        tags:
+            - { name: coreshop.registry, type_hint: productDiscountPriceCalculators }
 
     coreshop.registry.product.discount_calculators:
         class: CoreShop\Component\Registry\PrioritizedServiceRegistry
         arguments:
             - CoreShop\Component\Product\Calculator\ProductDiscountCalculatorInterface
             - product-discount-calculators
+        tags:
+            - { name: coreshop.registry, type_hint: productDiscountCalculators }
 
     coreshop.product.retail_price_calculator: '@CoreShop\Component\Product\Calculator\ProductRetailPriceCalculatorInterface'
     CoreShop\Component\Product\Calculator\ProductRetailPriceCalculatorInterface: '@CoreShop\Component\Product\Calculator\CompositeRetailPriceCalculator'
@@ -106,6 +112,8 @@ services:
         arguments:
             - CoreShop\Component\Product\Calculator\ProductPriceCalculatorInterface
             - product-price-calculators
+        tags:
+            - { name: coreshop.registry, type_hint: productPriceCalculators }
 
     coreshop.product.price_calculator: '@CoreShop\Component\Product\Calculator\ProductPriceCalculatorInterface'
     CoreShop\Component\Product\Calculator\ProductPriceCalculatorInterface: '@CoreShop\Component\Product\Calculator\ProductPriceCalculator'

--- a/src/CoreShop/Bundle/ProductBundle/Resources/config/services/price-rules.yml
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/config/services/price-rules.yml
@@ -71,6 +71,8 @@ services:
         arguments:
             - CoreShop\Component\Rule\Condition\ConditionCheckerInterface
             - product-price-rule-conditions
+        tags:
+            - { name: coreshop.registry, type_hint: productPriceRuleConditions }
 
     coreshop.form_registry.product_price_rule.conditions:
         class: CoreShop\Bundle\ResourceBundle\Form\Registry\FormTypeRegistry
@@ -80,6 +82,8 @@ services:
         arguments:
             - CoreShop\Component\Product\Rule\Action\ActionProcessorInterface
             - product-price-rule-actions
+        tags:
+            - { name: coreshop.registry, type_hint: productPriceRuleActions }
 
     coreshop.form_registry.product_price_rule.actions:
         class: CoreShop\Bundle\ResourceBundle\Form\Registry\FormTypeRegistry

--- a/src/CoreShop/Bundle/ProductBundle/Resources/config/services/rules.yml
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/config/services/rules.yml
@@ -6,6 +6,8 @@ services:
         class: CoreShop\Component\Registry\ServiceRegistry
         arguments:
             - 'CoreShop\Component\Product\Rule\Fetcher\ValidRulesFetcherInterface'
+        tags:
+            - { name: coreshop.registry, type_hint: productRuleFetchers }
 
     coreshop.product.rules.fetcher: '@CoreShop\Component\Product\Rule\Fetcher\ValidRulesFetcherInterface'
     CoreShop\Component\Product\Rule\Fetcher\ValidRulesFetcherInterface: '@CoreShop\Component\Product\Rule\Fetcher\CompositeValidRuleFetcher'

--- a/src/CoreShop/Bundle/ProductBundle/Resources/config/services/specific-price-rules.yml
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/config/services/specific-price-rules.yml
@@ -71,6 +71,8 @@ services:
         arguments:
             - CoreShop\Component\Rule\Condition\ConditionCheckerInterface
             - specific-product-price-rule-conditions
+        tags:
+            - { name: coreshop.registry, type_hint: productSpecificPriceRuleConditions }
 
     coreshop.form_registry.product_specific_price_rule.conditions:
         class: CoreShop\Bundle\ResourceBundle\Form\Registry\FormTypeRegistry
@@ -80,6 +82,8 @@ services:
         arguments:
             - CoreShop\Component\Product\Rule\Action\ActionProcessorInterface
             - product-price-rule-actions
+        tags:
+            - { name: coreshop.registry, type_hint: productSpecificPriceRuleActions }
 
     coreshop.form_registry.product_specific_price_rule.actions:
         class: CoreShop\Bundle\ResourceBundle\Form\Registry\FormTypeRegistry

--- a/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/config/services/actions.yml
+++ b/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/config/services/actions.yml
@@ -4,6 +4,8 @@ services:
         arguments:
             - CoreShop\Component\ProductQuantityPriceRules\Rule\Action\ProductQuantityPriceRuleActionInterface
             - product-quantity-price-rules-actions
+        tags:
+            - { name: coreshop.registry, type_hint: productQuantityPriceRuleActions }
 
     CoreShop\Component\ProductQuantityPriceRules\Rule\Action\PercentageDecreaseAction:
         tags:

--- a/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/config/services/calculator.yml
+++ b/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/config/services/calculator.yml
@@ -4,6 +4,8 @@ services:
         arguments:
             - CoreShop\Component\ProductQuantityPriceRules\Calculator\CalculatorInterface
             - product-quantity-price-rules-calculators
+        tags:
+            - { name: coreshop.registry, type_hint: productQuantityPriceRuleCalculators }
 
     CoreShop\Component\ProductQuantityPriceRules\Calculator\VolumeCalculator:
         arguments:

--- a/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/config/services/product-quantity-price-rules.yml
+++ b/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/config/services/product-quantity-price-rules.yml
@@ -51,6 +51,8 @@ services:
         arguments:
             - CoreShop\Component\Rule\Condition\ConditionCheckerInterface
             - product-quantity-price-rules-conditions
+        tags:
+            - { name: coreshop.registry, type_hint: productQuantityPriceRuleConditions }
 
     coreshop.form_registry.product_quantity_price_rules.conditions:
         class: CoreShop\Bundle\ResourceBundle\Form\Registry\FormTypeRegistry

--- a/src/CoreShop/Bundle/ResourceBundle/Resources/config/services/installer.yml
+++ b/src/CoreShop/Bundle/ResourceBundle/Resources/config/services/installer.yml
@@ -7,6 +7,8 @@ services:
         arguments:
             - CoreShop\Bundle\ResourceBundle\Installer\ResourceInstallerInterface
             - 'coreshop-resource-installer'
+        tags:
+            - { name: coreshop.registry, type_hint: resourceInstallers }
 
     CoreShop\Bundle\ResourceBundle\Installer\PimcoreClassInstaller:
         arguments:

--- a/src/CoreShop/Bundle/RuleBundle/Resources/config/services/rule_active_validator.yml
+++ b/src/CoreShop/Bundle/RuleBundle/Resources/config/services/rule_active_validator.yml
@@ -13,3 +13,5 @@ services:
         arguments:
             - 'CoreShop\Component\Rule\Condition\Assessor\RuleAvailabilityAssessorInterface'
             - 'rule-availability-assessor'
+        tags:
+            - { name: coreshop.registry, type_hint: ruleAvailabilityAssessors }

--- a/src/CoreShop/Bundle/SEOBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/SEOBundle/Resources/config/services.yml
@@ -10,6 +10,8 @@ services:
         arguments:
             - 'CoreShop\Component\SEO\Extractor\ExtractorInterface'
             - 'seo metadata extractor'
+        tags:
+            - { name: coreshop.registry, type_hint: seoExtractors }
 
     CoreShop\Component\SEO\SEOPresentation:
         arguments:

--- a/src/CoreShop/Bundle/ShippingBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/ShippingBundle/Resources/config/services.yml
@@ -27,6 +27,8 @@ services:
         arguments:
             - CoreShop\Component\Shipping\Calculator\CarrierPriceCalculatorInterface
             - shipping-price-calculators
+        tags:
+            - { name: coreshop.registry, type_hint: shippingPriceCalculators }
 
     coreshop.carrier.price_calculator.shipping_rules: '@CoreShop\Component\Shipping\Calculator\CarrierShippingRulePriceCalculator'
     CoreShop\Component\Shipping\Calculator\CarrierShippingRulePriceCalculator:

--- a/src/CoreShop/Bundle/ShippingBundle/Resources/config/services/shipping-rules.yml
+++ b/src/CoreShop/Bundle/ShippingBundle/Resources/config/services/shipping-rules.yml
@@ -6,7 +6,9 @@ services:
         class: CoreShop\Component\Registry\ServiceRegistry
         arguments:
             - CoreShop\Component\Rule\Condition\ConditionCheckerInterface
-            - ShippingRuleCondition
+            - shipping-rule-condition
+        tags:
+            - { name: coreshop.registry, type_hint: shippingRuleConditions }
 
     coreshop.form_registry.shipping_rule.conditions:
         class: CoreShop\Bundle\ResourceBundle\Form\Registry\FormTypeRegistry
@@ -15,7 +17,9 @@ services:
         class: CoreShop\Component\Registry\ServiceRegistry
         arguments:
             - CoreShop\Component\Shipping\Rule\Action\CarrierPriceActionProcessorInterface
-            - ShippingRuleAction
+            - shipping-rule-action
+        tags:
+            - { name: coreshop.registry, type_hint: shippingRuleActions }
 
     coreshop.form_registry.shipping_rule.actions:
         class: CoreShop\Bundle\ResourceBundle\Form\Registry\FormTypeRegistry

--- a/src/CoreShop/Bundle/ThemeBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/ThemeBundle/Resources/config/services.yml
@@ -10,6 +10,8 @@ services:
         arguments:
             - 'CoreShop\Bundle\ThemeBundle\Service\ThemeResolverInterface'
             - 'Theme Resolver'
+        tags:
+            - { name: coreshop.registry, type_hint: themeResolvers }
 
     coreshop.theme.active_theme: '@CoreShop\Bundle\ThemeBundle\Service\ActiveThemeInterface'
     CoreShop\Bundle\ThemeBundle\Service\ActiveThemeInterface: '@CoreShop\Bundle\ThemeBundle\Service\ActiveTheme'

--- a/src/CoreShop/Bundle/TrackingBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/TrackingBundle/Resources/config/services.yml
@@ -5,6 +5,8 @@ services:
         arguments:
             - CoreShop\Component\Tracking\Tracker\TrackerInterface
             - 'tracker'
+        tags:
+            - { name: coreshop.registry, type_hint: trackers }
 
     coreshop.registry.tracking.extractor:
         class: CoreShop\Component\Registry\ServiceRegistry
@@ -12,6 +14,8 @@ services:
         arguments:
             - CoreShop\Component\Tracking\Extractor\TrackingExtractorInterface
             - 'tracking-extractor'
+        tags:
+            - { name: coreshop.registry, type_hint: trackingExtractors }
 
     coreshop.tracking.resolver.tracking_config: '@CoreShop\Bundle\TrackingBundle\Resolver\ConfigResolverInterface'
     CoreShop\Bundle\TrackingBundle\Resolver\ConfigResolverInterface: '@CoreShop\Bundle\TrackingBundle\Resolver\ConfigResolver'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

Allows:

```php
<?php

namespace AppBundle\Controller;

use CoreShop\Component\Registry\ServiceRegistryInterface;
use Pimcore\Controller\FrontendController;
use Symfony\Component\HttpFoundation\Request;

class DefaultController extends FrontendController
{
    public function defaultAction(ServiceRegistryInterface $indexInterpretersRegistry)
    {
        var_dump($indexInterpretersRegistry->all());exit;
    }
}

```