### PR TITLE
Argument for re-index command

### DIFF
--- a/docs/03_Development/08_Index_and_Filters/01_Index/README.md
+++ b/docs/03_Development/08_Index_and_Filters/01_Index/README.md
@@ -32,8 +32,16 @@ Every field has some properties that needs to be configured
 
 ## Re-Index
 
-If you make changes to the index, you need to re-index all of your products. To do that, there is a cli Command
+If you make changes to the index, you need to re-index all of your products. To do that, there is a CLI command.
 
 ```bash
 $ php bin/console coreshop:index
+```
+
+If you don't want to re-index all of your indices, you can pass the corresponding IDs or names of the indices separated
+with a space as arguments to the CLI command. The following example will only re-index indices with IDs 1 and 2 and name
+"Products". If none of those indices exist, nothing will be re-indexed.
+
+```bash
+$ php bin/console coreshop:index 1 2 Products
 ```

--- a/src/CoreShop/Bundle/IndexBundle/Command/IndexCommand.php
+++ b/src/CoreShop/Bundle/IndexBundle/Command/IndexCommand.php
@@ -20,6 +20,7 @@ use Pimcore\Model\DataObject\AbstractObject;
 use Pimcore\Model\DataObject\Listing;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -66,7 +67,13 @@ final class IndexCommand extends Command
     {
         $this
             ->setName('coreshop:index')
-            ->setDescription('Reindex all Objects');
+            ->setDescription('Reindex all Objects')
+            ->addArgument(
+                'indices',
+                InputArgument::IS_ARRAY | InputArgument::OPTIONAL,
+                'IDs or names of Indices which are re-indexed',
+                null
+            );
     }
 
     /**
@@ -79,8 +86,43 @@ final class IndexCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $indices = $this->indexRepository->findAll();
-        $classesToUpdate = [];
+        $indices = $classesToUpdate = [];
+        $indexIds = $input->getArgument('indices');
+
+        if (null === $indexIds) {
+            $indices = $this->indexRepository->findAll();
+        } else {
+            foreach ($indexIds as $id) {
+                if (is_numeric($id)) {
+                    $index = $this->indexRepository->find($id);
+                } else {
+                    $index = $this->indexRepository->findOneBy(['name' => $id]);
+                }
+
+                if (null === $index) {
+                    continue;
+                }
+
+                $indices[] = $index;
+            }
+        }
+
+        if (empty($indices)) {
+            if (null === $indexIds) {
+                $output->writeln('<info>No Indices available, you have to first create an Index.</info>');
+                $this->dispatchInfo('status', 'No Indices available, you have to first create an Index.');
+            } else {
+                $output->writeln(
+                    sprintf('<info>No Indices found for %s</info>', implode(', ', $indexIds))
+                );
+                $this->dispatchInfo(
+                    'status',
+                    sprintf('No Indices found for %s', implode(', ', $indexIds))
+                );
+            }
+
+            return 0;
+        }
 
         /**
          * @var IndexInterface $index


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

This PR adds an argument to the coreshop:index command, which allows defining certain index IDs to re-index. Default stays the same: all indices get re-indexed.

Additionally, if no indices are found (either by ID lookup or findAll method) a message is displayed in the console.
