### PR TITLE
Remove unnecessary type assertions in `Pimcore` component

### DIFF
--- a/src/CoreShop/Component/Pimcore/DataObject/ObjectService.php
+++ b/src/CoreShop/Component/Pimcore/DataObject/ObjectService.php
@@ -14,7 +14,6 @@ namespace CoreShop\Component\Pimcore\DataObject;
 
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\DataObject\Service;
-use Webmozart\Assert\Assert;
 
 class ObjectService implements ObjectServiceInterface
 {
@@ -31,13 +30,6 @@ class ObjectService implements ObjectServiceInterface
      */
     public function copyObject(Concrete $fromObject, Concrete $toObject)
     {
-        /**
-         * @var $fromObject Concrete
-         * @var $toObject   Concrete
-         */
-        Assert::isInstanceOf($fromObject, Concrete::class);
-        Assert::isInstanceOf($toObject, Concrete::class);
-
         //load all in case of lazy loading fields
         $toFd = $toObject->getClass()->getFieldDefinitions();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

There's no need to assert the object type because it is defined for the parameters anyways.

Apart from that, the `webmozart/assert` library is not required in composer for this component.