### PR TITLE
[OrderBundle] CartItem Quantity has to be > 0

### DIFF
--- a/src/CoreShop/Bundle/OrderBundle/Form/Type/CartItemType.php
+++ b/src/CoreShop/Bundle/OrderBundle/Form/Type/CartItemType.php
@@ -18,8 +18,6 @@ use Symfony\Component\Form\DataMapperInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
-use Symfony\Component\Validator\Constraints\NotEqualTo;
-use Symfony\Component\Validator\Constraints\Range;
 
 final class CartItemType extends AbstractResourceType
 {

--- a/src/CoreShop/Bundle/OrderBundle/Form/Type/CartItemType.php
+++ b/src/CoreShop/Bundle/OrderBundle/Form/Type/CartItemType.php
@@ -18,6 +18,7 @@ use Symfony\Component\Form\DataMapperInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Validator\Constraints\NotEqualTo;
 use Symfony\Component\Validator\Constraints\Range;
 
 final class CartItemType extends AbstractResourceType
@@ -57,7 +58,6 @@ final class CartItemType extends AbstractResourceType
             $event->getForm()->add('quantity', QuantityType::class, [
                 'html5' => true,
                 'unit_definition' => $data->hasUnitDefinition() ? $data->getUnitDefinition() : null,
-                'constraints' => [new Range(['min' => 0])],
                 'label' => 'coreshop.ui.quantity',
                 'disabled' => $data->getIsGiftItem(),
             ]);

--- a/src/CoreShop/Bundle/OrderBundle/Resources/config/validation/CartItem.yml
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/config/validation/CartItem.yml
@@ -3,4 +3,4 @@ CoreShop\Component\Order\Model\CartItem:
         quantity:
             - NotBlank: { message: coreshop.cart_item.quantity.not_blank, groups: coreshop }
             - Type: { type: numeric, message: coreshop.cart_item.quantity.numeric, groups: coreshop }
-            - Range: { min: 0, minMessage: coreshop.cart_item.quantity.min, groups: coreshop }
+            - NotEqualTo: { value: 0, message: coreshop.cart_item.quantity.min, groups: coreshop }


### PR DESCRIPTION
the Range Validator can't handle that, so now we use the NotEqualTo Validator instead

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? |no

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->
