### PR TITLE
[Core] fix cloning and serializing (with DeepCopy) of UnitDefinitions…

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/pimcore/security.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/pimcore/security.yml
@@ -1,5 +1,5 @@
 parameters:
-    coreshop.security.frontend_regex: "^/(?!admin)[^/]++"
+    coreshop.security.frontend_regex: "^/(?!admin)[^/]*"
 
 pimcore:
     security:

--- a/src/CoreShop/Component/Core/Product/Cloner/ProductQuantityPriceRulesCloner.php
+++ b/src/CoreShop/Component/Core/Product/Cloner/ProductQuantityPriceRulesCloner.php
@@ -64,6 +64,21 @@ class ProductQuantityPriceRulesCloner implements ProductClonerInterface
     {
         $newQuantityPriceRule = clone $quantityPriceRule;
 
+         //Hack to get rid of the ID
+        $reflectionClass = new \ReflectionClass($newQuantityPriceRule);
+        $property = $reflectionClass->getProperty('id');
+        $property->setAccessible(true);
+        $property->setValue($newQuantityPriceRule, null);
+
+        foreach ([$newQuantityPriceRule->getConditions(), $newQuantityPriceRule->getActive()] as $batch) {
+            foreach ($batch as $entry) {
+                $reflectionClass = new \ReflectionClass($entry);
+                $property = $reflectionClass->getProperty('id');
+                $property->setAccessible(true);
+                $property->setValue($entry, null);
+            }
+        }
+
         $newQuantityPriceRule->setProduct($product->getId());
 
         $ranges = $newQuantityPriceRule->getRanges();

--- a/src/CoreShop/Component/Core/Product/Cloner/ProductUnitDefinitionsCloner.php
+++ b/src/CoreShop/Component/Core/Product/Cloner/ProductUnitDefinitionsCloner.php
@@ -27,6 +27,19 @@ class ProductUnitDefinitionsCloner implements ProductClonerInterface
 
         $unitDefinitions = clone $referenceProduct->getUnitDefinitions();
 
+        //Hack to get rid of the ID
+        $reflectionClass = new \ReflectionClass($unitDefinitions);
+        $property = $reflectionClass->getProperty('id');
+        $property->setAccessible(true);
+        $property->setValue($unitDefinitions, null);
+
+        foreach ($unitDefinitions->getUnitDefinitions() as $unitDefinition) {
+            $reflectionClass = new \ReflectionClass($unitDefinition);
+            $property = $reflectionClass->getProperty('id');
+            $property->setAccessible(true);
+            $property->setValue($unitDefinition, null);
+        }
+
         $product->setUnitDefinitions($unitDefinitions);
     }
 }

--- a/src/CoreShop/Component/Product/Model/ProductUnitDefinition.php
+++ b/src/CoreShop/Component/Product/Model/ProductUnitDefinition.php
@@ -141,13 +141,13 @@ class ProductUnitDefinition extends AbstractResource implements ProductUnitDefin
     {
         return sprintf('%s, (Conversion Rate: %s)', $this->getUnitName(), $this->getConversionRate());
     }
-
-    public function __clone()
-    {
-        if ($this->id === null) {
-            return;
-        }
-
-        $this->id = null;
-    }
+//
+//    public function __clone()
+//    {
+//        if ($this->id === null) {
+//            return;
+//        }
+//
+//        $this->id = null;
+//    }
 }

--- a/src/CoreShop/Component/Rule/Model/Condition.php
+++ b/src/CoreShop/Component/Rule/Model/Condition.php
@@ -77,12 +77,12 @@ class Condition implements ConditionInterface
         return $this->configuration;
     }
 
-    public function __clone()
-    {
-        if ($this->id === null) {
-            return;
-        }
-
-        $this->id = null;
-    }
+//    public function __clone()
+//    {
+//        if ($this->id === null) {
+//            return;
+//        }
+//
+//        $this->id = null;
+//    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1589

The Problems comes due to how Pimcore Serializes stuff for the cache. This triggers the __clone method and resets the id's, after reloading stuff from the cache, it is unknown data and breaks things.

@solverat You use the copy feature a lot, I would ask you to test this please. 