### PR TITLE
[FrontendBunde] Change function from private to protected

### DIFF
--- a/src/CoreShop/Bundle/FrontendBundle/Controller/CheckoutController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/CheckoutController.php
@@ -315,7 +315,7 @@ class CheckoutController extends FrontendController
         ]);
     }
 
-    private function addEventFlash(string $type, string $message = null, array $parameters = [])
+    protected function addEventFlash(string $type, string $message = null, array $parameters = [])
     {
         if (!$message) {
             return;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Otherwise the function could not be reused in overridden `doCheckout` function.
