### PR TITLE
fix return empty string if $string is null

### DIFF
--- a/src/CoreShop/Component/Pimcore/DataObject/AbstractSluggableLinkGenerator.php
+++ b/src/CoreShop/Component/Pimcore/DataObject/AbstractSluggableLinkGenerator.php
@@ -18,6 +18,10 @@ abstract class AbstractSluggableLinkGenerator implements LinkGeneratorInterface
 {
     protected function slugify($string)
     {
+        if ($string === null) {
+            return '';
+        }
+
         return strtolower(
             trim(
                 preg_replace('~[^0-9a-z]+~i', '-', html_entity_decode(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1498