### PR TITLE
storeId should be surrounded by commas in searchController

### DIFF
--- a/src/CoreShop/Bundle/FrontendBundle/Controller/SearchController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/SearchController.php
@@ -52,7 +52,7 @@ class SearchController extends FrontendController
                 '%' . $text . '%',
                 '%' . $text . '%',
                 '%' . $text . '%',
-                '%' . $this->container->get(StoreContextInterface::class)->getStore()->getId() . '%',
+                '%,' . $this->container->get(StoreContextInterface::class)->getStore()->getId() . ',%',
             ];
 
             $list = $this->get('coreshop.repository.product')->getList();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

storeId should be surrounded by commas to avoid matching for example storeId `10` when searching in store `1`