### PR TITLE
Fix checkout with addressAccessType COMPANY_ONLY

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Form/Type/AddressChoiceType.php
+++ b/src/CoreShop/Bundle/CoreBundle/Form/Type/AddressChoiceType.php
@@ -13,7 +13,7 @@
 namespace CoreShop\Bundle\CoreBundle\Form\Type;
 
 use CoreShop\Component\Address\Model\AddressInterface;
-use CoreShop\Component\Core\Customer\Allocator\CustomerAddressAllocator;
+use CoreShop\Component\Core\Customer\Allocator\CustomerAddressAllocatorInterface;
 use CoreShop\Component\Core\Model\CustomerInterface;
 use CoreShop\Component\Resource\Repository\PimcoreRepositoryInterface;
 use Symfony\Component\Form\AbstractType;
@@ -29,11 +29,18 @@ final class AddressChoiceType extends AbstractType
     private $customerRepository;
 
     /**
-     * @param PimcoreRepositoryInterface $customerRepository
+     * @var CustomerAddressAllocatorInterface
      */
-    public function __construct(PimcoreRepositoryInterface $customerRepository)
+    private $customerAddressAllocator;
+
+    /**
+     * @param PimcoreRepositoryInterface $customerRepository
+     * @param CustomerAddressAllocatorInterface $customerAddressAllocator
+     */
+    public function __construct(PimcoreRepositoryInterface $customerRepository, CustomerAddressAllocatorInterface $customerAddressAllocator)
     {
         $this->customerRepository = $customerRepository;
+        $this->customerAddressAllocator = $customerAddressAllocator;
     }
 
     /**
@@ -55,10 +62,9 @@ final class AddressChoiceType extends AbstractType
                         if (!$customer instanceof CustomerInterface) {
                             throw new \InvalidArgumentException('Customer needs to be set');
                         }
-                        
-                        $customerAddressAllocator = new CustomerAddressAllocator();
-                        $addresses = $customerAddressAllocator->allocateForCustomer($customer);
-                        
+
+                        $addresses = $this->customerAddressAllocator->allocateForCustomer($customer);
+
                         if (empty($allowedAddressIdentifier)) {
                             return $addresses;
                         }

--- a/src/CoreShop/Bundle/CoreBundle/Form/Type/AddressChoiceType.php
+++ b/src/CoreShop/Bundle/CoreBundle/Form/Type/AddressChoiceType.php
@@ -13,6 +13,7 @@
 namespace CoreShop\Bundle\CoreBundle\Form\Type;
 
 use CoreShop\Component\Address\Model\AddressInterface;
+use CoreShop\Component\Core\Customer\Allocator\CustomerAddressAllocator;
 use CoreShop\Component\Core\Model\CustomerInterface;
 use CoreShop\Component\Resource\Repository\PimcoreRepositoryInterface;
 use Symfony\Component\Form\AbstractType;
@@ -54,12 +55,15 @@ final class AddressChoiceType extends AbstractType
                         if (!$customer instanceof CustomerInterface) {
                             throw new \InvalidArgumentException('Customer needs to be set');
                         }
-
+                        
+                        $customerAddressAllocator = new CustomerAddressAllocator();
+                        $addresses = $customerAddressAllocator->allocateForCustomer($customer);
+                        
                         if (empty($allowedAddressIdentifier)) {
-                            return $customer->getAddresses();
+                            return $addresses;
                         }
 
-                        return array_filter($customer->getAddresses(), function (AddressInterface $address) use ($allowedAddressIdentifier) {
+                        return array_filter($addresses, function (AddressInterface $address) use ($allowedAddressIdentifier) {
                             $addressIdentifierName = $address->hasAddressIdentifier() ? $address->getAddressIdentifier()->getName() : null;
 
                             return in_array($addressIdentifierName, $allowedAddressIdentifier);

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services/form.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services/form.yml
@@ -13,6 +13,7 @@ services:
     CoreShop\Bundle\CoreBundle\Form\Type\AddressChoiceType:
         arguments:
             - '@coreshop.repository.customer'
+            - '@CoreShop\Component\Core\Customer\Allocator\CustomerAddressAllocatorInterface'
         tags:
             - { name: form.type }
 


### PR DESCRIPTION
When a customer only has access to company addresses, checkout is not possible as those addresses not show up.
This can be fixed by using the already implemented CustomerAddressAllocator also for FormType AddressChoiceType

Q | A
-- | --
Bug fix? | yes
New feature? | no
BC breaks? | no
Deprecations? | no
Fixed tickets |  

This pull request fixes a problem when a customer wants to do a checkout but only has access to the company addresses. The addressAccessType was not considered till now in CoreShop\Bundle\CoreBundle\Form\Type\AddressChoiceType.