### PR TITLE
Fix Character Length Count in Voucher Code Generator

### DIFF
--- a/src/CoreShop/Component/Order/Generator/CartPriceRuleVoucherCodeGenerator.php
+++ b/src/CoreShop/Component/Order/Generator/CartPriceRuleVoucherCodeGenerator.php
@@ -103,7 +103,7 @@ class CartPriceRuleVoucherCodeGenerator
         $code = '';
 
         while ($i < $length) {
-            $num = rand() % 33;
+            $num = rand() % (strlen($letters));
             $tmp = substr($letters, $num, 1);
             $code = $code . $tmp;
             $i++;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | --

`33` is a defined length for `FORMAT_ALPHANUMERIC` - if you're using `FORMAT_ALPHABETIC` or `FORMAT_NUMERIC` only, it will return null values which generates codes with wrong lengths.