### PR TITLE
[CoreBundle] Change repository so that unit definition deletion works with multiple product models 

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Controller/ProductValidationController.php
+++ b/src/CoreShop/Bundle/CoreBundle/Controller/ProductValidationController.php
@@ -100,7 +100,7 @@ class ProductValidationController extends AdminController
      */
     protected function getProductRepository()
     {
-        return $this->get('coreshop.repository.product');
+        return $this->get('coreshop.repository.stack.product');
     }
 
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

The validation controller for product unit definitions only worked for the default product model and not with multiple. Now it can query all product models via the stack repository. 
