### PR TITLE
use full unit definition label in choice field

### DIFF
--- a/src/CoreShop/Bundle/ProductBundle/Form/Type/Unit/ProductUnitDefinitionsChoiceType.php
+++ b/src/CoreShop/Bundle/ProductBundle/Form/Type/Unit/ProductUnitDefinitionsChoiceType.php
@@ -43,7 +43,7 @@ final class ProductUnitDefinitionsChoiceType extends AbstractType
             'entry_type' => ProductUnitDefinitionType::class,
             'choice_value' => 'id',
             'choice_label' => function (ProductUnitDefinitionInterface $definition) {
-                return $definition->getUnit()->getName();
+                return $definition->getUnit()->getFullLabel();
             },
             'choice_attr' => function (ProductUnitDefinitionInterface $definition) {
                 return ['data-cs-unit-precision' => $definition->getPrecision()];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | --

Use fully translated label instead of generic unit definition name:

![image](https://user-images.githubusercontent.com/700119/105631857-d6daf300-5e50-11eb-8edc-cf634c758ae6.png)

