### PR TITLE
[FrontendBundle] Print cart price rule label instead name if available

### DIFF
--- a/src/CoreShop/Bundle/FrontendBundle/Resources/views/Checkout/steps/summary/_rules.html.twig
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/views/Checkout/steps/summary/_rules.html.twig
@@ -4,7 +4,7 @@
     {% for priceRule in cart.getPriceRuleItems %}
         <tr>
             <td colspan="2" class="text-left">
-                {{ priceRule.cartPriceRule.getName }}
+                {{ priceRule.cartPriceRule.label ?: priceRule.cartPriceRule.name }}
             </td>
             <td class="text-center"></td>
             <td class="text-right" colspan="2">

--- a/src/CoreShop/Bundle/FrontendBundle/Resources/views/Common/order_detail.html.twig
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/views/Common/order_detail.html.twig
@@ -111,7 +111,7 @@
                 {% for priceRule in order.getPriceRuleItems %}
                     <tr>
                         <td colspan="2" class="text-center">
-                            {{ priceRule.cartPriceRule.getName }}
+                            {{ priceRule.cartPriceRule.label ?: priceRule.cartPriceRule.name }}
                         </td>
                         <td class="text-center">
 

--- a/src/CoreShop/Bundle/FrontendBundle/Resources/views/Quote/show.html.twig
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/views/Quote/show.html.twig
@@ -67,7 +67,7 @@
                 {% for priceRule in quote.getPriceRuleItems %}
                     <tr>
                         <td colspan="2" class="text-center">
-                            {{ priceRule.cartPriceRule.getName }}
+                            {{ priceRule.cartPriceRule.label ?: priceRule.cartPriceRule.name }}
                         </td>
                         <td class="text-center">
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

Print cart price rule label instead name, if available, in all places
