### PR TITLE
[Pimcore Bundle] Fix loading dynamic dropdown options

### DIFF
--- a/src/CoreShop/Bundle/PimcoreBundle/Controller/Admin/DynamicDropdownController.php
+++ b/src/CoreShop/Bundle/PimcoreBundle/Controller/Admin/DynamicDropdownController.php
@@ -31,9 +31,10 @@ final class DynamicDropdownController extends AdminController
      */
     public function optionsAction(Request $request)
     {
+        $folderName = $request->get('folderName');
         $parts = array_map(static function ($part) {
             return Service::getValidKey($part, 'object');
-        }, preg_split('/\//', $request->get('folderName'), null, PREG_SPLIT_NO_EMPTY));
+        }, preg_split('/\//', $folderName, null, PREG_SPLIT_NO_EMPTY));
         $parentFolderPath = sprintf('/%s', implode('/', $parts));
         $sort = $request->get('sortBy');
         $options = [];

--- a/src/CoreShop/Bundle/PimcoreBundle/Controller/Admin/DynamicDropdownController.php
+++ b/src/CoreShop/Bundle/PimcoreBundle/Controller/Admin/DynamicDropdownController.php
@@ -14,6 +14,7 @@ namespace CoreShop\Bundle\PimcoreBundle\Controller\Admin;
 
 use Pimcore\Bundle\AdminBundle\Controller\AdminController;
 use Pimcore\Model\DataObject;
+use Pimcore\Model\Element\Service;
 use Pimcore\Tool;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -30,8 +31,10 @@ final class DynamicDropdownController extends AdminController
      */
     public function optionsAction(Request $request)
     {
-        $folderName = $request->get('folderName');
-        $parentFolderPath = preg_replace('@[^a-zA-Z0-9/\-_\s]@', '', $folderName);
+        $parts = array_map(static function ($part) {
+            return Service::getValidKey($part, 'object');
+        }, preg_split('/\//', $request->get('folderName'), null, PREG_SPLIT_NO_EMPTY));
+        $parentFolderPath = sprintf('/%s', implode('/', $parts));
         $sort = $request->get('sortBy');
         $options = [];
 

--- a/src/CoreShop/Bundle/PimcoreBundle/Controller/Admin/DynamicDropdownController.php
+++ b/src/CoreShop/Bundle/PimcoreBundle/Controller/Admin/DynamicDropdownController.php
@@ -48,20 +48,7 @@ final class DynamicDropdownController extends AdminController
             $parentFolderPath = str_replace('//', '/', $parentFolderPath);
 
             $folder = DataObject\Folder::getByPath($parentFolderPath);
-
-            if ($folder) {
-                $options = $this->walkPath($request, $folder);
-            } else {
-                $message = sprintf('The folder submitted could not be found: "%s"', $folderName);
-
-                return $this->json(
-                    [
-                        'success' => false,
-                        'message' => $message,
-                        'options' => $options,
-                    ]
-                );
-            }
+            $options = $folder instanceof DataObject\AbstractObject ? $this->walkPath($request, $folder) : [];
         } else {
             $message = sprintf('The folder submitted for parentId is not valid: "%s"', $folderName);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

This PR fixes sanitizing the parent folder path when trying to load the options for dynamic dropdown tags. It uses the same validation as Pimcore. Furthermore, the method now returns an empty array, if the folder could not be found.
