### PR TITLE
fix: Error on saving money field

### DIFF
--- a/src/CoreShop/Bundle/MoneyBundle/CoreExtension/Money.php
+++ b/src/CoreShop/Bundle/MoneyBundle/CoreExtension/Money.php
@@ -554,7 +554,7 @@ class Money extends DataObject\ClassDefinition\Data implements
     public function getDataFromEditmode($data, $object = null, $params = [])
     {
         if (is_numeric($data)) {
-            return (int) round((round($data, $this->getDecimalPrecision()) * $this->getDecimalFactor()), 0);
+            return (int) round((round((float) $data, $this->getDecimalPrecision()) * $this->getDecimalFactor()), 0);
         }
 
         return $data;


### PR DESCRIPTION
When saving a DataObject containing a money field, it errors out on saving, because the number typed in into the field is parsed as a string to the PHP function. That is easily mitigated by parsing the string into a float, because the function already checks if the string is numeric.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | none

[This](https://prnt.sc/1sa6csc) happens normally when trying to save a DataObject containing a CoreShop money field.
