### PR TITLE
Bugfix for getParameter call

### DIFF
--- a/src/CoreShop/Bundle/NotificationBundle/Controller/NotificationRuleController.php
+++ b/src/CoreShop/Bundle/NotificationBundle/Controller/NotificationRuleController.php
@@ -53,7 +53,7 @@ class NotificationRuleController extends ResourceController
                     $actions[$type] = [];
                 }
 
-                $actions[$type] = array_merge($actions[$type], array_keys($this->getParameter($actionParameter)));
+                $actions[$type] = array_merge($actions[$type], array_keys($this->container->getParameter($actionParameter)));
             }
 
             if ($this->container->hasParameter($conditionParameter)) {
@@ -61,7 +61,7 @@ class NotificationRuleController extends ResourceController
                     $conditions[$type] = [];
                 }
 
-                $conditions[$type] = array_merge($conditions[$type], array_keys($this->getParameter($conditionParameter)));
+                $conditions[$type] = array_merge($conditions[$type], array_keys($this->container->getParameter($conditionParameter)));
             }
         }
 


### PR DESCRIPTION
getParametetr needs to be called via container

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no