### PR TITLE
Issues/concurrency

### DIFF
--- a/src/CoreShop/Bundle/OptimisticEntityLockBundle/EventListener/LockListener.php
+++ b/src/CoreShop/Bundle/OptimisticEntityLockBundle/EventListener/LockListener.php
@@ -105,9 +105,6 @@ class LockListener implements EventSubscriberInterface
         $stmt = $queryBuilder->execute();
         $currentVersion = (int)$stmt->fetchOne();
 
-        echo 'Object Lock: ' . $object->getOptimisticLockVersion() . PHP_EOL;
-        echo 'Current Lock: ' . $currentVersion . PHP_EOL;
-
         if ($currentVersion === $object->getOptimisticLockVersion()) {
             return;
         }

--- a/src/CoreShop/Bundle/OptimisticEntityLockBundle/EventListener/LockListener.php
+++ b/src/CoreShop/Bundle/OptimisticEntityLockBundle/EventListener/LockListener.php
@@ -103,7 +103,7 @@ class LockListener implements EventSubscriberInterface
         ;
 
         $stmt = $queryBuilder->execute();
-        $currentVersion = (int)$stmt->fetchOne();
+        $currentVersion = (int)$stmt->fetchColumn();
 
         if ($currentVersion === $object->getOptimisticLockVersion()) {
             return;

--- a/src/CoreShop/Bundle/OptimisticEntityLockBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/OptimisticEntityLockBundle/Resources/config/services.yml
@@ -6,5 +6,6 @@ services:
     CoreShop\Bundle\OptimisticEntityLockBundle\EventListener\LockListener:
         arguments:
             - '@CoreShop\Bundle\OptimisticEntityLockBundle\Manager\EntityLockManager'
+            - '@doctrine.dbal.default_connection'
         tags:
             - { name: kernel.event_subscriber }

--- a/src/CoreShop/Bundle/PayumBundle/EventListener/TransactionListener.php
+++ b/src/CoreShop/Bundle/PayumBundle/EventListener/TransactionListener.php
@@ -28,7 +28,6 @@ class TransactionListener implements EventSubscriberInterface
         $this->connection = $connection;
     }
 
-
     public static function getSubscribedEvents()
     {
         return [
@@ -41,12 +40,15 @@ class TransactionListener implements EventSubscriberInterface
     {
         $controller = $event->getController();
 
-        if (!$controller instanceof PayumController) {
+        if (!is_callable($controller)) {
+            return;
+        }
+
+        if (!$controller[0] instanceof PayumController) {
             return;
         }
 
         $event->getRequest()->attributes->add(['PAYUM_TRANSACTION_ACTIVE' => true]);
-
         $this->connection->beginTransaction();
     }
 

--- a/src/CoreShop/Bundle/PayumBundle/EventListener/TransactionListener.php
+++ b/src/CoreShop/Bundle/PayumBundle/EventListener/TransactionListener.php
@@ -12,6 +12,7 @@
 
 namespace CoreShop\Bundle\PayumBundle\EventListener;
 
+use CoreShop\Bundle\PayumBundle\Controller\PaymentController;
 use Doctrine\DBAL\Connection;
 use Payum\Bundle\PayumBundle\Controller\PayumController;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -48,7 +49,7 @@ class TransactionListener implements EventSubscriberInterface
             return;
         }
 
-        if (!$controller[0] instanceof PayumController) {
+        if (!$controller[0] instanceof PayumController && !$controller[0] instanceof PaymentController) {
             return;
         }
 

--- a/src/CoreShop/Bundle/PayumBundle/EventListener/TransactionListener.php
+++ b/src/CoreShop/Bundle/PayumBundle/EventListener/TransactionListener.php
@@ -44,6 +44,10 @@ class TransactionListener implements EventSubscriberInterface
             return;
         }
 
+        if (!is_array($controller)) {
+            return;
+        }
+
         if (!$controller[0] instanceof PayumController) {
             return;
         }

--- a/src/CoreShop/Bundle/PayumBundle/EventListener/TransactionListener.php
+++ b/src/CoreShop/Bundle/PayumBundle/EventListener/TransactionListener.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2020 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\PayumBundle\EventListener;
+
+use Doctrine\DBAL\Connection;
+use Payum\Bundle\PayumBundle\Controller\PayumController;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class TransactionListener implements EventSubscriberInterface
+{
+    protected $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::CONTROLLER => 'onKernelController',
+            KernelEvents::RESPONSE => 'onKernelResponse',
+        ];
+    }
+
+    public function onKernelController(ControllerEvent $event)
+    {
+        $controller = $event->getController();
+
+        if (!$controller instanceof PayumController) {
+            return;
+        }
+
+        $event->getRequest()->attributes->add(['PAYUM_TRANSACTION_ACTIVE' => true]);
+
+        $this->connection->beginTransaction();
+    }
+
+    public function onKernelResponse(ResponseEvent $event)
+    {
+        if (!$event->getRequest()->attributes->get('PAYUM_TRANSACTION_ACTIVE')) {
+            return;
+        }
+
+        $this->connection->commit();
+    }
+}

--- a/src/CoreShop/Bundle/PayumBundle/Resources/config/pimcore/config.yml
+++ b/src/CoreShop/Bundle/PayumBundle/Resources/config/pimcore/config.yml
@@ -1,0 +1,3 @@
+parameters:
+    payum.storage.doctrine.orm.class: CoreShop\Bundle\PayumBundle\Storage\LockingStorage
+

--- a/src/CoreShop/Bundle/PayumBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/PayumBundle/Resources/config/services.yml
@@ -50,3 +50,9 @@ services:
     CoreShop\Bundle\PayumBundle\Action\Offline\StatusAction:
         tags:
             - { name: payum.action, factory: offline, alias: coreshop.offline.status }
+
+    CoreShop\Bundle\PayumBundle\EventListener\TransactionListener:
+        arguments:
+            - '@doctrine.dbal.default_connection'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/src/CoreShop/Bundle/PayumBundle/Storage/LockingStorage.php
+++ b/src/CoreShop/Bundle/PayumBundle/Storage/LockingStorage.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2020 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\PayumBundle\Storage;
+
+use Doctrine\DBAL\LockMode;
+use Doctrine\ORM\EntityManager;
+use Payum\Core\Bridge\Doctrine\Storage\DoctrineStorage;
+
+class LockingStorage extends DoctrineStorage
+{
+    protected function doFind($id)
+    {
+        $objectManager = $this->objectManager;
+        if ($objectManager instanceof EntityManager) {
+            if ($objectManager->getConnection()->isTransactionActive()) {
+                return $objectManager->find($this->modelClass, $id, LockMode::PESSIMISTIC_WRITE);
+            }
+        }
+
+        return parent::doFind($id);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? |no

The Problem we have quite often now is: 

 - The Notify and the Capture Request come simultaneously
 - The Notify and Capture Controller read the Payment and update the same old Payment at quite the same time
 - These leads to a lot of issues: The workflow gets executed multiple times, States mess up, emails being sent multiple times, etc.
 - To fix this: We have to WRITE_LOCK the payment for the being of the request. This assures us that the second request, doesn't get to read the payment until the first one is finished. Since Payum doesn't support this out-of-the-box, we have to a be a bit tricky to do it....
