### PR TITLE
[CoreBundle] don't set product for store-values on pre-get-data

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/CoreExtension/StoreValues.php
+++ b/src/CoreShop/Bundle/CoreBundle/CoreExtension/StoreValues.php
@@ -278,12 +278,12 @@ class StoreValues extends Model\DataObject\ClassDefinition\Data implements
         if (!is_array($data)) {
             $data = [];
         }
-
-        foreach ($data as &$storeEntry) {
-            if ($storeEntry instanceof ProductStoreValuesInterface) {
-                $storeEntry->setProduct($object);
-            }
-        }
+//
+//        foreach ($data as &$storeEntry) {
+//            if ($storeEntry instanceof ProductStoreValuesInterface) {
+//                $storeEntry->setProduct($object);
+//            }
+//        }
 
         unset($storeEntry);
 


### PR DESCRIPTION
otherrwise we don't know if belongs to the object or not

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? |no

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->
