### PR TITLE
GH-1209 fix migration

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Migrations/Version20200107065213.php
+++ b/src/CoreShop/Bundle/CoreBundle/Migrations/Version20200107065213.php
@@ -8,11 +8,12 @@ use CoreShop\Component\Pimcore\Exception\ClassDefinitionNotFoundException;
 use Doctrine\DBAL\Schema\Schema;
 use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-class Version20200107065213 extends AbstractPimcoreMigration
+class Version20200107065213 extends AbstractPimcoreMigration implements ContainerAwareInterface
 {
     use ContainerAwareTrait;
 


### PR DESCRIPTION
+ add missing ContainerAwareInterface

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1209 
| Affected PRs | #1217 #1222 
<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->

Added missing ContainerAwareInterface in migration.

Fixes `getParameter() on null` error during migration.