### PR TITLE
Fix Firewall for URL path /

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -1,5 +1,5 @@
 parameters:
-    coreshop.security.frontend_regex: "^/(?!admin)[^/]++"
+    coreshop.security.frontend_regex: "^/(?!admin)[^/]*"
 
 security:
     providers:

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/pimcore/security.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/pimcore/security.yml
@@ -1,5 +1,5 @@
 parameters:
-    coreshop.security.frontend_regex: "^/(?!admin)[^/]++"
+    coreshop.security.frontend_regex: "^/(?!admin)[^/]*"
 
 pimcore:
     security:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

When the core shop is accessible directly under URL path `/` (so like when you call the home page https://example.org/) the logged in customer cannot be found with the `TokenBasedRequestResolver` because path `/` does not match the regex `^/(?!admin)[^/]++`. 