### PR TITLE
fix some migrations

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Migrations/Version20190226122625.php
+++ b/src/CoreShop/Bundle/CoreBundle/Migrations/Version20190226122625.php
@@ -19,22 +19,19 @@ class Version20190226122625 extends AbstractPimcoreMigration implements Containe
     {
         // install units and unit definitions
         if (!$schema->hasTable('coreshop_product_unit')) {
-            $this->addSql('
-                CREATE TABLE coreshop_product_unit_definitions (id INT AUTO_INCREMENT NOT NULL, default_unit_definition INT DEFAULT NULL, product INT NOT NULL COMMENT \'(DC2Type:pimcoreObject)\', UNIQUE INDEX UNIQ_5D50CA20D34A04AD (product), UNIQUE INDEX UNIQ_5D50CA20F3CE11C4 (default_unit_definition), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8MB4 COLLATE utf8mb4_general_ci ENGINE = InnoDB;
-                CREATE TABLE coreshop_product_unit (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(190) NOT NULL, creationDate DATE NOT NULL, modificationDate DATETIME DEFAULT NULL, UNIQUE INDEX UNIQ_803A19D05E237E06 (name), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8MB4 COLLATE utf8mb4_general_ci ENGINE = InnoDB;
-                CREATE TABLE coreshop_product_unit_definition (id INT AUTO_INCREMENT NOT NULL, product_unit_definitions INT DEFAULT NULL, unit INT DEFAULT NULL, conversion_rate DOUBLE PRECISION DEFAULT NULL, INDEX IDX_37BB52AF8685AB18 (product_unit_definitions), INDEX IDX_37BB52AFDCBB0C53 (unit), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8MB4 COLLATE utf8mb4_general_ci ENGINE = InnoDB;
-                CREATE TABLE coreshop_product_unit_definition_price (id INT AUTO_INCREMENT NOT NULL, unit_definition INT DEFAULT NULL, product_store_values INT DEFAULT NULL, price INT NOT NULL, INDEX IDX_13ECB5B6B98B918 (unit_definition), INDEX IDX_13ECB5BD314F81B (product_store_values), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8MB4 COLLATE utf8mb4_general_ci ENGINE = InnoDB;
-                ALTER TABLE coreshop_product_unit_definitions ADD CONSTRAINT FK_5D50CA20F3CE11C4 FOREIGN KEY (default_unit_definition) REFERENCES coreshop_product_unit_definition (id) ON DELETE SET NULL;
-                ALTER TABLE coreshop_product_unit_definition ADD CONSTRAINT FK_37BB52AF8685AB18 FOREIGN KEY (product_unit_definitions) REFERENCES coreshop_product_unit_definitions (id) ON DELETE CASCADE;
-                ALTER TABLE coreshop_product_unit_definition ADD CONSTRAINT FK_37BB52AFDCBB0C53 FOREIGN KEY (unit) REFERENCES coreshop_product_unit (id);
-                ALTER TABLE coreshop_product_unit_definition_price ADD CONSTRAINT FK_13ECB5B6B98B918 FOREIGN KEY (unit_definition) REFERENCES coreshop_product_unit_definition (id) ON DELETE CASCADE;
-                ALTER TABLE coreshop_product_unit_definition_price ADD CONSTRAINT FK_13ECB5BD314F81B FOREIGN KEY (product_store_values) REFERENCES coreshop_product_store_values (id) ON DELETE CASCADE;
-                ALTER TABLE coreshop_product_quantity_price_rule_range ADD unit_definition INT DEFAULT NULL;
-                ALTER TABLE coreshop_product_quantity_price_rule_range ADD CONSTRAINT FK_C6BA05DA6B98B918 FOREIGN KEY (unit_definition) REFERENCES coreshop_product_unit_definition (id);
-                ALTER TABLE coreshop_product_quantity_price_rule_range CHANGE range_from range_starting_from int(11) NOT NULL AFTER unit_definition, DROP range_to;
-                CREATE INDEX IDX_C6BA05DA6B98B918 ON coreshop_product_quantity_price_rule_range (unit_definition);
-                CREATE UNIQUE INDEX definitions_and_unit ON coreshop_product_unit_definition (product_unit_definitions, unit);
-            ');
+            $this->addSql('CREATE TABLE coreshop_product_unit_definitions (id INT AUTO_INCREMENT NOT NULL, default_unit_definition INT DEFAULT NULL, product INT NOT NULL COMMENT \'(DC2Type:pimcoreObject)\', UNIQUE INDEX UNIQ_5D50CA20D34A04AD (product), UNIQUE INDEX UNIQ_5D50CA20F3CE11C4 (default_unit_definition), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8MB4 COLLATE utf8mb4_general_ci ENGINE = InnoDB;');
+            $this->addSql('CREATE TABLE coreshop_product_unit (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(190) NOT NULL, creationDate DATE NOT NULL, modificationDate DATETIME DEFAULT NULL, UNIQUE INDEX UNIQ_803A19D05E237E06 (name), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8MB4 COLLATE utf8mb4_general_ci ENGINE = InnoDB;');
+            $this->addSql('CREATE TABLE coreshop_product_unit_definition (id INT AUTO_INCREMENT NOT NULL, product_unit_definitions INT DEFAULT NULL, unit INT DEFAULT NULL, conversion_rate DOUBLE PRECISION DEFAULT NULL, INDEX IDX_37BB52AF8685AB18 (product_unit_definitions), INDEX IDX_37BB52AFDCBB0C53 (unit), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8MB4 COLLATE utf8mb4_general_ci ENGINE = InnoDB;');
+            $this->addSql('CREATE TABLE coreshop_product_unit_definition_price (id INT AUTO_INCREMENT NOT NULL, unit_definition INT DEFAULT NULL, product_store_values INT DEFAULT NULL, price INT NOT NULL, INDEX IDX_13ECB5B6B98B918 (unit_definition), INDEX IDX_13ECB5BD314F81B (product_store_values), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8MB4 COLLATE utf8mb4_general_ci ENGINE = InnoDB;');
+            $this->addSql('ALTER TABLE coreshop_product_unit_definitions ADD CONSTRAINT FK_5D50CA20F3CE11C4 FOREIGN KEY (default_unit_definition) REFERENCES coreshop_product_unit_definition (id) ON DELETE SET NULL;');
+            $this->addSql('ALTER TABLE coreshop_product_unit_definition ADD CONSTRAINT FK_37BB52AF8685AB18 FOREIGN KEY (product_unit_definitions) REFERENCES coreshop_product_unit_definitions (id) ON DELETE CASCADE;');
+            $this->addSql('ALTER TABLE coreshop_product_unit_definition ADD CONSTRAINT FK_37BB52AFDCBB0C53 FOREIGN KEY (unit) REFERENCES coreshop_product_unit (id);');
+            $this->addSql('ALTER TABLE coreshop_product_unit_definition_price ADD CONSTRAINT FK_13ECB5B6B98B918 FOREIGN KEY (unit_definition) REFERENCES coreshop_product_unit_definition (id) ON DELETE CASCADE;');
+            $this->addSql('ALTER TABLE coreshop_product_quantity_price_rule_range ADD unit_definition INT DEFAULT NULL;');
+            $this->addSql('ALTER TABLE coreshop_product_quantity_price_rule_range ADD CONSTRAINT FK_C6BA05DA6B98B918 FOREIGN KEY (unit_definition) REFERENCES coreshop_product_unit_definition (id);');
+            $this->addSql('ALTER TABLE coreshop_product_quantity_price_rule_range CHANGE range_from range_starting_from int(11) NOT NULL AFTER unit_definition, DROP range_to;');
+            $this->addSql('CREATE INDEX IDX_C6BA05DA6B98B918 ON coreshop_product_quantity_price_rule_range (unit_definition);');
+            $this->addSql('CREATE UNIQUE INDEX definitions_and_unit ON coreshop_product_unit_definition (product_unit_definitions, unit);');
         }
 
         $unitDefinitionsField = [

--- a/src/CoreShop/Bundle/CoreBundle/Migrations/Version20190308132925.php
+++ b/src/CoreShop/Bundle/CoreBundle/Migrations/Version20190308132925.php
@@ -21,6 +21,7 @@ class Version20190308132925 extends AbstractPimcoreMigration implements Containe
         if (!$schema->hasTable('coreshop_product_store_values')) {
             $this->addSql('CREATE TABLE coreshop_product_store_values (id INT AUTO_INCREMENT NOT NULL, store INT DEFAULT NULL, product INT NOT NULL COMMENT \'(DC2Type:pimcoreObject)\', price INT NOT NULL, INDEX IDX_9EED0E97FF575877 (store), UNIQUE INDEX product_store (product, store), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8MB4 COLLATE utf8mb4_general_ci ENGINE = InnoDB;');
             $this->addSql('ALTER TABLE coreshop_product_store_values ADD CONSTRAINT FK_9EED0E97FF575877 FOREIGN KEY (store) REFERENCES coreshop_store (id) ON DELETE SET NULL;');
+            $this->addSql('ALTER TABLE coreshop_product_unit_definition_price ADD CONSTRAINT FK_13ECB5BD314F81B FOREIGN KEY (product_store_values) REFERENCES coreshop_product_store_values (id) ON DELETE CASCADE;');
         }
 
         $storeValuesField = [

--- a/src/CoreShop/Bundle/CoreBundle/Migrations/Version20190430153230.php
+++ b/src/CoreShop/Bundle/CoreBundle/Migrations/Version20190430153230.php
@@ -20,8 +20,15 @@ class Version20190430153230 extends AbstractPimcoreMigration implements Containe
      */
     public function up(Schema $schema)
     {
-        $this->addSql('INSERT INTO `users_permission_definitions` (`key`, `category`) VALUES (\'coreshop_permission_cart_list\', \'\');');
-        $this->addSql('INSERT INTO `users_permission_definitions` (`key`, `category`) VALUES (\'coreshop_permission_cart_create\', \'\');');
+        $table = $schema->getTable('users_permission_definitions');
+
+        if ($table->hasColumn('category')) {
+            $this->addSql('INSERT INTO `users_permission_definitions` (`key`, `category`) VALUES (\'coreshop_permission_cart_list\', \'\');');
+            $this->addSql('INSERT INTO `users_permission_definitions` (`key`, `category`) VALUES (\'coreshop_permission_cart_create\', \'\');');
+        } else {
+            $this->addSql('INSERT INTO `users_permission_definitions` (`key`) VALUES (\'coreshop_permission_cart_list\');');
+            $this->addSql('INSERT INTO `users_permission_definitions` (`key`) VALUES (\'coreshop_permission_cart_create\');');
+        }
 
         $cartClassId = $this->container->get('coreshop.repository.cart')->getClassId();
 

--- a/src/CoreShop/Bundle/CoreBundle/Migrations/Version20191113105705.php
+++ b/src/CoreShop/Bundle/CoreBundle/Migrations/Version20191113105705.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace CoreShop\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+class Version20191113105705 extends AbstractPimcoreMigration implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE coreshop_exchange_rate CHANGE exchangeRate exchangeRate NUMERIC(15, 10) NOT NULL;');
+        $this->container->get('pimcore.cache.core.handler')->clearTag('doctrine_pimcore_cache');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | --

This PR fix some migration erros:

## Version20190430153230
Use permission category only if available

## Version20190226122625
Remove `coreshop_product_store_values` CONSTRAINT => table is not available yet

## Version20190308132925
Insert `coreshop_product_store_values`CONSTRAINT => table is available
