### PR TITLE
fix voucher code export

### DIFF
--- a/src/CoreShop/Bundle/OrderBundle/Controller/CartPriceRuleController.php
+++ b/src/CoreShop/Bundle/OrderBundle/Controller/CartPriceRuleController.php
@@ -159,7 +159,7 @@ class CartPriceRuleController extends ResourceController
             header('Content-Encoding: UTF-8');
             header('Content-type: text/csv; charset=UTF-8');
             header("Content-Disposition: attachment; filename=\"$fileName.csv\"");
-            ini_set('display_errors', false); //to prevent warning messages in csv
+            ini_set('display_errors', 'off'); //to prevent warning messages in csv
             echo "\xEF\xBB\xBF";
             echo $csv;
             die();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Fix for:
Error: ini_set() expects parameter 2 to be string, bool given (500 Internal Server Error)

File: vendor/coreshop/core-shop/src/CoreShop/Bundle/OrderBundle/Controller/CartPriceRuleController.php::164
