### PR TITLE
Password reset redirect to home if user not exists

### DIFF
--- a/src/CoreShop/Bundle/FrontendBundle/Controller/RegisterController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/RegisterController.php
@@ -94,7 +94,9 @@ class RegisterController extends FrontendController
                 $customer = $this->get('coreshop.repository.customer')->findCustomerByEmail($passwordReset['email']);
 
                 if (!$customer instanceof CustomerInterface) {
-                    return $this->redirectToRoute('coreshop_index');
+                    $this->addFlash('error', $this->get('translator')->trans('coreshop.ui.password_reset_user_error'));
+
+                    return $this->redirectToRoute('coreshop_customer_password_reset_request');
                 }
 
                 $customer->setPasswordResetHash(hash('md5', $customer->getId().$customer->getEmail().mt_rand().time()));

--- a/src/CoreShop/Bundle/FrontendBundle/Resources/views/Register/password-reset-request.html.twig
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/views/Register/password-reset-request.html.twig
@@ -17,6 +17,8 @@
         </h2>
 
         <section class="registration-area">
+            {% include '@CoreShopFrontend/Common/flash_messages.html.twig' %}
+
             <div class="row">
                 <div class="col-sm-12">
                     <div class="card card-smart">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

If the user does not exist, an error message will appear
