### PR TITLE
Change namespace QueryFieldConfigGenerator path

### DIFF
--- a/src/CoreShop/Bundle/CurrencyBundle/DataHub/QueryType/MoneyCurrency.php
+++ b/src/CoreShop/Bundle/CurrencyBundle/DataHub/QueryType/MoneyCurrency.php
@@ -16,7 +16,7 @@ use CoreShop\Component\Currency\Model\Money;
 use CoreShop\Component\Resource\DataHub\DoctrineProvider;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
-use Pimcore\Bundle\DataHubBundle\GraphQL\QueryFieldConfigGenerator\Input;
+use Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectQueryFieldConfigGenerator\Input;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 

--- a/src/CoreShop/Bundle/MoneyBundle/DataHub/QueryType/Money.php
+++ b/src/CoreShop/Bundle/MoneyBundle/DataHub/QueryType/Money.php
@@ -13,7 +13,7 @@
 namespace CoreShop\Bundle\MoneyBundle\DataHub\QueryType;
 
 use GraphQL\Type\Definition\Type;
-use Pimcore\Bundle\DataHubBundle\GraphQL\QueryFieldConfigGenerator\Input;
+use Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectQueryFieldConfigGenerator\Input;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 
 class Money extends Input

--- a/src/CoreShop/Bundle/PimcoreBundle/DataHub/QueryType/SerializedData.php
+++ b/src/CoreShop/Bundle/PimcoreBundle/DataHub/QueryType/SerializedData.php
@@ -13,7 +13,7 @@
 namespace CoreShop\Bundle\PimcoreBundle\DataHub\QueryType;
 
 use CoreShop\Bundle\PimcoreBundle\DataHub\Type\SerializedDataType;
-use Pimcore\Bundle\DataHubBundle\GraphQL\QueryFieldConfigGenerator\Input;
+use Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectQueryFieldConfigGenerator\Input;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 
 class SerializedData extends Input

--- a/src/CoreShop/Bundle/ResourceBundle/DataHub/QueryType/Select.php
+++ b/src/CoreShop/Bundle/ResourceBundle/DataHub/QueryType/Select.php
@@ -14,7 +14,7 @@ namespace CoreShop\Bundle\ResourceBundle\DataHub\QueryType;
 
 use CoreShop\Bundle\ResourceBundle\DataHub\Resolver\ResourceResolver;
 use GraphQL\Type\Definition\Type;
-use Pimcore\Bundle\DataHubBundle\GraphQL\QueryFieldConfigGenerator\Input;
+use Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectQueryFieldConfigGenerator\Input;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 
 class Select extends Input

--- a/src/CoreShop/Component/Resource/DataHub/QueryType/Resource.php
+++ b/src/CoreShop/Component/Resource/DataHub/QueryType/Resource.php
@@ -13,7 +13,7 @@
 namespace CoreShop\Component\Resource\DataHub\QueryType;
 
 use CoreShop\Component\Resource\DataHub\DoctrineProvider;
-use Pimcore\Bundle\DataHubBundle\GraphQL\QueryFieldConfigGenerator\Input;
+use Pimcore\Bundle\DataHubBundle\GraphQL\DataObjectQueryFieldConfigGenerator\Input;
 use Pimcore\Bundle\DataHubBundle\GraphQL\Service;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 


### PR DESCRIPTION
Namespace in the pimcore data hub have changed https://github.com/pimcore/data-hub/tree/master/src/GraphQL/DataObjectQueryFieldConfigGenerator

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->
