### PR TITLE
[TRACKING] use single item price in order item extractor

### DIFF
--- a/src/CoreShop/Component/Core/Tracking/Extractor/OrderItemExtractor.php
+++ b/src/CoreShop/Component/Core/Tracking/Extractor/OrderItemExtractor.php
@@ -57,7 +57,7 @@ class OrderItemExtractor implements TrackingExtractorInterface
             'sku' => $product instanceof ProductInterface ? $product->getSku() : '',
             'name' => $product instanceof PurchasableInterface ? $product->getName() : '',
             'category' => (is_array($categories) && count($categories) > 0) ? $categories[0]->getName() : '',
-            'price' => $object->getTotal() / 100,
+            'price' => $object->getItemPrice() / 100,
             'quantity' => $object->getQuantity(),
             'currency' => $proposal ? $proposal->getCurrency()->getIsoCode() : '',
         ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | --

Branch: 2.0
Use single item price (`getItemPrice`) instead of item price * quantity (`getTotal`).