### PR TITLE
[OrderBundle][CoreBundle] Fix currency formatting in sale detail related components

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Resources/public/pimcore/js/order/detail/blocks/carriage.js
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/public/pimcore/js/order/detail/blocks/carriage.js
@@ -94,6 +94,6 @@ coreshop.order.order.detail.blocks.carriage = Class.create(coreshop.order.sale.d
         me.currencyPanel.setHtml('<span style="font-weight:bold;">' + t('coreshop_currency') + ': </span>' + me.sale.currency.name);
         me.weightPanel.setHtml('<span style="font-weight:bold;">' + t('coreshop_weight') + ': </span>' + (me.sale.shippingPayment.weight ? me.sale.shippingPayment.weight : 0));
         me.carrierPanel.setHtml('<span style="font-weight:bold;">' + t('coreshop_carrier') + ': </span>' + me.sale.shippingPayment.carrier);
-        me.pricePanel.setHtml('<span style="font-weight:bold;">' + t('coreshop_price') + ': </span>' + coreshop.util.format.currency(me.sale.currency.iso, me.sale.shippingPayment.cost));
+        me.pricePanel.setHtml('<span style="font-weight:bold;">' + t('coreshop_price') + ': </span>' + coreshop.util.format.currency(me.sale.currency.isoCode, me.sale.shippingPayment.cost));
     }
 });

--- a/src/CoreShop/Bundle/CurrencyBundle/Resources/config/serializer/Model.Currency.yml
+++ b/src/CoreShop/Bundle/CurrencyBundle/Resources/config/serializer/Model.Currency.yml
@@ -11,7 +11,7 @@ CoreShop\Component\Currency\Model\Currency:
             expose: true
             type: string
             groups: [List, Detailed]
-        iso:
+        isoCode:
             expose: true
             type: string
             groups: [Detailed]

--- a/src/CoreShop/Bundle/CurrencyBundle/Resources/config/serializer/Model.Currency.yml
+++ b/src/CoreShop/Bundle/CurrencyBundle/Resources/config/serializer/Model.Currency.yml
@@ -11,7 +11,7 @@ CoreShop\Component\Currency\Model\Currency:
             expose: true
             type: string
             groups: [List, Detailed]
-        isoCode:
+        iso:
             expose: true
             type: string
             groups: [Detailed]

--- a/src/CoreShop/Bundle/OrderBundle/Controller/AbstractCartCreationController.php
+++ b/src/CoreShop/Bundle/OrderBundle/Controller/AbstractCartCreationController.php
@@ -261,7 +261,7 @@ abstract class AbstractCartCreationController extends AbstractSaleController
         return [
             'name' => $currency->getName(),
             'symbol' => $currency->getSymbol(),
-            'iso' => $currency->getIsoCode()
+            'isoCode' => $currency->getIsoCode()
         ];
     }
 

--- a/src/CoreShop/Bundle/OrderBundle/Controller/AbstractSaleDetailController.php
+++ b/src/CoreShop/Bundle/OrderBundle/Controller/AbstractSaleDetailController.php
@@ -426,7 +426,7 @@ abstract class AbstractSaleDetailController extends AbstractSaleController
         return [
             'name' => $currency->getName(),
             'symbol' => $currency->getSymbol(),
-            'iso' => $currency->getIsoCode()
+            'isoCode' => $currency->getIsoCode()
         ];
     }
 

--- a/src/CoreShop/Bundle/OrderBundle/Controller/CartController.php
+++ b/src/CoreShop/Bundle/OrderBundle/Controller/CartController.php
@@ -401,7 +401,7 @@ class CartController extends AbstractSaleController
         return [
             'name' => $currency->getName(),
             'symbol' => $currency->getSymbol(),
-            'iso' => $currency->getIsoCode()
+            'isoCode' => $currency->getIsoCode()
         ];
     }
 

--- a/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/cart/detail/blocks/detail.js
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/cart/detail/blocks/detail.js
@@ -130,7 +130,7 @@ coreshop.order.cart.detail.blocks.detail = Class.create(coreshop.order.sale.deta
                     width: 150,
                     align: 'right',
                     text: t('coreshop_price_without_tax'),
-                    renderer: coreshop.util.format.currency.bind(this, this.sale.currency.iso)
+                    renderer: coreshop.util.format.currency.bind(this, this.sale.currency.isoCode)
                 },
 
                 {
@@ -139,7 +139,7 @@ coreshop.order.cart.detail.blocks.detail = Class.create(coreshop.order.sale.deta
                     width: 150,
                     align: 'right',
                     text: t('coreshop_price_with_tax'),
-                    renderer: coreshop.util.format.currency.bind(this, this.sale.currency.iso)
+                    renderer: coreshop.util.format.currency.bind(this, this.sale.currency.isoCode)
                 },
                 {
                     xtype: 'gridcolumn',
@@ -157,7 +157,7 @@ coreshop.order.cart.detail.blocks.detail = Class.create(coreshop.order.sale.deta
                     width: 150,
                     align: 'right',
                     text: t('coreshop_total_without_tax'),
-                    renderer: coreshop.util.format.currency.bind(this, this.sale.currency.iso)
+                    renderer: coreshop.util.format.currency.bind(this, this.sale.currency.isoCode)
                 },
                 {
                     xtype: 'gridcolumn',
@@ -165,7 +165,7 @@ coreshop.order.cart.detail.blocks.detail = Class.create(coreshop.order.sale.deta
                     width: 150,
                     align: 'right',
                     text: t('coreshop_total'),
-                    renderer: coreshop.util.format.currency.bind(this, this.sale.currency.iso)
+                    renderer: coreshop.util.format.currency.bind(this, this.sale.currency.isoCode)
                 },
                 {
                     menuDisabled: true,
@@ -204,7 +204,7 @@ coreshop.order.cart.detail.blocks.detail = Class.create(coreshop.order.sale.deta
                     dataIndex: 'value',
                     width: 150,
                     align: 'right',
-                    renderer: coreshop.util.format.currency.bind(this, this.sale.currency.iso)
+                    renderer: coreshop.util.format.currency.bind(this, this.sale.currency.isoCode)
                 }
             ]
         };

--- a/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/order/detail/blocks/invoice.js
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/order/detail/blocks/invoice.js
@@ -52,7 +52,7 @@ coreshop.order.order.detail.blocks.invoice = Class.create(coreshop.order.sale.de
                             text: t('coreshop_total_without_tax'),
                             flex: 1,
                             renderer: function (value) {
-                                return coreshop.util.format.currency(me.sale.currency.iso, value);
+                                return coreshop.util.format.currency(me.sale.currency.isoCode, value);
                             }
                         },
                         {
@@ -61,7 +61,7 @@ coreshop.order.order.detail.blocks.invoice = Class.create(coreshop.order.sale.de
                             text: t('coreshop_total'),
                             flex: 1,
                             renderer: function (value) {
-                                return coreshop.util.format.currency(me.sale.currency.iso, value);
+                                return coreshop.util.format.currency(me.sale.currency.isoCode, value);
                             }
                         },
                         {

--- a/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/order/detail/blocks/payment.js
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/order/detail/blocks/payment.js
@@ -83,7 +83,7 @@ coreshop.order.order.detail.blocks.payment = Class.create(coreshop.order.sale.de
                             text: t('coreshop_amount'),
                             flex: 1,
                             renderer: function (value) {
-                                return coreshop.util.format.currency_precision(me.sale.currency.iso, value, 2, 100);
+                                return coreshop.util.format.currency_precision(me.sale.currency.isoCode, value, 2, 100);
                             }
                         },
                         {
@@ -148,7 +148,7 @@ coreshop.order.order.detail.blocks.payment = Class.create(coreshop.order.sale.de
 
         if (me.paymentInfoAlert) {
             if (me.sale.totalPayed < me.sale.total || me.sale.totalPayed > me.sale.total) {
-                me.paymentInfoAlert.update(t('coreshop_order_payment_paid_warning').format(coreshop.util.format.currency(me.sale.currency.iso, me.sale.totalPayed), coreshop.util.format.currency(me.sale.currency.symbol, me.sale.totalGross)));
+                me.paymentInfoAlert.update(t('coreshop_order_payment_paid_warning').format(coreshop.util.format.currency(me.sale.currency.isoCode, me.sale.totalPayed), coreshop.util.format.currency(me.sale.currency.symbol, me.sale.totalGross)));
                 me.paymentInfoAlert.show();
             } else {
                 me.paymentInfoAlert.update('');

--- a/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/order/editInvoice.js
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/order/editInvoice.js
@@ -61,7 +61,7 @@ coreshop.order.order.editInvoice = {
                         fieldLabel: t('coreshop_total_without_tax'),
                         disabled: true,
                         value: invoice.get('totalNet') / pimcore.globalmanager.get('coreshop.currency.decimal_factor'),
-                        renderer: coreshop.util.format.currency.bind(this, currency.iso)
+                        renderer: coreshop.util.format.currency.bind(this, currency.isoCode)
                     },
                     {
                         xtype: 'textfield',
@@ -69,7 +69,7 @@ coreshop.order.order.editInvoice = {
                         fieldLabel: t('coreshop_total'),
                         disabled: true,
                         value: invoice.get('totalGross') / pimcore.globalmanager.get('coreshop.currency.decimal_factor'),
-                        renderer: coreshop.util.format.currency.bind(this, currency.iso)
+                        renderer: coreshop.util.format.currency.bind(this, currency.isoCode)
                     },
                     {
                         xtype: 'button',

--- a/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/order/invoice.js
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/order/invoice.js
@@ -73,7 +73,7 @@ coreshop.order.order.invoice = Class.create({
                 text: t('coreshop_price'),
                 width: 100,
                 align: 'right',
-                renderer: coreshop.util.format.currency.bind(this, this.order.currency.iso)
+                renderer: coreshop.util.format.currency.bind(this, this.order.currency.isoCode)
             },
             {
                 xtype: 'gridcolumn',
@@ -106,7 +106,7 @@ coreshop.order.order.invoice = Class.create({
                 text: t('coreshop_tax'),
                 width: 100,
                 align: 'right',
-                renderer: coreshop.util.format.currency.bind(this, this.order.currency.iso)
+                renderer: coreshop.util.format.currency.bind(this, this.order.currency.isoCode)
             },
             {
                 xtype: 'gridcolumn',
@@ -114,7 +114,7 @@ coreshop.order.order.invoice = Class.create({
                 text: t('coreshop_total'),
                 width: 100,
                 align: 'right',
-                renderer: coreshop.util.format.currency.bind(this, this.order.currency.iso)
+                renderer: coreshop.util.format.currency.bind(this, this.order.currency.isoCode)
             }
         ];
     },

--- a/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/order/shipment.js
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/order/shipment.js
@@ -72,7 +72,7 @@ coreshop.order.order.shipment = Class.create({
                 text: t('coreshop_price'),
                 width: 100,
                 align: 'right',
-                renderer: coreshop.util.format.currency.bind(this, this.order.currency.iso)
+                renderer: coreshop.util.format.currency.bind(this, this.order.currency.isoCode)
             },
             {
                 xtype: 'gridcolumn',

--- a/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/sale/create/step/products.js
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/sale/create/step/products.js
@@ -96,7 +96,7 @@ coreshop.order.sale.create.step.products = Class.create(coreshop.order.sale.crea
                     align: 'right',
                     text: t('coreshop_base_price'),
                     renderer: function (value, metaData, record) {
-                        return '<span style="font-weight:bold">' + coreshop.util.format.currency(me.sale.baseCurrency.iso, value) + '</span>';
+                        return '<span style="font-weight:bold">' + coreshop.util.format.currency(me.sale.baseCurrency.isoCode, value) + '</span>';
                     }.bind(this)
                 },
                 {
@@ -106,7 +106,7 @@ coreshop.order.sale.create.step.products = Class.create(coreshop.order.sale.crea
                     align: 'right',
                     text: t('coreshop_price'),
                     renderer: function (value, metaData, record) {
-                        return '<span style="font-weight:bold">' + coreshop.util.format.currency(me.sale.currency.iso, value) + '</span>';
+                        return '<span style="font-weight:bold">' + coreshop.util.format.currency(me.sale.currency.isoCode, value) + '</span>';
                     }.bind(this)
                 },
                 {
@@ -126,7 +126,7 @@ coreshop.order.sale.create.step.products = Class.create(coreshop.order.sale.crea
                     align: 'right',
                     text: t('coreshop_base_total'),
                     renderer: function (value, metaData, record) {
-                        return '<span style="font-weight:bold">' + coreshop.util.format.currency(me.sale.baseCurrency.iso, value) + '</span>';
+                        return '<span style="font-weight:bold">' + coreshop.util.format.currency(me.sale.baseCurrency.isoCode, value) + '</span>';
                     }.bind(this)
                 },
                 {
@@ -136,7 +136,7 @@ coreshop.order.sale.create.step.products = Class.create(coreshop.order.sale.crea
                     align: 'right',
                     text: t('coreshop_total'),
                     renderer: function (value, metaData, record) {
-                        return '<span style="font-weight:bold">' + coreshop.util.format.currency(me.sale.currency.iso, value) + '</span>';
+                        return '<span style="font-weight:bold">' + coreshop.util.format.currency(me.sale.currency.isoCode, value) + '</span>';
                     }.bind(this)
                 },
                 {

--- a/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/sale/create/step/totals.js
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/sale/create/step/totals.js
@@ -73,7 +73,7 @@ coreshop.order.sale.create.step.totals = Class.create(coreshop.order.sale.create
                             width: 150,
                             align: 'right',
                             renderer: function (value, metaData, record) {
-                                return '<span style="font-weight:bold">' + coreshop.util.format.currency(me.sale.currency.iso, value) + '</span>';
+                                return '<span style="font-weight:bold">' + coreshop.util.format.currency(me.sale.currency.isoCode, value) + '</span>';
                             }.bind(this)
                         }
                     ]

--- a/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/sale/detail/blocks/detail.js
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/sale/detail/blocks/detail.js
@@ -145,7 +145,7 @@ coreshop.order.sale.detail.blocks.detail = Class.create(coreshop.order.sale.deta
                     text: t('coreshop_wholesale_price'),
                     width: 150,
                     align: 'right',
-                    renderer: coreshop.util.format.currency.bind(this, this.sale.currency.iso)
+                    renderer: coreshop.util.format.currency.bind(this, this.sale.currency.isoCode)
                 },
                 {
                     xtype: 'gridcolumn',
@@ -153,7 +153,7 @@ coreshop.order.sale.detail.blocks.detail = Class.create(coreshop.order.sale.deta
                     text: t('coreshop_price_without_tax'),
                     width: 150,
                     align: 'right',
-                    renderer: coreshop.util.format.currency.bind(this, this.sale.currency.iso),
+                    renderer: coreshop.util.format.currency.bind(this, this.sale.currency.isoCode),
                     field: {
                         xtype: 'numberfield',
                         decimalPrecision: 4
@@ -165,7 +165,7 @@ coreshop.order.sale.detail.blocks.detail = Class.create(coreshop.order.sale.deta
                     text: t('coreshop_price_with_tax'),
                     width: 150,
                     align: 'right',
-                    renderer: coreshop.util.format.currency.bind(this, this.sale.currency.iso)
+                    renderer: coreshop.util.format.currency.bind(this, this.sale.currency.isoCode)
                 },
                 {
                     xtype: 'gridcolumn',
@@ -184,7 +184,7 @@ coreshop.order.sale.detail.blocks.detail = Class.create(coreshop.order.sale.deta
                     text: t('coreshop_total'),
                     width: 150,
                     align: 'right',
-                    renderer: coreshop.util.format.currency.bind(this, this.sale.currency.iso)
+                    renderer: coreshop.util.format.currency.bind(this, this.sale.currency.isoCode)
                 },
                 {
                     menuDisabled: true,

--- a/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/sale/detail/blocks/detail.js
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/sale/detail/blocks/detail.js
@@ -118,7 +118,7 @@ coreshop.order.sale.detail.blocks.detail = Class.create(coreshop.order.sale.deta
                             if (row.type === 'string') {
                                 value = row.value;
                             } else if (row.type === 'price') {
-                                value = coreshop.util.format.currency(_.sale.currency.iso, row.value)
+                                value = coreshop.util.format.currency(_.sale.currency.isoCode, row.value)
                             } else {
                                 value = '--';
                             }
@@ -228,7 +228,7 @@ coreshop.order.sale.detail.blocks.detail = Class.create(coreshop.order.sale.deta
                         var factor = record.get('factor') ?? pimcore.globalmanager.get('coreshop.currency.decimal_factor');
                         var precision = record.get('precision') ?? pimcore.globalmanager.get('coreshop.currency.decimal_precision');
 
-                        return '<span style="font-weight:bold">' + coreshop.util.format.currency_precision(this.sale.currency.iso, value, precision, factor) + '</span>';
+                        return '<span style="font-weight:bold">' + coreshop.util.format.currency_precision(this.sale.currency.isoCode, value, precision, factor) + '</span>';
                     }.bind(this)
                 }
             ]
@@ -262,7 +262,7 @@ coreshop.order.sale.detail.blocks.detail = Class.create(coreshop.order.sale.deta
                     width: 150,
                     align: 'right',
                     renderer: function (value) {
-                        return '<span style="font-weight:bold">' + coreshop.util.format.currency(this.sale.currency.iso, value) + '</span>';
+                        return '<span style="font-weight:bold">' + coreshop.util.format.currency(this.sale.currency.isoCode, value) + '</span>';
                     }.bind(this)
                 },
                 {
@@ -271,7 +271,7 @@ coreshop.order.sale.detail.blocks.detail = Class.create(coreshop.order.sale.deta
                     width: 150,
                     align: 'right',
                     renderer: function (value) {
-                        return '<span style="font-weight:bold">' + coreshop.util.format.currency(this.sale.currency.iso, value) + '</span>';
+                        return '<span style="font-weight:bold">' + coreshop.util.format.currency(this.sale.currency.isoCode, value) + '</span>';
                     }.bind(this)
                 }
             ]

--- a/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/sale/detail/blocks/header.js
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/sale/detail/blocks/header.js
@@ -72,7 +72,7 @@ coreshop.order.sale.detail.blocks.header = Class.create(coreshop.order.sale.deta
         var me = this;
 
         me.datePanel.setHtml(t('coreshop_date') + '<br/><span class="coreshop_order_big">' + Ext.Date.format(new Date(me.sale.saleDate * 1000), t('coreshop_date_time_format')) + '</span>');
-        me.totalPanel.setHtml(t('coreshop_sale_total') + '<br/><span class="coreshop_order_big">' + coreshop.util.format.currency(me.sale.currency.iso, me.sale.totalGross) + '</span>');
+        me.totalPanel.setHtml(t('coreshop_sale_total') + '<br/><span class="coreshop_order_big">' + coreshop.util.format.currency(me.sale.currency.isoCode, me.sale.totalGross) + '</span>');
         me.productPanel.setHtml(t('coreshop_product_count') + '<br/><span class="coreshop_order_big">' + me.sale.items.length + '</span>');
         me.storePanel.setHtml(t('coreshop_store') + '<br/><span class="coreshop_order_big">' + me.sale.store.name + '</span>');
     }

--- a/src/CoreShop/Bundle/ShippingBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/ShippingBundle/Resources/config/services.yml
@@ -8,7 +8,7 @@ services:
     _defaults:
         public: true
 
-  # Carrier Validator
+    # Carrier Validator
     coreshop.shipping.carrier.validator.composite: '@CoreShop\Component\Shipping\Validator\CompositeShippableCarrierValidator'
     CoreShop\Component\Shipping\Validator\ShippableCarrierValidatorInterface: '@CoreShop\Component\Shipping\Validator\CompositeShippableCarrierValidator'
     CoreShop\Component\Shipping\Validator\CompositeShippableCarrierValidator:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

The sale detail views are not working when using JMS Serializer because the currency is formatted in the wrong structure. This PR fixes that problem by changing the property access to `sale.currency.isoCode` instead of `sale.currency.iso`