### PR TITLE
fix: $indexIds is always an array, hence the condition is now empty n…

### DIFF
--- a/src/CoreShop/Bundle/IndexBundle/Command/IndexCommand.php
+++ b/src/CoreShop/Bundle/IndexBundle/Command/IndexCommand.php
@@ -89,7 +89,7 @@ final class IndexCommand extends Command
         $indices = $classesToUpdate = [];
         $indexIds = $input->getArgument('indices');
 
-        if (null === $indexIds) {
+        if (empty($indexIds)) {
             $indices = $this->indexRepository->findAll();
         } else {
             foreach ($indexIds as $id) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

In my previous PR I added the argument `$indexIds` to the re-index command. Since `$indexIds` always returns an array (not null) even if not defined in the command line, the first condition was always false. By checking for `empty()` we make sure the condition is applied correctly.

Sorry for the mistake!
