### PR TITLE
Fixed issue with saving address changes

### DIFF
--- a/src/CoreShop/Component/Core/Customer/CustomerTransformHelper.php
+++ b/src/CoreShop/Component/Core/Customer/CustomerTransformHelper.php
@@ -172,18 +172,15 @@ final class CustomerTransformHelper implements CustomerTransformHelperInterface
             return $address;
         }
 
-        // no affiliation has changed, return
-        if ($this->isNewEntity($address) === false && $address->getParent()->getId() === $newParent->getId()) {
-            return $address;
-        }
-
         // set new or changed parent
-        $address->setParent($newParent);
-        $address->setKey($this->getSaveKeyForMoving($address, $newParent));
+        if ($this->isNewEntity($address) === true || $address->getParent()->getId() !== $newParent->getId()) {
+            $address->setParent($newParent);
+            $address->setKey($this->getSaveKeyForMoving($address, $newParent));
 
-        // remove old relations
-        if ($removeOldRelations === true) {
-            $this->removeAddressRelations($address);
+            // remove old relations
+            if ($removeOldRelations === true) {
+                $this->removeAddressRelations($address);
+            }
         }
 
         $this->forceSave($address, false);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Fixed issue with saving address changes, reproducible on [demo](https://demo2.coreshop.org):
![bug](https://user-images.githubusercontent.com/16133208/82710652-a7516680-9c83-11ea-898c-49e0d58189ee.gif)

Issue is caused by `CustomerTransformHelper` responsible for saving address, but saving is done only in case the address is new or parent is different.
https://github.com/coreshop/CoreShop/blob/9228f1a6d346deb934387c32c033dd5c172d791f/src/CoreShop/Component/Core/Customer/CustomerTransformHelper.php#L175-L178
