### PR TITLE
Allow null return value in request resolver find store

### DIFF
--- a/src/CoreShop/Component/Store/Context/RequestBased/CompositeRequestResolver.php
+++ b/src/CoreShop/Component/Store/Context/RequestBased/CompositeRequestResolver.php
@@ -36,7 +36,7 @@ final class CompositeRequestResolver implements RequestResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function findStore(Request $request): StoreInterface
+    public function findStore(Request $request): ?StoreInterface
     {
         foreach ($this->requestResolvers as $requestResolver) {
             try {

--- a/src/CoreShop/Component/Store/Context/RequestBased/PimcoreAdminSiteBasedRequestResolver.php
+++ b/src/CoreShop/Component/Store/Context/RequestBased/PimcoreAdminSiteBasedRequestResolver.php
@@ -42,7 +42,7 @@ final class PimcoreAdminSiteBasedRequestResolver implements RequestResolverInter
     /**
      * {@inheritdoc}
      */
-    public function findStore(Request $request): StoreInterface
+    public function findStore(Request $request): ?StoreInterface
     {
         if ($this->requestHelper->isFrontendRequestByAdmin($request)) {
             $document = $this->documentService->getNearestDocumentByPath($request->getPathInfo());

--- a/src/CoreShop/Component/Store/Context/RequestBased/RequestResolverInterface.php
+++ b/src/CoreShop/Component/Store/Context/RequestBased/RequestResolverInterface.php
@@ -26,5 +26,5 @@ interface RequestResolverInterface
      * @return StoreInterface
      * @throws StoreNotFoundException
      */
-    public function findStore(Request $request): StoreInterface;
+    public function findStore(Request $request): ?StoreInterface;
 }

--- a/src/CoreShop/Component/Store/Context/RequestBased/SiteBasedRequestResolver.php
+++ b/src/CoreShop/Component/Store/Context/RequestBased/SiteBasedRequestResolver.php
@@ -32,7 +32,7 @@ final class SiteBasedRequestResolver implements RequestResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function findStore(Request $request): StoreInterface
+    public function findStore(Request $request): ?StoreInterface
     {
         if (Site::isSiteRequest()) {
             return $this->storeRepository->findOneBySite(Site::getCurrentSite()->getId());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | #1463 

Changed type hint of the findStore method to allow null values. This method returns null for sites that are not connected to any store. 

BC breaks because we change the return type of a method in RequestResolverInterface.