### PR TITLE
[ThemeBundle] introduce theme inheritance

### DIFF
--- a/src/CoreShop/Bundle/ThemeBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/ThemeBundle/DependencyInjection/Configuration.php
@@ -33,6 +33,51 @@ final class Configuration implements ConfigurationInterface
                         ->booleanNode('pimcore_site')->defaultFalse()->end()
                         ->booleanNode('pimcore_document_property')->defaultFalse()->end()
                     ->end()
+                ->end()
+                ->arrayNode('inheritance')
+                    ->normalizeKeys(false)
+                    ->useAttributeAsKey('theme_name')
+                    ->beforeNormalization()
+                        ->always()
+                            ->then(function ($config) {
+                                if (!\is_array($config)) {
+                                    return [];
+                                }
+                                // If XML config with only one routing attribute
+                                if (2 === \count($config) && isset($config['theme_name']) && isset($config['parent_themes'])) {
+                                    $config = [0 => $config];
+                                }
+
+                                $newConfig = [];
+                                foreach ($config as $k => $v) {
+                                    if (!\is_int($k)) {
+                                        $newConfig[$k] = [
+                                            'parent_themes' => $v['parent_themes'] ?? (\is_array($v) ? array_values($v) : [$v]),
+                                        ];
+                                    } else {
+                                        $newConfig[$v['theme_name']]['parent_themes'] = array_map(
+                                            function ($a) {
+                                                return \is_string($a) ? $a : $a['service'];
+                                            },
+                                            array_values($v['parent_themes'])
+                                        );
+                                    }
+                                }
+
+                                return $newConfig;
+                            })
+                        ->end()
+                        ->prototype('array')
+                            ->performNoDeepMerging()
+                            ->children()
+                                ->arrayNode('parent_themes')
+                                    ->requiresAtLeastOneElement()
+                                    ->prototype('scalar')->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/src/CoreShop/Bundle/ThemeBundle/DependencyInjection/CoreShopThemeExtension.php
+++ b/src/CoreShop/Bundle/ThemeBundle/DependencyInjection/CoreShopThemeExtension.php
@@ -13,12 +13,15 @@
 namespace CoreShop\Bundle\ThemeBundle\DependencyInjection;
 
 use CoreShop\Bundle\ThemeBundle\DependencyInjection\Compiler\CompositeThemeResolverPass;
+use CoreShop\Bundle\ThemeBundle\Service\InheritanceLocator;
 use CoreShop\Bundle\ThemeBundle\Service\PimcoreDocumentPropertyResolver;
 use CoreShop\Bundle\ThemeBundle\Service\PimcoreSiteThemeResolver;
 use CoreShop\Bundle\ThemeBundle\Service\ThemeResolverInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class CoreShopThemeExtension extends Extension
@@ -39,6 +42,23 @@ class CoreShopThemeExtension extends Extension
 
         if (false === $config['default_resolvers']['pimcore_document_property']) {
             $container->removeDefinition(PimcoreDocumentPropertyResolver::class);
+        }
+
+        if (isset($config['inheritance']) && count($config['inheritance']) > 0) {
+            $container->setParameter('coreshop.theme_bundle.inheritance', $config['inheritance']);
+
+            $inheritanceLocator = new Definition(InheritanceLocator::class);
+            $inheritanceLocator->setArguments([
+                new Reference('kernel'),
+                new Reference('liip_theme.active_theme'),
+                '%kernel.root_dir%/Resources',
+                [],
+                '%liip_theme.path_patterns%',
+                '%coreshop.theme_bundle.inheritance%'
+            ]);
+            $inheritanceLocator->setDecoratedService('liip_theme.file_locator');
+
+            $container->setDefinition(InheritanceLocator::class, $inheritanceLocator);
         }
 
         $container

--- a/src/CoreShop/Bundle/ThemeBundle/Exception/CircularDependencyFoundException.php
+++ b/src/CoreShop/Bundle/ThemeBundle/Exception/CircularDependencyFoundException.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2020 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\ThemeBundle\Exception;
+
+class CircularDependencyFoundException extends \Exception
+{
+    /**
+     * @param string[]   $themes
+     * @param \Exception $previous
+     */
+    public function __construct(array $themes, ?\Exception $previous = null)
+    {
+        $cycle = $this->getCycleFromArray($themes);
+
+        $message = sprintf(
+            'Circular dependency was found while resolving theme "%s", caused by cycle "%s".',
+            $this->getFirstTheme($themes),
+            $this->formatCycleToString($cycle)
+        );
+
+        parent::__construct($message, 0, $previous);
+    }
+
+    private function getCycleFromArray(array $themes)
+    {
+        while (reset($themes) !== end($themes) || 1 === count($themes)) {
+            array_shift($themes);
+        }
+
+        if (0 === count($themes)) {
+            throw new \InvalidArgumentException('There is no cycle within given themes.');
+        }
+
+        return $themes;
+    }
+
+    private function formatCycleToString(array $themes)
+    {
+        return implode(' -> ', $themes);
+    }
+
+    /**
+     * @param string[] $themes
+     */
+    private function getFirstTheme(array $themes)
+    {
+        return reset($themes);
+    }
+}

--- a/src/CoreShop/Bundle/ThemeBundle/Service/InheritanceLocator.php
+++ b/src/CoreShop/Bundle/ThemeBundle/Service/InheritanceLocator.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2020 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\ThemeBundle\Service;
+
+use Liip\ThemeBundle\ActiveTheme;
+use Liip\ThemeBundle\Locator\FileLocator;
+use Sylius\Bundle\ThemeBundle\Loader\CircularDependencyFoundException;
+use Sylius\Bundle\ThemeBundle\Model\ThemeInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class InheritanceLocator extends FileLocator
+{
+    protected $kernel;
+    protected $path;
+    protected $basePaths = array();
+    protected $pathPatterns;
+    protected $activeTheme;
+    protected $lastTheme;
+    protected $inheritance;
+
+    public function __construct(
+        KernelInterface $kernel,
+        ActiveTheme $activeTheme,
+        $path = null,
+        array $paths = array(),
+        array $pathPatterns = array(),
+        array $inheritance = []
+    ) {
+        parent::__construct($kernel, $activeTheme, $path, $paths, $pathPatterns);
+
+        $this->inheritance = $inheritance;
+    }
+
+    protected function getPathsForBundleResource($parameters)
+    {
+        $paths = array();
+        $hierarchy = $this->resolveHierarchy();
+
+       foreach ($hierarchy as $theme) {
+            $parameters['%current_theme%'] = $theme;
+
+            $paths[] = strtr('%bundle_path%/Resources/themes/%current_theme%/%template%', $parameters);
+
+            if (!empty($parameters['%dir%'])) {
+                $paths[] = strtr('%dir%/themes/%current_theme%/%bundle_name%/%template%', $parameters);
+            }
+        }
+
+        return array_merge($paths, parent::getPathsForBundleResource($parameters));
+    }
+
+    protected function getPathsForAppResource($parameters)
+    {
+        $paths = array();
+        $hierarchy = $this->resolveHierarchy();
+
+        foreach ($hierarchy as $theme) {
+            $parameters['%current_theme%'] = $theme;
+
+            $paths[] = strtr("%app_path%/themes/%current_theme%/%template%", $parameters);
+        }
+
+        return array_merge($paths, parent::getPathsForAppResource($parameters));
+    }
+
+    protected function resolveHierarchy()
+    {
+        $this->checkCircularDependency($this->lastTheme);
+
+        return $this->getThemeHierarchy($this->lastTheme);
+    }
+
+    protected function getThemeHierarchy(string $theme): array
+    {
+        $parents = [];
+        $inheritance = isset($this->inheritance[$theme]) ? $this->inheritance[$theme]['parent_themes'] : [];
+
+        foreach ($inheritance as $parent) {
+            $parents = array_merge(
+                $parents,
+                $this->getThemeHierarchy($parent)
+            );
+        }
+
+        return array_merge([$theme], $parents);
+    }
+
+    protected function checkCircularDependency(string $theme, array $previousThemes = []): void
+    {
+        $inheritance = isset($this->inheritance[$theme]) ? $this->inheritance[$theme]['parent_themes'] : [];
+
+        if (0 === count($inheritance)) {
+            return;
+        }
+
+        $previousThemes[] = $theme;
+        foreach ($inheritance as $parent) {
+            if (in_array($parent, $previousThemes, true)) {
+                throw new \CoreShop\Bundle\ThemeBundle\Exception\CircularDependencyFoundException(array_merge($previousThemes, [$parent]));
+            }
+
+            $this->checkCircularDependency($parent, $previousThemes);
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

Allows to have theme inheritance and re-use themes in other themes:

```yml
core_shop_theme:
    inheritance:
        agro_at:
            - agro_de
        agro_com:
            - agro_at
```