### PR TITLE
re-add id reset on entity clone

### DIFF
--- a/src/CoreShop/Component/Product/Model/ProductUnitDefinitions.php
+++ b/src/CoreShop/Component/Product/Model/ProductUnitDefinitions.php
@@ -230,8 +230,7 @@ class ProductUnitDefinitions extends AbstractResource implements ProductUnitDefi
 
         $additionalUnits = $this->getAdditionalUnitDefinitions();
 
-        //Doctrine internally does that
-        //$this->id = null;
+        $this->id = null;
         $this->unitDefinitions =  new ArrayCollection();
         $this->defaultUnitDefinition = null;
 

--- a/src/CoreShop/Component/Product/Model/ProductUnitDefinitions.php
+++ b/src/CoreShop/Component/Product/Model/ProductUnitDefinitions.php
@@ -19,7 +19,7 @@ use Doctrine\Common\Collections\Collection;
 class ProductUnitDefinitions extends AbstractResource implements ProductUnitDefinitionsInterface
 {
     /**
-     * @var int
+     * @var int|null
      */
     protected $id;
 

--- a/src/CoreShop/Component/ProductQuantityPriceRules/Model/ProductQuantityPriceRule.php
+++ b/src/CoreShop/Component/ProductQuantityPriceRules/Model/ProductQuantityPriceRule.php
@@ -27,7 +27,7 @@ class ProductQuantityPriceRule implements ProductQuantityPriceRuleInterface
     use ToggleableTrait;
 
     /**
-     * @var int
+     * @var int|null
      */
     protected $id;
 

--- a/src/CoreShop/Component/ProductQuantityPriceRules/Model/ProductQuantityPriceRule.php
+++ b/src/CoreShop/Component/ProductQuantityPriceRules/Model/ProductQuantityPriceRule.php
@@ -291,7 +291,7 @@ class ProductQuantityPriceRule implements ProductQuantityPriceRuleInterface
         $conditions = $this->getConditions();
         $ranges = $this->getRanges();
 
-        //$this->id = null;
+        $this->id = null;
         $this->product = null;
         $this->conditions = new ArrayCollection();
         $this->ranges = new ArrayCollection();

--- a/src/CoreShop/Component/ProductQuantityPriceRules/Model/QuantityRange.php
+++ b/src/CoreShop/Component/ProductQuantityPriceRules/Model/QuantityRange.php
@@ -17,7 +17,7 @@ use CoreShop\Component\Resource\Model\AbstractResource;
 class QuantityRange extends AbstractResource implements QuantityRangeInterface
 {
     /**
-     * @var int
+     * @var int|null
      */
     protected $id;
 

--- a/src/CoreShop/Component/ProductQuantityPriceRules/Model/QuantityRange.php
+++ b/src/CoreShop/Component/ProductQuantityPriceRules/Model/QuantityRange.php
@@ -157,6 +157,6 @@ class QuantityRange extends AbstractResource implements QuantityRangeInterface
         }
 
         $this->rule = null;
-        //$this->id = null;
+        $this->id = null;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | --

Without resetting the id, entities won't get cloned. Instead the master entity data will just get moved.