### PR TITLE
fix: add missing translation

### DIFF
--- a/src/CoreShop/Bundle/FrontendBundle/Resources/install/pimcore/translations.yml
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/install/pimcore/translations.yml
@@ -485,6 +485,12 @@ translations:
           en: 'Search'
           de: 'Suche'
 
+  coreshop.ui.search_results_for:
+      languages:
+          de_CH: 'Suchergebnisse für'
+          en: 'Searchresults for'
+          de: 'Suchergebnisse für'
+
   coreshop.ui.settings:
       languages:
           de_CH: 'Einstellungen'


### PR DESCRIPTION
for `coreshop.ui.search_results_for`

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no