### PR TITLE
change assets:install for fresh installations

### DIFF
--- a/docs/03_Development/01_Extending_Guide/04_Extending_Rule_Actions.md
+++ b/docs/03_Development/01_Extending_Guide/04_Extending_Rule_Actions.md
@@ -96,10 +96,11 @@ coreshop.product.pricerule.actions.custom = Class.create(coreshop.rules.actions.
 });
 
 ```
-Don't forget to run the following command afterwards to deploy it if needed:
+
+Don't forget to run the following command afterwards to deploy it if needed. If you're using the latest symfony structure, omit the `web`.
 ```
-bin/console assets:install
-``` 
+bin/console assets:install web
+```
 
 
 

--- a/docs/03_Development/01_Extending_Guide/05_Extending_Rule_Conditions.md
+++ b/docs/03_Development/01_Extending_Guide/05_Extending_Rule_Conditions.md
@@ -86,8 +86,13 @@ coreshop.product.pricerule.conditions.custom = Class.create(coreshop.rules.condi
         return this.form;
     }
 });
-
 ```
+
+Don't forget to run the following command afterwards to deploy it if needed. If you're using the latest symfony structure, omit the `web`.
+```
+bin/console assets:install web
+```
+
 
 ## Registering the Custom Condition to the Container and load the Javascript File
 We now need to create our Service Definition for our Custom Condition:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

I changed the `bin/console assets:install` to `bin/console assets:install web`, because Symfony will using `public` by default in current versions. I also copied the hint from *Extending Rule Action* to *Extending Rule Condition*
