### PR TITLE
Prevent PHP exception by non nullable return type

### DIFF
--- a/src/CoreShop/Bundle/ResourceBundle/Pimcore/ObjectManager.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Pimcore/ObjectManager.php
@@ -166,7 +166,7 @@ final class ObjectManager implements \Doctrine\Persistence\ObjectManager
     {
         $id = spl_object_hash($resource);
 
-        if (method_exists($resource, 'getId')) {
+        if (method_exists($resource, 'getId') && $resource->getId()) {
             $id = $resource->getId();
         }
 


### PR DESCRIPTION
When creating an object the $id was overwritten in the getResourceId method and set to null. This created a php exception and breaks the code.
This code change will prevent that by checking if the id of the resource object is not null.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

<!--
When creating an object the $id variable was overwritten in the getResourceId method and set to null. This creates a PHP exception and breaks the code.
This code change will prevent that by checking if the id of the resource object is not null.
-->
