### PR TITLE
[TRACKING] use single item price in order item extractor in CS 2.1

### DIFF
--- a/src/CoreShop/Component/Core/Tracking/Extractor/OrderItemExtractor.php
+++ b/src/CoreShop/Component/Core/Tracking/Extractor/OrderItemExtractor.php
@@ -70,7 +70,7 @@ class OrderItemExtractor implements TrackingExtractorInterface
             'sku' => $product instanceof ProductInterface ? $product->getSku() : '',
             'name' => $product instanceof PurchasableInterface ? $product->getName() : '',
             'category' => (is_array($categories) && count($categories) > 0) ? $categories[0]->getName() : '',
-            'price' => $object->getTotal() / $this->decimalFactor,
+            'price' => $object->getItemPrice() / $this->decimalFactor,
             'quantity' => $object->getQuantity(),
             'currency' => $proposal ? $proposal->getCurrency()->getIsoCode() : '',
         ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | --

Branch: 2.1
Use single item price (`getItemPrice`) instead of item price * quantity (`getTotal`).