### PR TITLE
exchange fzaninotto/faker, change with fakerphp/faker -- 2.2 dev 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -193,7 +193,7 @@
         "symfony-tests-dir": "tests",
         "symfony-assets-install": "relative",
         "branch-alias": {
-            "dev-master": "2.4-dev"
+            "dev-2.2-dev-3.0": "2.4-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -193,7 +193,7 @@
         "symfony-tests-dir": "tests",
         "symfony-assets-install": "relative",
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "2.4-dev"
         }
     }
 }

--- a/src/CoreShop/Bundle/ResourceBundle/CoreExtension/Select.php
+++ b/src/CoreShop/Bundle/ResourceBundle/CoreExtension/Select.php
@@ -162,7 +162,7 @@ abstract class Select extends Data\Select implements Data\CustomVersionMarshalIn
      */
     public function getDataForResource($data, $object = null, $params = [])
     {
-        if (method_exists($data, 'getId') && is_a($data, $this->getModel())) {
+        if ($data && method_exists($data, 'getId') && is_a($data, $this->getModel())) {
             return $data->getId();
         }
 
@@ -198,7 +198,7 @@ abstract class Select extends Data\Select implements Data\CustomVersionMarshalIn
      */
     public function getDataForQueryResource($data, $object = null, $params = [])
     {
-        if (method_exists($data, 'getId') && is_a($data, $this->getModel())) {
+        if ($data && method_exists($data, 'getId') && is_a($data, $this->getModel())) {
             return $data->getId();
         }
 

--- a/src/CoreShop/Bundle/ResourceBundle/DependencyInjection/Compiler/StackRepositoryPass.php
+++ b/src/CoreShop/Bundle/ResourceBundle/DependencyInjection/Compiler/StackRepositoryPass.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace CoreShop\Bundle\ResourceBundle\DependencyInjection\Compiler;
 
+use CoreShop\Bundle\ResourceBundle\CoreShopResourceBundle;
 use CoreShop\Bundle\ResourceBundle\Pimcore\Repository\StackRepository;
 use CoreShop\Component\Resource\Metadata\Metadata;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -41,7 +42,7 @@ final class StackRepositoryPass implements CompilerPassInterface
             $definition = new Definition(Metadata::class);
             $definition
                 ->setFactory([Metadata::class, 'fromAliasAndConfiguration'])
-                ->setArguments([$alias, []]);
+                ->setArguments([$alias, ['driver' => CoreShopResourceBundle::DRIVER_PIMCORE]]);
 
             $repositoryDefinition = new Definition(StackRepository::class);
             $repositoryDefinition->setArguments([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

Request: Please take out `fzaninotto/faker`, possibly change with `fakerphp/faker`, or other.

Because `fzaninotto/faker` did not like php 8,  
```Workflow: Install 
        1. Install pimcore and 
        2. Install coreshop
```
is not possible for me, because of `fzaninotto/faker`.  Exchange not possible via composer, since it is not a direct dependency [Source: Julien B.](https://stackoverflow.com/users/4346453/julien-b).

My unsuccessful try's to exchange via composer I have described on [stackoverflow](https://stackoverflow.com/questions/68559676/uninstall-fzaninotto-faker-and-change-with-fakerphp-faker-via-composer).
