### PR TITLE
fix addressAccessType check and improve view

### DIFF
--- a/src/CoreShop/Bundle/FrontendBundle/Resources/views/Customer/address.html.twig
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/views/Customer/address.html.twig
@@ -14,9 +14,13 @@
         </nav>
 
         <h2 class="main-heading text-center">
-            {{ 'coreshop.ui.address'|trans }} <br/>
+            {% if address.addressIdentifier is not empty %}
+                {{ ('coreshop.ui.' ~ address.addressIdentifier.name ~ '_address')|trans }}
+            {% else %}
+                {{ 'coreshop.ui.address'|trans }}
+            {% endif %}
             {% if not address.getId %}
-                <span>{{ 'coreshop.ui.add_new_address'|trans }}</span>
+                – <span>{{ 'coreshop.ui.add_new_address'|trans }}</span>
             {% endif %}
         </h2>
 

--- a/src/CoreShop/Bundle/FrontendBundle/Resources/views/Customer/addresses.html.twig
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/views/Customer/addresses.html.twig
@@ -26,6 +26,8 @@
                         <div class="card-body">
                             {% if customer is not coreshop_address_owner_of(address) %}
                                 <span class="badge badge badge-secondary float-right">{{ 'coreshop.ui.company_address'|trans }}</span>
+                            {% elseif address.addressIdentifier is not empty %}
+                                <span class="badge badge badge-secondary float-right">{{ ('coreshop.ui.' ~ address.addressIdentifier.name ~ '_address')|trans }}</span>
                             {% endif %}
                             {{ address|coreshop_format_address }}
                             <br/>

--- a/src/CoreShop/Bundle/FrontendBundle/Resources/views/Customer/addresses.html.twig
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/views/Customer/addresses.html.twig
@@ -25,9 +25,9 @@
                     <div class="card card-smart">
                         <div class="card-body">
                             {% if customer is not coreshop_address_owner_of(address) %}
-                                <span class="badge badge badge-secondary float-right">{{ 'coreshop.ui.company_address'|trans }}</span>
+                                <span class="badge badge-secondary float-right">{{ 'coreshop.ui.company_address'|trans }}</span>
                             {% elseif address.addressIdentifier is not empty %}
-                                <span class="badge badge badge-secondary float-right">{{ ('coreshop.ui.' ~ address.addressIdentifier.name ~ '_address')|trans }}</span>
+                                <span class="badge badge-secondary float-right">{{ ('coreshop.ui.' ~ address.addressIdentifier.name ~ '_address')|trans }}</span>
                             {% endif %}
                             {{ address|coreshop_format_address }}
                             <br/>

--- a/src/CoreShop/Component/Core/Customer/Address/AddressAssignmentManager.php
+++ b/src/CoreShop/Component/Core/Customer/Address/AddressAssignmentManager.php
@@ -84,7 +84,7 @@ final class AddressAssignmentManager implements AddressAssignmentManagerInterfac
             return true;
         }
 
-        if ($customer->getAddressAccessType() === null) {
+        if (empty($customer->getAddressAccessType())) {
             return $customer->hasAddress($address);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | --

## Fixes
- `getAddressAccessType` can be null or an empty string (pimcore at its best...)
- Add address type badge to address overview card for better identification (if defined)
- Add address type headline on editing for better identification (if defined)