### PR TITLE
ignore failed payments in total amount check

### DIFF
--- a/src/CoreShop/Bundle/OrderBundle/Controller/OrderPaymentController.php
+++ b/src/CoreShop/Bundle/OrderBundle/Controller/OrderPaymentController.php
@@ -78,6 +78,7 @@ class OrderPaymentController extends PimcoreController
         $paymentProvider = $this->getPaymentProviderRepository()->find($paymentProviderId);
         $totalPayed = array_sum(array_map(function (PaymentInterface $payment) {
             if ($payment->getState() === PaymentInterface::STATE_CANCELLED ||
+                $payment->getState() === PaymentInterface::STATE_FAILED ||
                 $payment->getState() === PaymentInterface::STATE_REFUNDED) {
                 return 0;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | --

It's not possible to add a new payment in backend if a failed payment is available.
