### PR TITLE
fix: ignore CartNotFoundException during interactiveLogin event

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/EventListener/CartBlamerListener.php
+++ b/src/CoreShop/Bundle/CoreBundle/EventListener/CartBlamerListener.php
@@ -17,6 +17,7 @@ namespace CoreShop\Bundle\CoreBundle\EventListener;
 use CoreShop\Bundle\CoreBundle\Event\CustomerRegistrationEvent;
 use CoreShop\Component\Core\Model\CustomerInterface;
 use CoreShop\Component\Order\Context\CartContextInterface;
+use CoreShop\Component\Order\Context\CartNotFoundException;
 use CoreShop\Component\Order\Manager\CartManagerInterface;
 use CoreShop\Component\Order\Model\OrderInterface;
 use CoreShop\Component\Order\Processor\CartProcessorInterface;
@@ -88,8 +89,12 @@ final class CartBlamerListener
         $this->cartProcessor->process($cart);
     }
 
-    private function getCart(): OrderInterface
+    private function getCart(): ?OrderInterface
     {
-        return $this->cartContext->getCart();
+        try {
+            return $this->cartContext->getCart();
+        } catch (CartNotFoundException $exception) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
The CartBlamerListener shouldn't throw exceptions during interactive login

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

The CartBlamerListener::blame() method already have an early return on null, let the getCart() then indeed return null when there is no cart found.