### PR TITLE
[OrderBundle] Values should be zero, if amount should not be defined

### DIFF
--- a/src/CoreShop/Bundle/OrderBundle/Form/Type/Rule/Condition/AmountConfigurationType.php
+++ b/src/CoreShop/Bundle/OrderBundle/Form/Type/Rule/Condition/AmountConfigurationType.php
@@ -46,14 +46,12 @@ final class AmountConfigurationType extends AbstractType
                 'constraints' => [
                     new NotBlank(['groups' => $this->validationGroups]),
                     new Type(['type' => 'numeric', 'groups' => $this->validationGroups]),
-                    new GreaterThan(['value' => 0, 'groups' => $this->validationGroups]),
                 ],
             ])
             ->add('maxAmount', MoneyType::class, [
                 'constraints' => [
                     new NotBlank(['groups' => $this->validationGroups]),
                     new Type(['type' => 'numeric', 'groups' => $this->validationGroups]),
-                    new GreaterThan(['value' => 0, 'groups' => $this->validationGroups]),
                 ],
             ]);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

There is a check if a value is 0 in the condition checker, but 0s are not valid in the given form configuration
