### PR TITLE
[WorkflowBundle] Add enabled option to workflow callbacks

### DIFF
--- a/src/CoreShop/Bundle/WorkflowBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/WorkflowBundle/DependencyInjection/Configuration.php
@@ -166,6 +166,7 @@ final class Configuration implements ConfigurationInterface
                     ->useAttributeAsKey('name')
                     ->prototype('array')
                         ->children()
+                            ->booleanNode('enabled')->defaultTrue()->cannotBeEmpty()->end()
                             ->variableNode('on')->end()
                             ->variableNode('do')->end()
                             ->scalarNode('priority')->defaultValue(0)->end()

--- a/src/CoreShop/Bundle/WorkflowBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/WorkflowBundle/DependencyInjection/Configuration.php
@@ -166,7 +166,7 @@ final class Configuration implements ConfigurationInterface
                     ->useAttributeAsKey('name')
                     ->prototype('array')
                         ->children()
-                            ->booleanNode('enabled')->defaultTrue()->cannotBeEmpty()->end()
+                            ->booleanNode('enabled')->defaultTrue()->end()
                             ->variableNode('on')->end()
                             ->variableNode('do')->end()
                             ->scalarNode('priority')->defaultValue(0)->end()

--- a/src/CoreShop/Bundle/WorkflowBundle/EventListener/WorkflowListener.php
+++ b/src/CoreShop/Bundle/WorkflowBundle/EventListener/WorkflowListener.php
@@ -99,6 +99,11 @@ class WorkflowListener implements EventSubscriberInterface
     public function applyTransition($transitionName, Event $event, $actions)
     {
         foreach ($actions as $callback) {
+            
+            if($callback['enabled'] === false){
+                continue;   
+            }
+            
             if (!in_array($transitionName, $callback['on'])) {
                 continue;
             }

--- a/src/CoreShop/Bundle/WorkflowBundle/EventListener/WorkflowListener.php
+++ b/src/CoreShop/Bundle/WorkflowBundle/EventListener/WorkflowListener.php
@@ -99,7 +99,6 @@ class WorkflowListener implements EventSubscriberInterface
     public function applyTransition($transitionName, Event $event, $actions)
     {
         foreach ($actions as $callback) {
-            
             if($callback['enabled'] === false){
                 continue;   
             }

--- a/src/CoreShop/Bundle/WorkflowBundle/EventListener/WorkflowListener.php
+++ b/src/CoreShop/Bundle/WorkflowBundle/EventListener/WorkflowListener.php
@@ -99,7 +99,7 @@ class WorkflowListener implements EventSubscriberInterface
     public function applyTransition($transitionName, Event $event, $actions)
     {
         foreach ($actions as $callback) {
-            if($callback['enabled'] === false){
+            if ($callback['enabled'] === false) {
                 continue;   
             }
             


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

Easily disable any callback defined on workflows. useful if you want to disable callbacks, when customizing existing workflows of CoreShop or disable callbacks based on parameters. 
