### PR TITLE
Fix `(DataObject)BatchListing::key()`

### DIFF
--- a/src/CoreShop/Component/Pimcore/BatchProcessing/BatchListing.php
+++ b/src/CoreShop/Component/Pimcore/BatchProcessing/BatchListing.php
@@ -55,7 +55,7 @@ final class BatchListing implements Iterator, Countable
 
     public function key(): int
     {
-        return ($this->index + 1) * ($this->loop + 1);
+        return ($this->loop * $this->batchSize) + ($this->index + 1);
     }
 
     public function valid(): bool

--- a/src/CoreShop/Component/Pimcore/BatchProcessing/DataObjectBatchListing.php
+++ b/src/CoreShop/Component/Pimcore/BatchProcessing/DataObjectBatchListing.php
@@ -54,7 +54,7 @@ final class DataObjectBatchListing implements Iterator, Countable
 
     public function key(): int
     {
-        return ($this->index + 1) * ($this->loop + 1);
+        return ($this->loop * $this->batchSize) + ($this->index + 1);
     }
 
     public function valid(): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #...

I would expect `key()` to return a consecutive number, but that is not currently the case.

Suppose `$batchSize` is `3`. Then `key()` would return the following in the current implementation: 1, 2, 3, 2, 4, 6, 3, 6, 9, ...

So the first batch would have the expected keys. The following ones, however, would not, since `$this->loop` is incremented and `$this->index` is reset with each batch. 

Thus, the current code `($this->index + 1) * ($this->loop + 1)` results in:
```
(0 + 1) * (0 + 1) = 1
(1 + 1) * (0 + 1) = 2
(2 + 1) * (0 + 1) = 3
(0 + 1) * (1 + 1) = 2
(1 + 1) * (1 + 1) = 4
(2 + 1) * (1 + 1) = 6
(0 + 1) * (2 + 1) = 3
(1 + 1) * (2 + 1) = 6
(2 + 1) * (2 + 1) = 9
```

This fix `($this->loop * $this->batchSize) + ($this->index + 1)` gives:
```
(0 * 3) + (0 + 1) = 1
(0 * 3) + (1 + 1) = 2
(0 * 3) + (2 + 1) = 3
(1 * 3) + (0 + 1) = 4
(1 * 3) + (1 + 1) = 5
(1 * 3) + (2 + 1) = 6
(2 * 3) + (0 + 1) = 7
(2 * 3) + (1 + 1) = 8
(2 * 3) + (2 + 1) = 9
```

---

Note: this error exists in previous versions, too. I wasn't sure which branch to target, though. If you tell me which one, I'll rebase.