### PR TITLE
[ResourceBundle] Fix unique entity validator

### DIFF
--- a/src/CoreShop/Bundle/ResourceBundle/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Validator/Constraints/UniqueEntityValidator.php
@@ -104,7 +104,7 @@ final class UniqueEntityValidator extends ConstraintValidator
              */
             $foundElement = $elements[0];
 
-            if ($constraint->allowSameEntity && count($elements) === 1 && $entity->getId() === $foundElement) {
+            if ($constraint->allowSameEntity && count($elements) === 1 && $entity->getId() === $foundElement->getId()) {
                 return;
             }
 


### PR DESCRIPTION
Not working because it checked the object against the object id

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | -


