### PR TITLE
fix payment details in backed order view

### DIFF
--- a/src/CoreShop/Bundle/OrderBundle/Controller/OrderController.php
+++ b/src/CoreShop/Bundle/OrderBundle/Controller/OrderController.php
@@ -204,8 +204,21 @@ class OrderController extends AbstractSaleDetailController
                     if (empty($detailValue) && $detailValue != 0) {
                         continue;
                     }
+
                     if (is_array($detailValue)) {
                         $detailValue = join(', ', $detailValue);
+                    }
+
+                    if (true === is_bool($detailValue)) {
+                        if (true === $detailValue) {
+                            $detailValue = 'true';
+                        } else {
+                            $detailValue = 'false';
+                        }
+                    }
+
+                    if (false === is_string($detailValue)) {
+                        $detailValue = (string)$detailValue;
                     }
 
                     $details[] = [$detailName, htmlentities($detailValue)];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

open order detail failed because some parameters not a string, a fixed preview:
![image](https://user-images.githubusercontent.com/2986829/98352514-64f7c800-201e-11eb-82ae-5a52d72e5452.png)
