### PR TITLE
[Rule] refactor Rule conditions and actions peristance

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Migrations/Version20210614115749.php
+++ b/src/CoreShop/Bundle/CoreBundle/Migrations/Version20210614115749.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace CoreShop\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
+
+class Version20210614115749 extends AbstractPimcoreMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE coreshop_rule_condition ADD sort INT DEFAULT NULL;');
+        $this->addSql('ALTER TABLE coreshop_rule_action ADD sort INT DEFAULT NULL;');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+
+    }
+}

--- a/src/CoreShop/Bundle/IndexBundle/Resources/config/doctrine/model/Filter.orm.yml
+++ b/src/CoreShop/Bundle/IndexBundle/Resources/config/doctrine/model/Filter.orm.yml
@@ -43,6 +43,8 @@ CoreShop\Component\Index\Model\Filter:
     manyToMany:
         preConditions:
             targetEntity: CoreShop\Component\Index\Model\FilterConditionInterface
+            orderBy: { 'sort': 'ASC' }
+            orphanRemoval: true
             joinTable:
                 name: coreshop_filter_condition_pre_conditions
                 joinColumns:
@@ -57,6 +59,8 @@ CoreShop\Component\Index\Model\Filter:
                 - all
         conditions:
             targetEntity: CoreShop\Component\Index\Model\FilterConditionInterface
+            orderBy: { 'sort': 'ASC' }
+            orphanRemoval: true
             joinTable:
                 name: coreshop_filter_condition_conditions
                 joinColumns:

--- a/src/CoreShop/Bundle/NotificationBundle/Resources/config/doctrine/model/NotificationRule.orm.yml
+++ b/src/CoreShop/Bundle/NotificationBundle/Resources/config/doctrine/model/NotificationRule.orm.yml
@@ -35,6 +35,8 @@ CoreShop\Component\Notification\Model\NotificationRule:
     manyToMany:
         conditions:
             targetEntity: CoreShop\Component\Rule\Model\ConditionInterface
+            orphanRemoval: true
+            orderBy: { 'sort': 'ASC' }
             cascade:
                 - all
             joinTable:
@@ -52,6 +54,8 @@ CoreShop\Component\Notification\Model\NotificationRule:
 
         actions:
             targetEntity: CoreShop\Component\Rule\Model\ActionInterface
+            orphanRemoval: true
+            orderBy: { 'sort': 'ASC' }
             cascade:
                 - all
             joinTable:

--- a/src/CoreShop/Bundle/OrderBundle/Form/Type/Rule/Condition/NestedConfigurationType.php
+++ b/src/CoreShop/Bundle/OrderBundle/Form/Type/Rule/Condition/NestedConfigurationType.php
@@ -43,7 +43,8 @@ final class NestedConfigurationType extends AbstractNestedConfigurationType
 
         $builder
             ->add('conditions', CartPriceRuleConditionCollectionType::class, [
-                'constraints' => new Valid(['groups' => $this->validationGroups])
+                'constraints' => new Valid(['groups' => $this->validationGroups]),
+                'nested' => true
             ]);
 
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {

--- a/src/CoreShop/Bundle/OrderBundle/Resources/config/doctrine/model/CartPriceRule.orm.yml
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/config/doctrine/model/CartPriceRule.orm.yml
@@ -42,6 +42,8 @@ CoreShop\Component\Order\Model\CartPriceRule:
     manyToMany:
         conditions:
             targetEntity: CoreShop\Component\Rule\Model\ConditionInterface
+            orphanRemoval: true
+            orderBy: { 'sort': 'ASC' }
             cascade:
                 - all
             joinTable:
@@ -59,6 +61,8 @@ CoreShop\Component\Order\Model\CartPriceRule:
 
         actions:
             targetEntity: CoreShop\Component\Rule\Model\ActionInterface
+            orphanRemoval: true
+            orderBy: { 'sort': 'ASC' }
             cascade:
                 - all
             joinTable:

--- a/src/CoreShop/Bundle/ProductBundle/Form/Type/Rule/Condition/ProductPriceNestedConfigurationType.php
+++ b/src/CoreShop/Bundle/ProductBundle/Form/Type/Rule/Condition/ProductPriceNestedConfigurationType.php
@@ -43,7 +43,8 @@ final class ProductPriceNestedConfigurationType extends AbstractNestedConfigurat
 
         $builder
             ->add('conditions', ProductPriceRuleConditionCollectionType::class, [
-                'constraints' => new Valid(['groups' => $this->validationGroups])
+                'constraints' => new Valid(['groups' => $this->validationGroups]),
+                'nested' => true
             ]);
 
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {

--- a/src/CoreShop/Bundle/ProductBundle/Form/Type/Rule/Condition/ProductSpecificPriceNestedConfigurationType.php
+++ b/src/CoreShop/Bundle/ProductBundle/Form/Type/Rule/Condition/ProductSpecificPriceNestedConfigurationType.php
@@ -43,7 +43,8 @@ final class ProductSpecificPriceNestedConfigurationType extends AbstractNestedCo
 
         $builder
             ->add('conditions', ProductSpecificPriceRuleConditionCollectionType::class, [
-                'constraints' => [new Valid(['groups' => $this->validationGroups])]
+                'constraints' => [new Valid(['groups' => $this->validationGroups])],
+                'nested' => true
             ]);
 
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {

--- a/src/CoreShop/Bundle/ProductBundle/Resources/config/doctrine/model/ProductPriceRule.orm.yml
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/config/doctrine/model/ProductPriceRule.orm.yml
@@ -38,6 +38,8 @@ CoreShop\Component\Product\Model\ProductPriceRule:
     manyToMany:
         conditions:
             targetEntity: CoreShop\Component\Rule\Model\ConditionInterface
+            orphanRemoval: true
+            orderBy: { 'sort': 'ASC' }
             cascade:
                 - all
             joinTable:
@@ -55,6 +57,8 @@ CoreShop\Component\Product\Model\ProductPriceRule:
 
         actions:
             targetEntity: CoreShop\Component\Rule\Model\ActionInterface
+            orphanRemoval: true
+            orderBy: { 'sort': 'ASC' }
             cascade:
                 - all
             joinTable:

--- a/src/CoreShop/Bundle/ProductBundle/Resources/config/doctrine/model/ProductSpecificPriceRule.orm.yml
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/config/doctrine/model/ProductSpecificPriceRule.orm.yml
@@ -41,6 +41,8 @@ CoreShop\Component\Product\Model\ProductSpecificPriceRule:
     manyToMany:
         conditions:
             targetEntity: CoreShop\Component\Rule\Model\ConditionInterface
+            orphanRemoval: true
+            orderBy: { 'sort': 'ASC' }
             cascade:
                 - all
             joinTable:
@@ -58,6 +60,8 @@ CoreShop\Component\Product\Model\ProductSpecificPriceRule:
 
         actions:
             targetEntity: CoreShop\Component\Rule\Model\ActionInterface
+            orphanRemoval: true
+            orderBy: { 'sort': 'ASC' }
             cascade:
                 - all
             joinTable:

--- a/src/CoreShop/Bundle/ProductBundle/Resources/public/pimcore/js/specificprice/object/item.js
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/public/pimcore/js/specificprice/object/item.js
@@ -19,6 +19,8 @@ coreshop.product.specificprice.object.item = Class.create(coreshop.rules.item, {
     postSaveObject: function (object, refreshedRuleData, task, fieldName) {
         // remove dirty flag!
         //this.settingsForm.getForm().setValues(this.settingsForm.getForm().getValues());
+        this.conditions.reload(refreshedRuleData.conditions);
+        this.actions.reload(refreshedRuleData.actions);
     },
 
     getPanel: function () {

--- a/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Form/Type/Rule/Condition/ProductQuantityPriceRuleNestedConfigurationType.php
+++ b/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Form/Type/Rule/Condition/ProductQuantityPriceRuleNestedConfigurationType.php
@@ -28,7 +28,7 @@ final class ProductQuantityPriceRuleNestedConfigurationType extends AbstractNest
         parent::buildForm($builder, $options);
 
         $builder
-            ->add('conditions', ProductQuantityPriceRuleConditionCollectionType::class);
+            ->add('conditions', ProductQuantityPriceRuleConditionCollectionType::class, ['nested' => true]);
 
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
             $data = $event->getData();

--- a/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/config/doctrine/model/ProductQuantityPriceRule.orm.yml
+++ b/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/config/doctrine/model/ProductQuantityPriceRule.orm.yml
@@ -38,6 +38,8 @@ CoreShop\Component\ProductQuantityPriceRules\Model\ProductQuantityPriceRule:
     manyToMany:
         conditions:
             targetEntity: CoreShop\Component\Rule\Model\ConditionInterface
+            orphanRemoval: true
+            orderBy: { 'sort': 'ASC' }
             cascade:
                 - all
             joinTable:

--- a/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/public/pimcore/js/productQuantityPriceRules/object/item.js
+++ b/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/public/pimcore/js/productQuantityPriceRules/object/item.js
@@ -26,6 +26,8 @@ coreshop.product_quantity_price_rules.object.item = Class.create(coreshop.rules.
         // remove dirty flag!
         this.settings.getForm().setValues(this.settings.getForm().getValues());
         this.ranges.postSaveObject(object, refreshedRuleData, task, fieldName);
+
+        this.conditions.reload(refreshedRuleData.conditions);
     },
 
     onClipboardUpdated: function () {

--- a/src/CoreShop/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -161,6 +161,11 @@ class ResourceController extends AdminController
             $this->manager->persist($resource);
             $this->manager->flush();
 
+            $this->manager->clear();
+
+            //Reload resource
+            $resource = $this->repository->find($resource->getId());
+
             $this->eventDispatcher->dispatchPostEvent('save', $this->metadata, $resource, $request);
 
             return $this->viewHandler->handle(['data' => $resource, 'success' => true], ['group' => 'Detailed']);

--- a/src/CoreShop/Bundle/ResourceBundle/Doctrine/ORM/EntityMerger.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Doctrine/ORM/EntityMerger.php
@@ -144,8 +144,19 @@ class EntityMerger
                 }, $visited);
 
                 $this->mergeCollection($newData, $origData, $assoc, static function ($foundEntry) use ($newCollection) {
-                    $newCollection->add($foundEntry);
-                }, $visited);
+                    $found = false;
+
+                    foreach ($newCollection as $entry) {
+                        if (spl_object_hash($entry) === spl_object_hash($foundEntry)) {
+                            $found = true;
+                            break;
+                        }
+                    }
+
+                    if (!$found) {
+                        $newCollection->add($foundEntry);
+                    }
+                }, $visited, true);
 
                 // @todo: check if we really need to build this reference!
                 $newData = &$newCollection;
@@ -188,7 +199,14 @@ class EntityMerger
      * @param \Closure   $notFound
      * @param array      $visited
      */
-    private function mergeCollection(Collection $from, Collection $to, array $assoc, \Closure $notFound, array &$visited)
+    private function mergeCollection(
+        Collection $from,
+        Collection $to,
+        array $assoc,
+        \Closure $notFound,
+        array &$visited,
+        bool $mergeFoundEntity = false
+    )
     {
         $assocClass = $this->em->getClassMetadata($assoc['targetEntity']);
 
@@ -196,11 +214,20 @@ class EntityMerger
             $found = false;
             $origId = $assocClass->getIdentifierValues($fromEntry);
 
-            foreach ($to as $toEntry) {
+            foreach ($to as $offset => $toEntry) {
                 $newId = $assocClass->getIdentifierValues($toEntry);
+
+                if (!$newId) {
+                    continue;
+                }
 
                 if ($newId === $origId) {
                     $found = true;
+
+                    if ($mergeFoundEntity) {
+                        $to->set($offset, $fromEntry);
+                    }
+
                     break;
                 }
             }

--- a/src/CoreShop/Bundle/RuleBundle/Form/DataMapper/ActionsFormMapper.php
+++ b/src/CoreShop/Bundle/RuleBundle/Form/DataMapper/ActionsFormMapper.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2020 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\RuleBundle\Form\DataMapper;
+
+use CoreShop\Component\Resource\Model\ResourceInterface;
+use CoreShop\Component\Rule\Model\ActionInterface;
+use Doctrine\Common\Collections\Collection;
+use Symfony\Component\Form\DataMapperInterface;
+
+/**
+ * @internal
+ */
+class ActionsFormMapper implements DataMapperInterface
+{
+    private $propertyMapper;
+
+    public function __construct(DataMapperInterface $propertyMapper)
+    {
+        $this->propertyMapper = $propertyMapper;
+    }
+
+    public function mapDataToForms($data, $forms): void
+    {
+//        $this->propertyPathDataMapper->mapDataToForms($data, $forms);
+    }
+
+    public function mapFormsToData($forms, &$data): void
+    {
+        if (!$data instanceof Collection) {
+            return;
+        }
+
+        $actualData = [];
+
+        foreach ($forms as $form) {
+            $formData = $form->getData();
+            $id = $form->get('id')->getData();
+
+            if (!$formData instanceof ActionInterface) {
+                continue;
+            }
+
+            if ($id) {
+                foreach ($data as $entry) {
+                    if (!$entry instanceof ResourceInterface) {
+                        continue;
+                    }
+
+                    if ($entry->getId() === $id) {
+                        $this->propertyMapper->mapFormsToData($form, $entry);
+
+                        $actualData[] = $entry;
+                        continue 2;
+                    }
+                }
+            }
+
+            $actualData[] = $formData;
+        }
+
+        $data = $actualData;
+    }
+}

--- a/src/CoreShop/Bundle/RuleBundle/Form/DataMapper/ConditionsFormMapper.php
+++ b/src/CoreShop/Bundle/RuleBundle/Form/DataMapper/ConditionsFormMapper.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2020 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\RuleBundle\Form\DataMapper;
+
+use CoreShop\Component\Resource\Model\ResourceInterface;
+use CoreShop\Component\Rule\Model\ConditionInterface;
+use Doctrine\Common\Collections\Collection;
+use Symfony\Component\Form\DataMapperInterface;
+
+/**
+ * @internal
+ */
+class ConditionsFormMapper implements DataMapperInterface
+{
+    private $propertyMapper;
+
+    public function __construct(DataMapperInterface $propertyMapper)
+    {
+        $this->propertyMapper = $propertyMapper;
+    }
+
+    public function mapDataToForms($data, $forms): void
+    {
+//        $this->propertyPathDataMapper->mapDataToForms($data, $forms);
+    }
+
+    public function mapFormsToData($forms, &$data): void
+    {
+        if (!$data instanceof Collection) {
+            return;
+        }
+
+        $actualData = [];
+
+        foreach ($forms as $form) {
+            $formData = $form->getData();
+            $id = $form->get('id')->getData();
+
+            if (!$formData instanceof ConditionInterface) {
+                continue;
+            }
+
+            if ($id) {
+                foreach ($data as $entry) {
+                    if (!$entry instanceof ResourceInterface) {
+                        continue;
+                    }
+
+                    if ($entry->getId() === $id) {
+                        $this->propertyMapper->mapFormsToData($form, $entry);
+
+                        $actualData[] = $entry;
+                        continue 2;
+                    }
+                }
+            }
+
+            $actualData[] = $formData;
+        }
+
+        $data = $actualData;
+    }
+}

--- a/src/CoreShop/Bundle/RuleBundle/Form/Type/RuleActionCollectionType.php
+++ b/src/CoreShop/Bundle/RuleBundle/Form/Type/RuleActionCollectionType.php
@@ -12,7 +12,9 @@
 
 namespace CoreShop\Bundle\RuleBundle\Form\Type;
 
+use CoreShop\Bundle\RuleBundle\Form\DataMapper\ActionsFormMapper;
 use CoreShop\Bundle\RuleBundle\Form\Type\Core\AbstractConfigurationCollectionType;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class RuleActionCollectionType extends AbstractConfigurationCollectionType
@@ -20,6 +22,11 @@ class RuleActionCollectionType extends AbstractConfigurationCollectionType
     public function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->setDataMapper(new ActionsFormMapper($builder->getDataMapper()));
     }
 
     /**

--- a/src/CoreShop/Bundle/RuleBundle/Form/Type/RuleActionType.php
+++ b/src/CoreShop/Bundle/RuleBundle/Form/Type/RuleActionType.php
@@ -12,6 +12,7 @@
 
 namespace CoreShop\Bundle\RuleBundle\Form\Type;
 
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class RuleActionType extends AbstractConfigurableRuleElementType
@@ -22,6 +23,9 @@ class RuleActionType extends AbstractConfigurableRuleElementType
     public function buildForm(FormBuilderInterface $builder, array $options = [])
     {
         parent::buildForm($builder, $options);
+
+        $builder->add('id', IntegerType::class, ['mapped' => false]);
+        $builder->add('sort', IntegerType::class);
     }
 
     /**

--- a/src/CoreShop/Bundle/RuleBundle/Form/Type/RuleConditionCollectionType.php
+++ b/src/CoreShop/Bundle/RuleBundle/Form/Type/RuleConditionCollectionType.php
@@ -12,7 +12,9 @@
 
 namespace CoreShop\Bundle\RuleBundle\Form\Type;
 
+use CoreShop\Bundle\RuleBundle\Form\DataMapper\ConditionsFormMapper;
 use CoreShop\Bundle\RuleBundle\Form\Type\Core\AbstractConfigurationCollectionType;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class RuleConditionCollectionType extends AbstractConfigurationCollectionType
@@ -20,6 +22,11 @@ class RuleConditionCollectionType extends AbstractConfigurationCollectionType
     public function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->setDataMapper(new ConditionsFormMapper($builder->getDataMapper()));
     }
 
     /**

--- a/src/CoreShop/Bundle/RuleBundle/Form/Type/RuleConditionCollectionType.php
+++ b/src/CoreShop/Bundle/RuleBundle/Form/Type/RuleConditionCollectionType.php
@@ -22,11 +22,15 @@ class RuleConditionCollectionType extends AbstractConfigurationCollectionType
     public function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
+
+        $resolver->setDefault('nested', false);
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->setDataMapper(new ConditionsFormMapper($builder->getDataMapper()));
+        if (!$options['nested']) {
+            $builder->setDataMapper(new ConditionsFormMapper($builder->getDataMapper()));
+        }
     }
 
     /**

--- a/src/CoreShop/Bundle/RuleBundle/Form/Type/RuleConditionType.php
+++ b/src/CoreShop/Bundle/RuleBundle/Form/Type/RuleConditionType.php
@@ -12,6 +12,7 @@
 
 namespace CoreShop\Bundle\RuleBundle\Form\Type;
 
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class RuleConditionType extends AbstractConfigurableRuleElementType
@@ -22,6 +23,9 @@ class RuleConditionType extends AbstractConfigurableRuleElementType
     public function buildForm(FormBuilderInterface $builder, array $options = [])
     {
         parent::buildForm($builder, $options);
+
+        $builder->add('id', IntegerType::class, ['mapped' => false]);
+        $builder->add('sort', IntegerType::class);
     }
 
     /**

--- a/src/CoreShop/Bundle/RuleBundle/Resources/config/doctrine/model/Action.orm.yml
+++ b/src/CoreShop/Bundle/RuleBundle/Resources/config/doctrine/model/Action.orm.yml
@@ -11,6 +11,10 @@ CoreShop\Component\Rule\Model\Action:
         type:
             column: type
             type: string
+        sort:
+            column: sort
+            type: integer
+            nullable: true
         configuration:
             column: configuration
             type: array

--- a/src/CoreShop/Bundle/RuleBundle/Resources/config/doctrine/model/Condition.orm.yml
+++ b/src/CoreShop/Bundle/RuleBundle/Resources/config/doctrine/model/Condition.orm.yml
@@ -11,6 +11,10 @@ CoreShop\Component\Rule\Model\Condition:
         type:
             column: type
             type: string
+        sort:
+            column: sort
+            type: integer
+            nullable: true
         configuration:
             column: configuration
             type: array

--- a/src/CoreShop/Bundle/RuleBundle/Resources/config/serializer/Model.Action.yml
+++ b/src/CoreShop/Bundle/RuleBundle/Resources/config/serializer/Model.Action.yml
@@ -11,6 +11,10 @@ CoreShop\Component\Rule\Model\Action:
             expose: true
             type: string
             groups: [Detailed, Version]
+        sort:
+            expose: true
+            type: int
+            groups: [ Detailed, Version ]
         configuration:
             expose: true
             type: array

--- a/src/CoreShop/Bundle/RuleBundle/Resources/config/serializer/Model.Condition.yml
+++ b/src/CoreShop/Bundle/RuleBundle/Resources/config/serializer/Model.Condition.yml
@@ -11,6 +11,10 @@ CoreShop\Component\Rule\Model\Condition:
             expose: true
             type: string
             groups: [Detailed, Version]
+        sort:
+            expose: true
+            type: int
+            groups: [Detailed, Version]
         configuration:
             expose: true
             type: array

--- a/src/CoreShop/Bundle/RuleBundle/Resources/public/pimcore/js/rules/abstract.js
+++ b/src/CoreShop/Bundle/RuleBundle/Resources/public/pimcore/js/rules/abstract.js
@@ -108,27 +108,22 @@ coreshop.rules.abstract = Class.create({
 
                 var blockElement = Ext.getCmp(blockId);
                 var index = coreshop.rules[namespace].abstract.prototype.getIndex(blockElement, container);
-                var tmpContainer = pimcore.viewport;
 
                 var newIndex = index - 1;
                 if (newIndex < 0) {
                     newIndex = 0;
                 }
 
+                this.parent.setDirty(true);
+
                 // move this node temorary to an other so ext recognizes a change
                 container.remove(blockElement, false);
-                tmpContainer.add(blockElement);
-                container.updateLayout();
-                tmpContainer.updateLayout();
-
-                // move the element to the right position
-                tmpContainer.remove(blockElement, false);
                 container.insert(newIndex, blockElement);
+
                 container.updateLayout();
-                tmpContainer.updateLayout();
 
                 pimcore.layout.refresh();
-            }.bind(window, index, parent, container, namespace),
+            }.bind(this, index, parent, container, namespace),
             xtype: 'button'
         }, {
             iconCls: 'pimcore_icon_down',
@@ -137,23 +132,17 @@ coreshop.rules.abstract = Class.create({
                 var container = container;
                 var blockElement = Ext.getCmp(blockId);
                 var index = coreshop.rules[namespace].abstract.prototype.getIndex(blockElement, container);
-                var tmpContainer = pimcore.viewport;
+
+                this.parent.setDirty(true);
 
                 // move this node temorary to an other so ext recognizes a change
                 container.remove(blockElement, false);
-                tmpContainer.add(blockElement);
-                container.updateLayout();
-                tmpContainer.updateLayout();
-
-                // move the element to the right position
-                tmpContainer.remove(blockElement, false);
                 container.insert(index + 1, blockElement);
                 container.updateLayout();
-                tmpContainer.updateLayout();
 
                 pimcore.layout.refresh();
 
-            }.bind(window, index, parent, container, namespace),
+            }.bind(this, index, parent, container, namespace),
             xtype: 'button'
         }];
 
@@ -168,7 +157,9 @@ coreshop.rules.abstract = Class.create({
                 handler: function (index, parent, container, namespace) {
                     parent.setDirty(true);
                     container.remove(Ext.getCmp(index));
-                }.bind(window, index, parent, container, namespace),
+
+                    this.parent.setDirty(true);
+                }.bind(this, index, parent, container, namespace),
                 xtype: 'button'
             }
         ]);

--- a/src/CoreShop/Bundle/RuleBundle/Resources/public/pimcore/js/rules/action.js
+++ b/src/CoreShop/Bundle/RuleBundle/Resources/public/pimcore/js/rules/action.js
@@ -19,6 +19,14 @@ coreshop.rules.action = Class.create({
         this.dirty = false;
     },
 
+    reload: function (actions) {
+        this.actionsContainer.removeAll();
+
+        Ext.each(actions, function(action) {
+            this.addAction(action.type, action, false);
+        }.bind(this));
+    },
+
     getLayout: function () {
         // init
         var _this = this;
@@ -127,12 +135,14 @@ coreshop.rules.action = Class.create({
                 }
             }
 
-            if (actionClass.data.id) {
-                action['id'] = actionClass.data.id;
+            if (actionClass.id) {
+                action['id'] = actionClass.id;
             }
 
             action['configuration'] = configuration;
             action['type'] = actions[i].xparent.type;
+            action['sort'] = (i + 1);
+
             actionData.push(action);
 
             if (Ext.isFunction(this.prepareAction)) {

--- a/src/CoreShop/Bundle/RuleBundle/Resources/public/pimcore/js/rules/condition.js
+++ b/src/CoreShop/Bundle/RuleBundle/Resources/public/pimcore/js/rules/condition.js
@@ -19,6 +19,14 @@ coreshop.rules.condition = Class.create({
         this.dirty = false;
     },
 
+    reload: function (conditions) {
+        this.conditionsContainer.removeAll();
+
+        Ext.each(conditions, function(condition) {
+            this.addCondition(condition.type, condition, false);
+        }.bind(this));
+    },
+
     getLayout: function () {
         // init
         var _this = this;
@@ -135,12 +143,13 @@ coreshop.rules.condition = Class.create({
                 }
             }
 
-            if (conditionClass.data.id) {
-                condition['id'] = conditionClass.data.id;
+            if (conditionClass.id) {
+                condition['id'] = conditionClass.id;
             }
 
             condition['configuration'] = configuration;
             condition['type'] = conditions[i].xparent.type;
+            condition['sort'] = (i + 1);
 
             if (Ext.isFunction(this.prepareCondition)) {
                 condition = this.prepareCondition(condition);

--- a/src/CoreShop/Bundle/RuleBundle/Resources/public/pimcore/js/rules/item.js
+++ b/src/CoreShop/Bundle/RuleBundle/Resources/public/pimcore/js/rules/item.js
@@ -61,8 +61,13 @@ coreshop.rules.item = Class.create(coreshop.resource.item, {
         }
     },
 
+    postSave: function(result) {
+        this.conditions.reload(result.data.conditions);
+        this.actions.reload(result.data.actions);
+    },
+
     getSaveData: function () {
-        saveData = this.settingsForm.getForm().getFieldValues();
+        var saveData = this.settingsForm.getForm().getFieldValues();
         saveData['conditions'] = this.conditions.getConditionsData();
         saveData['actions'] = this.actions.getActionsData();
 

--- a/src/CoreShop/Bundle/ShippingBundle/Form/Type/Rule/Condition/NestedConfigurationType.php
+++ b/src/CoreShop/Bundle/ShippingBundle/Form/Type/Rule/Condition/NestedConfigurationType.php
@@ -43,7 +43,8 @@ final class NestedConfigurationType extends AbstractNestedConfigurationType
 
         $builder
             ->add('conditions', ShippingRuleConditionCollectionType::class, [
-                'constraints' => [new Valid(['groups' => $this->validationGroups])]
+                'constraints' => [new Valid(['groups' => $this->validationGroups])],
+                'nested' => true
             ]);
 
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {

--- a/src/CoreShop/Bundle/ShippingBundle/Resources/config/doctrine/model/ShippingRule.orm.yml
+++ b/src/CoreShop/Bundle/ShippingBundle/Resources/config/doctrine/model/ShippingRule.orm.yml
@@ -28,6 +28,8 @@ CoreShop\Component\Shipping\Model\ShippingRule:
     manyToMany:
         conditions:
             targetEntity: CoreShop\Component\Rule\Model\ConditionInterface
+            orphanRemoval: true
+            orderBy: { 'sort': 'ASC' }
             cascade:
                 - all
             joinTable:
@@ -45,6 +47,8 @@ CoreShop\Component\Shipping\Model\ShippingRule:
 
         actions:
             targetEntity: CoreShop\Component\Rule\Model\ActionInterface
+            orphanRemoval: true
+            orderBy: { 'sort': 'ASC' }
             cascade:
               - all
             joinTable:

--- a/src/CoreShop/Component/Rule/Model/Action.php
+++ b/src/CoreShop/Component/Rule/Model/Action.php
@@ -29,6 +29,11 @@ class Action implements ActionInterface
     protected $type;
 
     /**
+     * @var int
+     */
+    protected $sort;
+
+    /**
      * @var array
      */
     protected $configuration;
@@ -44,6 +49,14 @@ class Action implements ActionInterface
     /**
      * {@inheritdoc}
      */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function setType($type)
     {
         $this->type = $type;
@@ -54,19 +67,17 @@ class Action implements ActionInterface
     /**
      * {@inheritdoc}
      */
-    public function setConfiguration(array $configuration)
+    public function getSort()
     {
-        $this->configuration = $configuration;
-
-        return $this;
+        return $this->sort;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getType()
+    public function setSort($sort)
     {
-        return $this->type;
+        $this->sort = $sort;
     }
 
     /**
@@ -75,5 +86,15 @@ class Action implements ActionInterface
     public function getConfiguration()
     {
         return $this->configuration;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setConfiguration(array $configuration)
+    {
+        $this->configuration = $configuration;
+
+        return $this;
     }
 }

--- a/src/CoreShop/Component/Rule/Model/ActionInterface.php
+++ b/src/CoreShop/Component/Rule/Model/ActionInterface.php
@@ -17,22 +17,32 @@ use CoreShop\Component\Resource\Model\ResourceInterface;
 interface ActionInterface extends ResourceInterface
 {
     /**
-     * @param string $type
-     */
-    public function setType($type);
-
-    /**
-     * @param array $configuration
-     */
-    public function setConfiguration(array $configuration);
-
-    /**
      * @return string
      */
     public function getType();
 
     /**
+     * @param string $type
+     */
+    public function setType($type);
+
+        /**
+     * @return int
+     */
+    public function getSort();
+
+    /**
+    * @param int $sort
+     */
+    public function setSort($sort);
+
+    /**
      * @return array
      */
     public function getConfiguration();
+
+    /**
+     * @param array $configuration
+     */
+    public function setConfiguration(array $configuration);
 }

--- a/src/CoreShop/Component/Rule/Model/Condition.php
+++ b/src/CoreShop/Component/Rule/Model/Condition.php
@@ -29,6 +29,11 @@ class Condition implements ConditionInterface
     protected $type;
 
     /**
+     * @var int
+     */
+    protected $sort;
+
+    /**
      * @var array
      */
     protected $configuration;
@@ -44,11 +49,43 @@ class Condition implements ConditionInterface
     /**
      * {@inheritdoc}
      */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function setType($type)
     {
         $this->type = $type;
 
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSort()
+    {
+        return $this->sort;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setSort($sort)
+    {
+        $this->sort = $sort;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfiguration()
+    {
+        return $this->configuration;
     }
 
     /**
@@ -61,21 +98,6 @@ class Condition implements ConditionInterface
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getType()
-    {
-        return $this->type;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getConfiguration()
-    {
-        return $this->configuration;
-    }
 
     public function __clone()
     {

--- a/src/CoreShop/Component/Rule/Model/Condition.php
+++ b/src/CoreShop/Component/Rule/Model/Condition.php
@@ -87,7 +87,17 @@ class Condition implements ConditionInterface
     {
         return $this->configuration;
     }
-    
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setConfiguration(array $configuration)
+    {
+        $this->configuration = $configuration;
+
+        return $this;
+    }
+
 //    public function __clone()
 //    {
 //        if ($this->id === null) {

--- a/src/CoreShop/Component/Rule/Model/ConditionInterface.php
+++ b/src/CoreShop/Component/Rule/Model/ConditionInterface.php
@@ -17,22 +17,32 @@ use CoreShop\Component\Resource\Model\ResourceInterface;
 interface ConditionInterface extends ResourceInterface
 {
     /**
-     * @param string $type
-     */
-    public function setType($type);
-
-    /**
-     * @param array $configuration
-     */
-    public function setConfiguration(array $configuration);
-
-    /**
      * @return string
      */
     public function getType();
 
     /**
+     * @param string $type
+     */
+    public function setType($type);
+
+    /**
+     * @return int
+     */
+    public function getSort();
+
+    /**
+    * @param int $sort
+     */
+    public function setSort($sort);
+
+    /**
      * @return array
      */
     public function getConfiguration();
+
+    /**
+     * @param array $configuration
+     */
+    public function setConfiguration(array $configuration);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | #1618 

THIS IS A BC BREAK! But I don't see a way around it. This is due to how Symfony Form works with Collections/Arrays. We have to refactor that in order to make it properly work.

 - Add sorting field
 - Fixes in Entity Merger with ManyToMany Collections
 - Add reloading of conditions/actions on save
 - Force reload Resource on save
 - Fix orphan removal for conditions and actions