### PR TITLE
Remove Store Values after Store has been removed

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Migrations/Version20191113121206.php
+++ b/src/CoreShop/Bundle/CoreBundle/Migrations/Version20191113121206.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace CoreShop\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+class Version20191113121206  extends AbstractPimcoreMigration implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE coreshop_product_store_values DROP FOREIGN KEY FK_9EED0E97FF575877;');
+        $this->addSql('ALTER TABLE coreshop_product_store_values ADD CONSTRAINT FK_9EED0E97FF575877 FOREIGN KEY (store) REFERENCES coreshop_store (id) ON DELETE CASCADE;');
+
+        $this->container->get('pimcore.cache.core.handler')->clearTag('doctrine_pimcore_cache');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+    }
+}

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/doctrine/model/ProductStoreValues.orm.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/doctrine/model/ProductStoreValues.orm.yml
@@ -22,7 +22,7 @@ CoreShop\Component\Core\Model\ProductStoreValues:
             joinColumn:
                 name: store
                 referencedColumnName: id
-                onDelete: 'SET NULL'
+                onDelete: CASCADE
     oneToMany:
         productUnitDefinitionPrices:
             targetEntity: CoreShop\Component\Core\Model\ProductUnitDefinitionPriceInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | sort of
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | --

After a store gets removed, all values in `coreshop_product_store_values` remain as orphans. This PR changes the coreshop_store constraint from `SET NULL` to `CASCADE`.
