### PR TITLE
Allow sales numbers to be more dynamic

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services/order.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services/order.yml
@@ -81,6 +81,7 @@ services:
             - '@coreshop.configuration.service'
             - 'system.order.prefix'
             - 'system.order.suffix'
+            - '@coreshop.expression_language'
 
     coreshop.quote.number_generator.prefix_suffix:
         class: CoreShop\Component\Core\Order\NumberGenerator\SaleNumberGenerator
@@ -90,6 +91,7 @@ services:
             - '@coreshop.configuration.service'
             - 'system.quote.prefix'
             - 'system.quote.suffix'
+            - '@coreshop.expression_language'
 
     coreshop.order_invoice.number_generator.prefix_suffix:
         class: CoreShop\Component\Core\Order\NumberGenerator\SaleNumberGenerator
@@ -99,6 +101,7 @@ services:
             - '@coreshop.configuration.service'
             - 'system.invoice.prefix'
             - 'system.invoice.suffix'
+            - '@coreshop.expression_language'
 
     coreshop.order_shipment.number_generator.prefix_suffix:
         class: CoreShop\Component\Core\Order\NumberGenerator\SaleNumberGenerator
@@ -108,6 +111,7 @@ services:
             - '@coreshop.configuration.service'
             - 'system.shipment.prefix'
             - 'system.shipment.suffix'
+            - '@coreshop.expression_language'
 
     coreshop.mail.processor.order: '@CoreShop\Bundle\CoreBundle\Order\OrderMailProcessor'
     CoreShop\Bundle\CoreBundle\Order\OrderMailProcessor:

--- a/src/CoreShop/Component/Core/Order/NumberGenerator/SaleNumberGenerator.php
+++ b/src/CoreShop/Component/Core/Order/NumberGenerator/SaleNumberGenerator.php
@@ -72,7 +72,18 @@ final class SaleNumberGenerator implements NumberGeneratorInterface
         }
 
         if ($store instanceof StoreInterface) {
-            return sprintf('%s%s%s', $this->configurationService->getForStore($this->prefixConfigurationKey, $store), $this->numberGenerator->generate($model), $this->configurationService->getForStore($this->suffixConfigurationKey, $store));
+            $prefix = $this->configurationService->getForStore($this->prefixConfigurationKey, $store);
+            $suffix = $this->configurationService->getForStore($this->suffixConfigurationKey, $store);
+            
+            //Implement some useful replacements
+            $prefix = str_replace('{date}',date('Ymd'),$prefix);
+            $prefix = str_replace('{year}',date('Y'),$prefix);
+            $prefix = str_replace('{month}',date('m'),$prefix);
+            $prefix = str_replace('{day}',date('d'),$prefix);
+            
+            //ToDo: Implement the same replacements for $suffix (use same function for both)
+            
+            return sprintf('%s%s%s', $prefix, $this->numberGenerator->generate($model), $suffix);
         }
 
         return $this->numberGenerator->generate($model);

--- a/src/CoreShop/Component/Core/Order/NumberGenerator/SaleNumberGenerator.php
+++ b/src/CoreShop/Component/Core/Order/NumberGenerator/SaleNumberGenerator.php
@@ -19,6 +19,7 @@ use CoreShop\Component\Order\Model\SaleInterface;
 use CoreShop\Component\Order\NumberGenerator\NumberGeneratorInterface;
 use CoreShop\Component\Resource\Model\ResourceInterface;
 use CoreShop\Component\Store\Model\StoreAwareInterface;
+use Symfony\Component\DependencyInjection\ExpressionLanguage;
 
 final class SaleNumberGenerator implements NumberGeneratorInterface
 {
@@ -75,13 +76,9 @@ final class SaleNumberGenerator implements NumberGeneratorInterface
             $prefix = $this->configurationService->getForStore($this->prefixConfigurationKey, $store);
             $suffix = $this->configurationService->getForStore($this->suffixConfigurationKey, $store);
             
-            //Implement some useful replacements
-            $prefix = str_replace('{date}',date('Ymd'),$prefix);
-            $prefix = str_replace('{year}',date('Y'),$prefix);
-            $prefix = str_replace('{month}',date('m'),$prefix);
-            $prefix = str_replace('{day}',date('d'),$prefix);
-            
-            //ToDo: Implement the same replacements for $suffix (use same function for both)
+            $expr = new ExpressionLanguage();
+            $prefix = $expr->evaluate($prefix);
+            $suffix = $expr->evaluate($suffix);
             
             return sprintf('%s%s%s', $prefix, $this->numberGenerator->generate($model), $suffix);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This would give us the possibility to use numbers like:
O2019-12-12345678
by prefix config:
O{year}-{month}-

Similar to the shopware feature: https://docs.shopware.com/en/shopware-6-en/settings/Numberranges

The current implementation in this pull request is just a base for discussing this proposal.