### PR TITLE
[CoreExtensions] refactor how Doctrine Entities are cloned

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/CoreExtension/StoreValues.php
+++ b/src/CoreShop/Bundle/CoreBundle/CoreExtension/StoreValues.php
@@ -19,20 +19,24 @@ use CoreShop\Component\Core\Model\ProductInterface;
 use CoreShop\Component\Core\Model\ProductStoreValuesInterface;
 use CoreShop\Component\Core\Model\StoreInterface;
 use CoreShop\Component\Core\Repository\ProductStoreValuesRepositoryInterface;
+use CoreShop\Component\Pimcore\BCLayer\CustomDataCopyInterface;
 use CoreShop\Component\Pimcore\BCLayer\CustomRecyclingMarshalInterface;
 use CoreShop\Component\Product\Model\ProductUnitDefinitionsInterface;
 use CoreShop\Component\Resource\Factory\FactoryInterface;
 use CoreShop\Component\Resource\Factory\RepositoryFactoryInterface;
 use CoreShop\Component\Store\Repository\StoreRepositoryInterface;
+use Doctrine\Common\Collections\ArrayCollection;
 use JMS\Serializer\DeserializationContext;
 use JMS\Serializer\SerializationContext;
 use Pimcore\Model;
+use Pimcore\Model\DataObject\Concrete;
 use Webmozart\Assert\Assert;
 
 class StoreValues extends Model\DataObject\ClassDefinition\Data implements
     Model\DataObject\ClassDefinition\Data\CustomResourcePersistingInterface,
     Model\DataObject\ClassDefinition\Data\CustomVersionMarshalInterface,
-    CustomRecyclingMarshalInterface
+    CustomRecyclingMarshalInterface,
+    CustomDataCopyInterface
 {
     use TempEntityManagerTrait;
 
@@ -304,6 +308,44 @@ class StoreValues extends Model\DataObject\ClassDefinition\Data implements
         }
 
         return $data;
+    }
+
+    public function createDataCopy(Concrete $object, $data)
+    {
+        if (!is_array($data)) {
+            return [];
+        }
+
+        if (!$object instanceof ProductInterface) {
+            return [];
+        }
+
+        $newStoreValues = [];
+
+        foreach ($data as $storeValue) {
+            if (!$storeValue instanceof ProductStoreValuesInterface) {
+                continue;
+            }
+
+            $newStoreValue = clone $storeValue;
+
+            $reflectionClass = new \ReflectionClass($newStoreValue);
+            $property = $reflectionClass->getProperty('id');
+            $property->setAccessible(true);
+            $property->setValue($newStoreValue, null);
+
+            $property = $reflectionClass->getProperty('product');
+            $property->setAccessible(true);
+            $property->setValue($newStoreValue, null);
+
+            $property = $reflectionClass->getProperty('productUnitDefinitionPrices');
+            $property->setAccessible(true);
+            $property->setValue($newStoreValue, new ArrayCollection());
+
+            $newStoreValues[] = $newStoreValue;
+        }
+
+        return $newStoreValues;
     }
 
     /**

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services/product.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services/product.yml
@@ -3,10 +3,18 @@ services:
         public: true
 
     coreshop.product.cloner.quantity_price_rules: '@CoreShop\Component\Core\Product\Cloner\ProductQuantityPriceRulesCloner'
-    CoreShop\Component\Core\Product\Cloner\ProductQuantityPriceRulesCloner: ~
+    CoreShop\Component\Core\Product\Cloner\ProductQuantityPriceRulesCloner:
+        arguments:
+            - '@CoreShop\Component\Core\Product\Cloner\UnitMatcherInterface'
 
     coreshop.product.cloner.unit_definitions: '@CoreShop\Component\Core\Product\Cloner\ProductUnitDefinitionsCloner'
-    CoreShop\Component\Core\Product\Cloner\ProductUnitDefinitionsCloner: ~
+    CoreShop\Component\Core\Product\Cloner\ProductUnitDefinitionsCloner:
+        arguments:
+            - '@CoreShop\Component\Core\Product\Cloner\UnitMatcherInterface'
+
+    coreshop.product.cloner.unit_matcher: '@CoreShop\Component\Core\Product\Cloner\UnitMatcher'
+    CoreShop\Component\Core\Product\Cloner\UnitMatcherInterface: '@CoreShop\Component\Core\Product\Cloner\UnitMatcher'
+    CoreShop\Component\Core\Product\Cloner\UnitMatcher: ~
 
     coreshop.product.tax_factory: '@CoreShop\Component\Core\Product\ProductTaxCalculatorFactory'
     CoreShop\Component\Core\Product\ProductTaxCalculatorFactory:

--- a/src/CoreShop/Bundle/ProductBundle/CoreExtension/ProductUnitDefinition.php
+++ b/src/CoreShop/Bundle/ProductBundle/CoreExtension/ProductUnitDefinition.php
@@ -13,7 +13,9 @@
 namespace CoreShop\Bundle\ProductBundle\CoreExtension;
 
 use CoreShop\Component\Pimcore\BCLayer\CustomRecyclingMarshalInterface;
+use CoreShop\Component\Product\Model\ProductInterface;
 use CoreShop\Component\Product\Model\ProductUnitDefinitionInterface;
+use CoreShop\Component\Product\Model\ProductUnitDefinitionsInterface;
 use CoreShop\Component\Resource\Model\ResourceInterface;
 use CoreShop\Component\Resource\Repository\RepositoryInterface;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
@@ -151,6 +153,36 @@ class ProductUnitDefinition extends Data implements
         }
 
         return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createDataCopy(Concrete $object, $data)
+    {
+        if (!$data instanceof ProductUnitDefinitionsInterface) {
+            return null;
+        }
+
+        if (!$object instanceof ProductInterface) {
+            return null;
+        }
+
+        $data->setProduct($object);
+
+        $reflectionClass = new \ReflectionClass($data);
+        $property = $reflectionClass->getProperty('id');
+        $property->setAccessible(true);
+        $property->setValue($data, null);
+
+        foreach ($data->getUnitDefinitions() as $unitDefinition) {
+            $reflectionClass = new \ReflectionClass($unitDefinition);
+            $property = $reflectionClass->getProperty('id');
+            $property->setAccessible(true);
+            $property->setValue($unitDefinition, null);
+        }
+
+        return $data;
     }
 
     /**

--- a/src/CoreShop/Bundle/ProductBundle/CoreExtension/ProductUnitDefinitions.php
+++ b/src/CoreShop/Bundle/ProductBundle/CoreExtension/ProductUnitDefinitions.php
@@ -15,6 +15,7 @@ namespace CoreShop\Bundle\ProductBundle\CoreExtension;
 use CoreShop\Bundle\ProductBundle\Form\Type\Unit\ProductUnitDefinitionsType;
 use CoreShop\Bundle\ResourceBundle\CoreExtension\TempEntityManagerTrait;
 use CoreShop\Bundle\ResourceBundle\Doctrine\ORM\EntityMerger;
+use CoreShop\Component\Pimcore\BCLayer\CustomDataCopyInterface;
 use CoreShop\Component\Pimcore\BCLayer\CustomRecyclingMarshalInterface;
 use CoreShop\Component\Product\Model\ProductInterface;
 use CoreShop\Component\Product\Model\ProductUnitDefinitionInterface;
@@ -22,17 +23,20 @@ use CoreShop\Component\Product\Model\ProductUnitDefinitionsInterface;
 use CoreShop\Component\Product\Model\ProductUnitInterface;
 use CoreShop\Component\Product\Repository\ProductUnitDefinitionsRepositoryInterface;
 use CoreShop\Component\Resource\Factory\RepositoryFactoryInterface;
+use Doctrine\Common\Collections\ArrayCollection;
 use JMS\Serializer\DeserializationContext;
 use JMS\Serializer\SerializationContext;
 use Pimcore\Model;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
+use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\DataObject\LazyLoadedFieldsInterface;
 use Webmozart\Assert\Assert;
 
 class ProductUnitDefinitions extends Data implements
     Data\CustomResourcePersistingInterface,
     Data\CustomVersionMarshalInterface,
-    CustomRecyclingMarshalInterface
+    CustomRecyclingMarshalInterface,
+    CustomDataCopyInterface
 {
     use TempEntityManagerTrait;
 
@@ -164,6 +168,55 @@ class ProductUnitDefinitions extends Data implements
         $code .= "}\n\n";
 
         return $code;
+    }
+
+    public function createDataCopy(Concrete $object, $data)
+    {
+        if (!$data instanceof ProductUnitDefinitionsInterface) {
+            return null;
+        }
+
+        $newData = clone $data;
+
+        $reflectionClass = new \ReflectionClass($newData);
+
+        $property = $reflectionClass->getProperty('unitDefinitions');
+        $property->setAccessible(true);
+        $property->setValue($newData, new ArrayCollection());
+
+        $property = $reflectionClass->getProperty('id');
+        $property->setAccessible(true);
+        $property->setValue($newData, null);
+
+        $property = $reflectionClass->getProperty('product');
+        $property->setAccessible(true);
+        $property->setValue($newData, null);
+
+        $property = $reflectionClass->getProperty('defaultUnitDefinition');
+        $property->setAccessible(true);
+        $property->setValue($newData, null);
+
+        $newDefaultDefinition = clone $data->getDefaultUnitDefinition();
+        $reflectionClass = new \ReflectionClass($newDefaultDefinition);
+        $property = $reflectionClass->getProperty('id');
+        $property->setAccessible(true);
+        $property->setValue($newDefaultDefinition, null);
+
+        $newData->setDefaultUnitDefinition($newDefaultDefinition);
+
+        foreach ($data->getAdditionalUnitDefinitions() as $unitDefinition) {
+            $newUnitDefinition = clone $unitDefinition;
+
+            $reflectionClass = new \ReflectionClass($newUnitDefinition);
+            $property = $reflectionClass->getProperty('id');
+            $property->setAccessible(true);
+            $property->setValue($newUnitDefinition, null);
+
+            $newUnitDefinition->setProductUnitDefinitions($newData);
+            $newData->addAdditionalUnitDefinition($newUnitDefinition);
+        }
+
+        return $newData;
     }
 
     /**
@@ -306,6 +359,8 @@ class ProductUnitDefinitions extends Data implements
         if ($productUnitDefinitions instanceof ProductUnitDefinitionsInterface) {
             $entityMerger = new EntityMerger($this->getEntityManager());
             $entityMerger->merge($productUnitDefinitions);
+
+            $productUnitDefinitions->setProduct($object);
 
             $this->getEntityManager()->persist($productUnitDefinitions);
             $this->getEntityManager()->flush($productUnitDefinitions);

--- a/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/CoreExtension/ProductQuantityPriceRules.php
+++ b/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/CoreExtension/ProductQuantityPriceRules.php
@@ -16,6 +16,7 @@ use CoreShop\Bundle\ProductQuantityPriceRulesBundle\Event\ProductQuantityPriceRu
 use CoreShop\Bundle\ProductQuantityPriceRulesBundle\Form\Type\ProductQuantityPriceRuleType;
 use CoreShop\Bundle\ResourceBundle\CoreExtension\TempEntityManagerTrait;
 use CoreShop\Bundle\ResourceBundle\Doctrine\ORM\EntityMerger;
+use CoreShop\Component\Pimcore\BCLayer\CustomDataCopyInterface;
 use CoreShop\Component\Pimcore\BCLayer\CustomRecyclingMarshalInterface;
 use CoreShop\Component\ProductQuantityPriceRules\Events;
 use CoreShop\Component\ProductQuantityPriceRules\Model\ProductQuantityPriceRuleInterface;
@@ -23,6 +24,7 @@ use CoreShop\Component\ProductQuantityPriceRules\Model\QuantityRangeInterface;
 use CoreShop\Component\ProductQuantityPriceRules\Model\QuantityRangePriceAwareInterface;
 use CoreShop\Component\ProductQuantityPriceRules\Repository\ProductQuantityPriceRuleRepositoryInterface;
 use CoreShop\Component\Resource\Factory\RepositoryFactoryInterface;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManager;
 use JMS\Serializer\DeserializationContext;
 use JMS\Serializer\SerializationContext;
@@ -34,7 +36,8 @@ use Webmozart\Assert\Assert;
 class ProductQuantityPriceRules extends Data implements
     Data\CustomResourcePersistingInterface,
     Data\CustomVersionMarshalInterface,
-    CustomRecyclingMarshalInterface
+    CustomRecyclingMarshalInterface,
+    CustomDataCopyInterface
 {
     use TempEntityManagerTrait;
 
@@ -109,6 +112,76 @@ class ProductQuantityPriceRules extends Data implements
     public function getDataFromResource($data, $object = null, $params = [])
     {
         return [];
+    }
+
+    public function createDataCopy(Concrete $object, $data)
+    {
+        if (!is_array($data)) {
+            return [];
+        }
+
+        if (!$object instanceof QuantityRangePriceAwareInterface) {
+            return [];
+        }
+
+        $newPriceRules = [];
+
+        foreach ($data as $priceRule) {
+            if (!$priceRule instanceof ProductQuantityPriceRuleInterface) {
+                continue;
+            }
+
+            $newPriceRule = clone $priceRule;
+
+            $reflectionClass = new \ReflectionClass($newPriceRule);
+            $property = $reflectionClass->getProperty('id');
+            $property->setAccessible(true);
+            $property->setValue($newPriceRule, null);
+
+            $property = $reflectionClass->getProperty('product');
+            $property->setAccessible(true);
+            $property->setValue($newPriceRule, null);
+
+            $property = $reflectionClass->getProperty('conditions');
+            $property->setAccessible(true);
+            $property->setValue($newPriceRule, new ArrayCollection());
+
+            $property = $reflectionClass->getProperty('ranges');
+            $property->setAccessible(true);
+            $property->setValue($newPriceRule, new ArrayCollection());
+
+            foreach ($priceRule->getConditions() as $condition) {
+                $newCondition = clone $condition;
+
+                $reflectionClass = new \ReflectionClass($newCondition);
+                $property = $reflectionClass->getProperty('id');
+                $property->setAccessible(true);
+                $property->setValue($newCondition, null);
+
+                $newPriceRule->addCondition($newCondition);
+            }
+
+            foreach ($priceRule->getRanges() as $range) {
+                $newRange = clone $range;
+
+                $reflectionClass = new \ReflectionClass($newRange);
+                $property = $reflectionClass->getProperty('id');
+                $property->setAccessible(true);
+                $property->setValue($newRange, null);
+
+                if ($reflectionClass->hasProperty('unitDefinition')) {
+                    $property = $reflectionClass->getProperty('unitDefinition');
+                    $property->setAccessible(true);
+                    $property->setValue($newRange, null);
+                }
+
+                $newPriceRule->addRange($newRange);
+            }
+
+            $newPriceRules[] = $newPriceRule;
+        }
+
+        return $newPriceRules;
     }
 
     /**

--- a/src/CoreShop/Component/Core/Model/ProductInterface.php
+++ b/src/CoreShop/Component/Core/Model/ProductInterface.php
@@ -20,7 +20,6 @@ use CoreShop\Component\ProductQuantityPriceRules\Model\QuantityRangePriceAwareIn
 use CoreShop\Component\SEO\Model\PimcoreSEOAwareInterface;
 use CoreShop\Component\SEO\Model\SEOImageAwareInterface;
 use CoreShop\Component\SEO\Model\SEOOpenGraphAwareInterface;
-use CoreShop\Component\Store\Model\StoresAwareInterface;
 use CoreShop\Component\Taxation\Model\TaxRuleGroupInterface;
 
 interface ProductInterface extends

--- a/src/CoreShop/Component/Core/Model/ProductStoreValues.php
+++ b/src/CoreShop/Component/Core/Model/ProductStoreValues.php
@@ -130,9 +130,4 @@ class ProductStoreValues extends AbstractResource implements ProductStoreValuesI
     {
         return sprintf('Price: %s (Store: %d)', $this->getPrice(), $this->getStore()->getId());
     }
-
-    public function __clone()
-    {
-        $this->id = null;
-    }
 }

--- a/src/CoreShop/Component/Core/Model/QuantityRange.php
+++ b/src/CoreShop/Component/Core/Model/QuantityRange.php
@@ -116,15 +116,4 @@ class QuantityRange extends BaseQuantityRange implements QuantityRangeInterface
     {
         $this->pseudoPrice = $pseudoPrice;
     }
-
-    public function __clone()
-    {
-        parent::__clone();
-
-        if ($this->unitDefinition === null) {
-            return;
-        }
-
-        $this->unitDefinition = null;
-    }
 }

--- a/src/CoreShop/Component/Core/Product/Cloner/ProductQuantityPriceRulesCloner.php
+++ b/src/CoreShop/Component/Core/Product/Cloner/ProductQuantityPriceRulesCloner.php
@@ -14,164 +14,93 @@ namespace CoreShop\Component\Core\Product\Cloner;
 
 use CoreShop\Component\Core\Model\ProductInterface;
 use CoreShop\Component\Core\Model\QuantityRangeInterface;
+use CoreShop\Component\Pimcore\BCLayer\CustomDataCopyInterface;
 use CoreShop\Component\Product\Model\ProductUnitDefinitionInterface;
-use CoreShop\Component\ProductQuantityPriceRules\Model\ProductQuantityPriceRuleInterface;
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Pimcore\Model\DataObject\Concrete;
 
 class ProductQuantityPriceRulesCloner implements ProductClonerInterface
 {
-    /**
-     * {@inheritDoc}
-     */
-    public function clone(ProductInterface $product, ProductInterface $referenceProduct, bool $resetExistingData = false)
+    protected $unitMatcher;
+
+    public function __construct(UnitMatcherInterface $unitMatcher)
     {
+        $this->unitMatcher = $unitMatcher;
+    }
+
+    public function clone(
+        ProductInterface $product,
+        ProductInterface $referenceProduct,
+        bool $resetExistingData = false
+    ) {
         if ($product->getId() === null) {
-            throw new \Exception(sprintf('cannot clone quantity price rules on a un-stored product (reference product id: %d.', $referenceProduct->getId()));
+            throw new \Exception(
+                sprintf(
+                    'cannot clone quantity price rules on a un-stored product (reference product id: %d.',
+                    $referenceProduct->getId()
+                )
+            );
         }
 
         $quantityPriceRules = $referenceProduct->getQuantityPriceRules();
 
-        if (!is_array($quantityPriceRules)) {
-            return;
+        /**
+         * @var Concrete $referenceProduct
+         * @psalm-var Concrete $referenceProduct
+         */
+        $qprFieldDefinition = $referenceProduct->getClass()->getFieldDefinition('quantityPriceRules');
+
+        if (!$qprFieldDefinition instanceof CustomDataCopyInterface) {
+            throw new \Exception('Field Definition must implement CustomDataCopyInterface');
         }
 
-        $hasQuantityPriceRules = is_array($product->getQuantityPriceRules()) && count($product->getQuantityPriceRules()) > 0;
+        $newQuantityPriceRules = $qprFieldDefinition->createDataCopy($referenceProduct, $quantityPriceRules);
+        $this->reallocateRanges($product, $newQuantityPriceRules, $quantityPriceRules);
 
-        if ($hasQuantityPriceRules === true && $resetExistingData === false) {
-            return;
-        }
-
-        $newQuantityPriceRules = [];
-
-        /** @var ProductQuantityPriceRuleInterface $quantityPriceRule */
-        foreach ($quantityPriceRules as $quantityPriceRule) {
-            $newQuantityPriceRules[] = $this->cloneAndReallocateRangeQuantityUnit($product, $quantityPriceRule);
-        }
-
-        if (count($newQuantityPriceRules) > 0) {
-            $product->setQuantityPriceRules($newQuantityPriceRules);
-        }
+        $product->setQuantityPriceRules($newQuantityPriceRules);
     }
 
-    /**
-     * @param ProductInterface                  $product
-     * @param ProductQuantityPriceRuleInterface $quantityPriceRule
-     *
-     * @return ProductQuantityPriceRuleInterface
-     * @throws \Exception
-     */
-    protected function cloneAndReallocateRangeQuantityUnit(ProductInterface $product, ProductQuantityPriceRuleInterface $quantityPriceRule)
-    {
-        $newQuantityPriceRule = clone $quantityPriceRule;
-
-         //Hack to get rid of the ID
-        $reflectionClass = new \ReflectionClass($newQuantityPriceRule);
-        $property = $reflectionClass->getProperty('id');
-        $property->setAccessible(true);
-        $property->setValue($newQuantityPriceRule, null);
-
-        $property = $reflectionClass->getProperty('product');
-        $property->setAccessible(true);
-        $property->setValue($newQuantityPriceRule, null);
-
-        $property = $reflectionClass->getProperty('conditions');
-        $property->setAccessible(true);
-        $property->setValue($newQuantityPriceRule, new ArrayCollection());
-
-        $property = $reflectionClass->getProperty('ranges');
-        $property->setAccessible(true);
-        $property->setValue($newQuantityPriceRule, new ArrayCollection());
-
-        foreach ($quantityPriceRule->getConditions() as $condition) {
-            $newCondition = clone $condition;
-
-            $reflectionClass = new \ReflectionClass($newCondition);
-            $property = $reflectionClass->getProperty('id');
-            $property->setAccessible(true);
-            $property->setValue($newCondition, null);
-
-            $newQuantityPriceRule->addCondition($newCondition);
+    protected function reallocateRanges(
+        ProductInterface $product,
+        array $newQuantityPriceRules,
+        array $oldQuantityPriceRules
+    ) {
+        if (count($oldQuantityPriceRules) !== count($newQuantityPriceRules)) {
+            throw new \Exception('Count of old an new rules does not match');
         }
 
-        foreach ($quantityPriceRule->getRanges() as $range) {
-            $newRange = clone $range;
+        foreach ($newQuantityPriceRules as $j => $newQuantityPriceRule) {
+            $quantityPriceRule = $oldQuantityPriceRules[$j];
 
-            $reflectionClass = new \ReflectionClass($newRange);
-            $property = $reflectionClass->getProperty('id');
-            $property->setAccessible(true);
-            $property->setValue($newRange, null);
+            $ranges = $newQuantityPriceRule->getRanges();
+            $referenceRanges = $quantityPriceRule->getRanges();
 
-            if ($reflectionClass->hasProperty('unitDefinition')) {
-                $property = $reflectionClass->getProperty('unitDefinition');
-                $property->setAccessible(true);
-                $property->setValue($newRange, null);
-            }
-
-            $newQuantityPriceRule->addRange($newRange);
-        }
-
-        $newQuantityPriceRule->setProduct($product->getId());
-
-        $ranges = $newQuantityPriceRule->getRanges();
-        $referenceRanges = $quantityPriceRule->getRanges();
-
-        if (!$ranges instanceof Collection) {
-            return $newQuantityPriceRule;
-        }
-
-        foreach ($ranges as $index => $range) {
-
-            if (!$range instanceof QuantityRangeInterface) {
+            if (!$ranges instanceof Collection) {
                 continue;
             }
 
-            $referenceRange = null;
-            $allocatedUnitDefinition = null;
+            foreach ($ranges as $index => $range) {
+                if (!$range instanceof QuantityRangeInterface) {
+                    continue;
+                }
 
-            if ($ranges instanceof Collection) {
                 $referenceRange = $referenceRanges->get($index);
-            }
 
-            if ($referenceRange instanceof QuantityRangeInterface && $referenceRange->getUnitDefinition() instanceof ProductUnitDefinitionInterface) {
-                $allocatedUnitDefinition = $this->findMatchingUnitDefinitionByUnitName($product, $referenceRange->getUnitDefinition()->getUnitName());
-            }
+                if ($referenceRange instanceof QuantityRangeInterface &&
+                    $referenceRange->getUnitDefinition() instanceof ProductUnitDefinitionInterface
+                ) {
+                    $allocatedUnitDefinition = $this->unitMatcher->findMatchingUnitDefinitionByUnitName(
+                        $product,
+                        $referenceRange->getUnitDefinition()->getUnitName()
+                    );
 
-            if (!$allocatedUnitDefinition instanceof ProductUnitDefinitionInterface) {
-                continue;
-            }
+                    if (!$allocatedUnitDefinition instanceof ProductUnitDefinitionInterface) {
+                        continue;
+                    }
 
-            $range->setUnitDefinition($allocatedUnitDefinition);
-
-        }
-
-        return $newQuantityPriceRule;
-    }
-
-    /**
-     * @param ProductInterface $product
-     * @param string           $unitName
-     *
-     * @return ProductUnitDefinitionInterface|null
-     */
-    protected function findMatchingUnitDefinitionByUnitName(ProductInterface $product, string $unitName)
-    {
-        if ($product->hasUnitDefinitions() === false) {
-            return null;
-        }
-
-        /** @var ProductUnitDefinitionInterface $unitDefinition */
-        foreach ($product->getUnitDefinitions()->getUnitDefinitions() as $unitDefinition) {
-
-            if (!$unitDefinition instanceof ProductUnitDefinitionInterface) {
-                continue;
-            }
-
-            if ($unitDefinition->getUnitName() === $unitName) {
-                return $unitDefinition;
+                    $range->setUnitDefinition($allocatedUnitDefinition);
+                }
             }
         }
-
-        return null;
     }
 }

--- a/src/CoreShop/Component/Core/Product/Cloner/ProductQuantityPriceRulesCloner.php
+++ b/src/CoreShop/Component/Core/Product/Cloner/ProductQuantityPriceRulesCloner.php
@@ -45,8 +45,8 @@ class ProductQuantityPriceRulesCloner implements ProductClonerInterface
         $quantityPriceRules = $referenceProduct->getQuantityPriceRules();
 
         /**
-         * @var Concrete $referenceProduct
-         * @psalm-var Concrete $referenceProduct
+         * @var Concrete&ProductInterface $referenceProduct
+         * @psalm-var Concrete&ProductInterface $referenceProduct
          */
         $qprFieldDefinition = $referenceProduct->getClass()->getFieldDefinition('quantityPriceRules');
 

--- a/src/CoreShop/Component/Core/Product/Cloner/ProductQuantityPriceRulesCloner.php
+++ b/src/CoreShop/Component/Core/Product/Cloner/ProductQuantityPriceRulesCloner.php
@@ -36,7 +36,7 @@ class ProductQuantityPriceRulesCloner implements ProductClonerInterface
         if ($product->getId() === null) {
             throw new \Exception(
                 sprintf(
-                    'cannot clone quantity price rules on a un-stored product (reference product id: %d.',
+                    'cannot clone quantity price rules on a unsaved product (reference product id: %d.)',
                     $referenceProduct->getId()
                 )
             );

--- a/src/CoreShop/Component/Core/Product/Cloner/ProductUnitDefinitionsCloner.php
+++ b/src/CoreShop/Component/Core/Product/Cloner/ProductUnitDefinitionsCloner.php
@@ -13,6 +13,7 @@
 namespace CoreShop\Component\Core\Product\Cloner;
 
 use CoreShop\Component\Core\Model\ProductInterface;
+use Doctrine\Common\Collections\ArrayCollection;
 
 class ProductUnitDefinitionsCloner implements ProductClonerInterface
 {
@@ -33,11 +34,36 @@ class ProductUnitDefinitionsCloner implements ProductClonerInterface
         $property->setAccessible(true);
         $property->setValue($unitDefinitions, null);
 
-        foreach ($unitDefinitions->getUnitDefinitions() as $unitDefinition) {
-            $reflectionClass = new \ReflectionClass($unitDefinition);
+        $property = $reflectionClass->getProperty('unitDefinitions');
+        $property->setAccessible(true);
+        $property->setValue($unitDefinitions, new ArrayCollection());
+
+        $property = $reflectionClass->getProperty('product');
+        $property->setAccessible(true);
+        $property->setValue($unitDefinitions, null);
+
+        $property = $reflectionClass->getProperty('defaultUnitDefinition');
+        $property->setAccessible(true);
+        $property->setValue($unitDefinitions, null);
+
+        $newDefaultDefinition = clone $referenceProduct->getUnitDefinitions()->getDefaultUnitDefinition();
+        $reflectionClass = new \ReflectionClass($newDefaultDefinition);
+        $property = $reflectionClass->getProperty('id');
+        $property->setAccessible(true);
+        $property->setValue($newDefaultDefinition, null);
+
+        $unitDefinitions->setDefaultUnitDefinition($newDefaultDefinition);
+
+        foreach ($referenceProduct->getUnitDefinitions()->getAdditionalUnitDefinitions() as $unitDefinition) {
+            $newUnitDefinition = clone $unitDefinition;
+
+            $reflectionClass = new \ReflectionClass($newUnitDefinition);
             $property = $reflectionClass->getProperty('id');
             $property->setAccessible(true);
-            $property->setValue($unitDefinition, null);
+            $property->setValue($newUnitDefinition, null);
+
+            $newUnitDefinition->setProductUnitDefinitions($unitDefinitions);
+            $unitDefinitions->addAdditionalUnitDefinition($newUnitDefinition);
         }
 
         $product->setUnitDefinitions($unitDefinitions);

--- a/src/CoreShop/Component/Core/Product/Cloner/ProductUnitDefinitionsCloner.php
+++ b/src/CoreShop/Component/Core/Product/Cloner/ProductUnitDefinitionsCloner.php
@@ -13,59 +13,86 @@
 namespace CoreShop\Component\Core\Product\Cloner;
 
 use CoreShop\Component\Core\Model\ProductInterface;
-use Doctrine\Common\Collections\ArrayCollection;
+use CoreShop\Component\Core\Model\ProductStoreValuesInterface;
+use CoreShop\Component\Pimcore\BCLayer\CustomDataCopyInterface;
+use Pimcore\Model\DataObject\Concrete;
 
 class ProductUnitDefinitionsCloner implements ProductClonerInterface
 {
-    /**
-     * {@inheritDoc}
-     */
-    public function clone(ProductInterface $product, ProductInterface $referenceProduct, bool $resetExistingData = false)
+    protected $unitMatcher;
+
+    public function __construct(UnitMatcherInterface $unitMatcher)
     {
+        $this->unitMatcher = $unitMatcher;
+    }
+
+    public function clone(
+        ProductInterface $product,
+        ProductInterface $referenceProduct,
+        bool $resetExistingData = false
+    ) {
         if ($product->hasUnitDefinitions() === true && $resetExistingData === false) {
             return;
         }
 
-        $unitDefinitions = clone $referenceProduct->getUnitDefinitions();
+        /**
+         * @var Concrete $referenceProduct
+         * @psalm-var Concrete $referenceProduct
+         */
+        $unitDefinitionsFieldDefinition = $referenceProduct->getClass()->getFieldDefinition('unitDefinitions');
 
-        //Hack to get rid of the ID
-        $reflectionClass = new \ReflectionClass($unitDefinitions);
-        $property = $reflectionClass->getProperty('id');
-        $property->setAccessible(true);
-        $property->setValue($unitDefinitions, null);
-
-        $property = $reflectionClass->getProperty('unitDefinitions');
-        $property->setAccessible(true);
-        $property->setValue($unitDefinitions, new ArrayCollection());
-
-        $property = $reflectionClass->getProperty('product');
-        $property->setAccessible(true);
-        $property->setValue($unitDefinitions, null);
-
-        $property = $reflectionClass->getProperty('defaultUnitDefinition');
-        $property->setAccessible(true);
-        $property->setValue($unitDefinitions, null);
-
-        $newDefaultDefinition = clone $referenceProduct->getUnitDefinitions()->getDefaultUnitDefinition();
-        $reflectionClass = new \ReflectionClass($newDefaultDefinition);
-        $property = $reflectionClass->getProperty('id');
-        $property->setAccessible(true);
-        $property->setValue($newDefaultDefinition, null);
-
-        $unitDefinitions->setDefaultUnitDefinition($newDefaultDefinition);
-
-        foreach ($referenceProduct->getUnitDefinitions()->getAdditionalUnitDefinitions() as $unitDefinition) {
-            $newUnitDefinition = clone $unitDefinition;
-
-            $reflectionClass = new \ReflectionClass($newUnitDefinition);
-            $property = $reflectionClass->getProperty('id');
-            $property->setAccessible(true);
-            $property->setValue($newUnitDefinition, null);
-
-            $newUnitDefinition->setProductUnitDefinitions($unitDefinitions);
-            $unitDefinitions->addAdditionalUnitDefinition($newUnitDefinition);
+        if (!$unitDefinitionsFieldDefinition instanceof CustomDataCopyInterface) {
+            throw new \Exception('Field Definition must implement CustomDataCopyInterface');
         }
 
+        $storeValuesFieldDefinition = $referenceProduct->getClass()->getFieldDefinition('storeValues');
+
+        if (!$storeValuesFieldDefinition instanceof CustomDataCopyInterface) {
+            throw new \Exception('Field Definition must implement CustomDataCopyInterface');
+        }
+
+        $unitDefinitions = $unitDefinitionsFieldDefinition->createDataCopy(
+            $referenceProduct,
+            $referenceProduct->getUnitDefinitions()
+        );
+
+        $storeValues = $storeValuesFieldDefinition->createDataCopy(
+            $referenceProduct,
+            $referenceProduct->getStoreValues()
+        );
+
         $product->setUnitDefinitions($unitDefinitions);
+        $product->setStoreValues($storeValues);
+
+        /**
+         * @var ProductStoreValuesInterface $storeValue
+         */
+        foreach ($referenceProduct->getStoreValues() as $storeValue) {
+            $newStoreValue = $product->getStoreValues($storeValue->getStore());
+
+            if (!$newStoreValue) {
+                continue;
+            }
+
+            foreach ($storeValue->getProductUnitDefinitionPrices() as $definitionPrice) {
+                $newUnitDefinition = $this->unitMatcher->findMatchingUnitDefinitionByUnitName($product, $definitionPrice->getUnitDefinition()->getUnitName());
+
+                if (!$newUnitDefinition) {
+                    continue;
+                }
+
+                $newDefinitionPrice = clone $definitionPrice;
+
+                $reflectionClass = new \ReflectionClass($newDefinitionPrice);
+                $property = $reflectionClass->getProperty('id');
+                $property->setAccessible(true);
+                $property->setValue($newDefinitionPrice, null);
+
+                $newDefinitionPrice->setProductStoreValues($newStoreValue);
+                $newDefinitionPrice->setUnitDefinition($newUnitDefinition);
+
+                $newStoreValue->addProductUnitDefinitionPrice($newDefinitionPrice);
+            }
+        }
     }
 }

--- a/src/CoreShop/Component/Core/Product/Cloner/ProductUnitDefinitionsCloner.php
+++ b/src/CoreShop/Component/Core/Product/Cloner/ProductUnitDefinitionsCloner.php
@@ -36,8 +36,8 @@ class ProductUnitDefinitionsCloner implements ProductClonerInterface
         }
 
         /**
-         * @var Concrete $referenceProduct
-         * @psalm-var Concrete $referenceProduct
+         * @var Concrete&ProductInterface $referenceProduct
+         * @psalm-var Concrete&ProductInterface $referenceProduct
          */
         $unitDefinitionsFieldDefinition = $referenceProduct->getClass()->getFieldDefinition('unitDefinitions');
 

--- a/src/CoreShop/Component/Core/Product/Cloner/UnitMatcher.php
+++ b/src/CoreShop/Component/Core/Product/Cloner/UnitMatcher.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.org)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Component\Core\Product\Cloner;
+
+use CoreShop\Component\Core\Model\ProductInterface;
+use CoreShop\Component\Core\Model\QuantityRangeInterface;
+use CoreShop\Component\Pimcore\BCLayer\CustomDataCopyInterface;
+use CoreShop\Component\Product\Model\ProductUnitDefinitionInterface;
+use CoreShop\Component\ProductQuantityPriceRules\Model\ProductQuantityPriceRuleInterface;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Pimcore\Model\DataObject\Concrete;
+
+class UnitMatcher implements UnitMatcherInterface
+{
+    public function findMatchingUnitDefinitionByUnitName(ProductInterface $product, string $unitName)
+    {
+        if ($product->hasUnitDefinitions() === false) {
+            return null;
+        }
+
+        /** @var ProductUnitDefinitionInterface $unitDefinition */
+        foreach ($product->getUnitDefinitions()->getUnitDefinitions() as $unitDefinition) {
+
+            if (!$unitDefinition instanceof ProductUnitDefinitionInterface) {
+                continue;
+            }
+
+            if ($unitDefinition->getUnitName() === $unitName) {
+                return $unitDefinition;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/CoreShop/Component/Core/Product/Cloner/UnitMatcherInterface.php
+++ b/src/CoreShop/Component/Core/Product/Cloner/UnitMatcherInterface.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.org)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Component\Core\Product\Cloner;
+
+use CoreShop\Component\Core\Model\ProductInterface;
+
+interface UnitMatcherInterface
+{
+    public function findMatchingUnitDefinitionByUnitName(ProductInterface $product, string $unitName);
+}

--- a/src/CoreShop/Component/Pimcore/BCLayer/CustomDataCopyInterface.php
+++ b/src/CoreShop/Component/Pimcore/BCLayer/CustomDataCopyInterface.php
@@ -12,7 +12,7 @@
 
 namespace CoreShop\Component\Pimcore\BCLayer;
 
-if (interface_exists(\Pimcore\Model\DataObject\ClassDefinition\Data\CustomVersionMarshalInterface::class)) {
+if (interface_exists(\Pimcore\Model\DataObject\ClassDefinition\Data\CustomDataCopyInterface::class)) {
     interface CustomDataCopyInterface extends \Pimcore\Model\DataObject\ClassDefinition\Data\CustomDataCopyInterface
     {
     }

--- a/src/CoreShop/Component/Pimcore/BCLayer/CustomDataCopyInterface.php
+++ b/src/CoreShop/Component/Pimcore/BCLayer/CustomDataCopyInterface.php
@@ -12,12 +12,18 @@
 
 namespace CoreShop\Component\Pimcore\BCLayer;
 
+use Pimcore\Model\DataObject\Concrete;
+
 if (interface_exists(\Pimcore\Model\DataObject\ClassDefinition\Data\CustomDataCopyInterface::class)) {
     interface CustomDataCopyInterface extends \Pimcore\Model\DataObject\ClassDefinition\Data\CustomDataCopyInterface
     {
     }
 } else {
+    /**
+     * @method mixed createDataCopy(Concrete $object, $data)
+     */
     interface CustomDataCopyInterface
     {
+
     }
 }

--- a/src/CoreShop/Component/Pimcore/BCLayer/CustomDataCopyInterface.php
+++ b/src/CoreShop/Component/Pimcore/BCLayer/CustomDataCopyInterface.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.org)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Component\Pimcore\BCLayer;
+
+if (interface_exists(\Pimcore\Model\DataObject\ClassDefinition\Data\CustomVersionMarshalInterface::class)) {
+    interface CustomDataCopyInterface extends \Pimcore\Model\DataObject\ClassDefinition\Data\CustomDataCopyInterface
+    {
+    }
+} else {
+    interface CustomDataCopyInterface
+    {
+    }
+}

--- a/src/CoreShop/Component/Product/Model/ProductSpecificPriceRule.php
+++ b/src/CoreShop/Component/Product/Model/ProductSpecificPriceRule.php
@@ -72,9 +72,4 @@ class ProductSpecificPriceRule extends AbstractPriceRule implements ProductSpeci
     {
         return new ProductSpecificPriceRuleTranslation();
     }
-
-    public function __clone()
-    {
-        $this->id = null;
-    }
 }

--- a/src/CoreShop/Component/Product/Model/ProductUnitDefinition.php
+++ b/src/CoreShop/Component/Product/Model/ProductUnitDefinition.php
@@ -141,13 +141,4 @@ class ProductUnitDefinition extends AbstractResource implements ProductUnitDefin
     {
         return sprintf('%s, (Conversion Rate: %s)', $this->getUnitName(), $this->getConversionRate());
     }
-//
-//    public function __clone()
-//    {
-//        if ($this->id === null) {
-//            return;
-//        }
-//
-//        $this->id = null;
-//    }
 }

--- a/src/CoreShop/Component/Product/Model/ProductUnitDefinitions.php
+++ b/src/CoreShop/Component/Product/Model/ProductUnitDefinitions.php
@@ -218,30 +218,4 @@ class ProductUnitDefinitions extends AbstractResource implements ProductUnitDefi
 
         return $additionalDefinitionsSorted;
     }
-
-    public function __clone()
-    {
-        if ($this->id === null) {
-            return;
-        }
-
-        $newDefaultUnitDefinition = clone $this->getDefaultUnitDefinition();
-        $newDefaultUnitDefinition->setProductUnitDefinitions($this);
-
-        $additionalUnits = $this->getAdditionalUnitDefinitions();
-
-        $this->id = null;
-        $this->unitDefinitions =  new ArrayCollection();
-        $this->defaultUnitDefinition = null;
-
-        $this->setDefaultUnitDefinition($newDefaultUnitDefinition);
-
-        if ($additionalUnits instanceof Collection) {
-            foreach ($additionalUnits as $additionalUnit) {
-                $newAdditionalDefinition = clone $additionalUnit;
-                $newAdditionalDefinition->setProductUnitDefinitions($this);
-                $this->addUnitDefinition($newAdditionalDefinition);
-            }
-        }
-    }
 }

--- a/src/CoreShop/Component/ProductQuantityPriceRules/Model/ProductQuantityPriceRule.php
+++ b/src/CoreShop/Component/ProductQuantityPriceRules/Model/ProductQuantityPriceRule.php
@@ -27,7 +27,7 @@ class ProductQuantityPriceRule implements ProductQuantityPriceRuleInterface
     use ToggleableTrait;
 
     /**
-     * @var int|null
+     * @var int
      */
     protected $id;
 
@@ -280,37 +280,5 @@ class ProductQuantityPriceRule implements ProductQuantityPriceRuleInterface
     public function __toString()
     {
         return sprintf('%s (%s)', $this->getName(), $this->getId());
-    }
-
-    public function __clone()
-    {
-        if ($this->id === null) {
-            return;
-        }
-
-        $conditions = $this->getConditions();
-        $ranges = $this->getRanges();
-
-        $this->id = null;
-        $this->product = null;
-        $this->conditions = new ArrayCollection();
-        $this->ranges = new ArrayCollection();
-
-        if ($conditions instanceof Collection) {
-            /** @var ConditionInterface $condition */
-            foreach ($conditions as $condition) {
-                $newCondition = clone $condition;
-                $this->addCondition($newCondition);
-            }
-        }
-
-        if ($ranges instanceof Collection) {
-            /** @var QuantityRangeInterface $range */
-            foreach ($ranges as $range) {
-                $newRange = clone $range;
-                $newRange->setRule($this);
-                $this->addRange($newRange);
-            }
-        }
     }
 }

--- a/src/CoreShop/Component/ProductQuantityPriceRules/Model/QuantityRange.php
+++ b/src/CoreShop/Component/ProductQuantityPriceRules/Model/QuantityRange.php
@@ -149,14 +149,4 @@ class QuantityRange extends AbstractResource implements QuantityRangeInterface
     {
         $this->rule = $rule;
     }
-
-    public function __clone()
-    {
-        if ($this->id === null) {
-            return;
-        }
-
-        $this->rule = null;
-        $this->id = null;
-    }
 }

--- a/src/CoreShop/Component/Resource/Pimcore/Model/PimcoreModelInterface.php
+++ b/src/CoreShop/Component/Resource/Pimcore/Model/PimcoreModelInterface.php
@@ -13,6 +13,7 @@
 namespace CoreShop\Component\Resource\Pimcore\Model;
 
 use CoreShop\Component\Resource\Model\ResourceInterface;
+use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\Element\ElementInterface;
 
 interface PimcoreModelInterface extends ResourceInterface, ElementInterface
@@ -61,4 +62,9 @@ interface PimcoreModelInterface extends ResourceInterface, ElementInterface
      * @return mixed
      */
     public function delete();
+
+    /**
+     * @return ClassDefinition
+     */
+    public function getClass();
 }

--- a/src/CoreShop/Component/Rule/Model/Condition.php
+++ b/src/CoreShop/Component/Rule/Model/Condition.php
@@ -97,13 +97,4 @@ class Condition implements ConditionInterface
 
         return $this;
     }
-
-//    public function __clone()
-//    {
-//        if ($this->id === null) {
-//            return;
-//        }
-//
-//        $this->id = null;
-//    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? |no
| Fixed tickets | #1765

Don't use `__clone` anymore, as it is way too unpredictable in some matters. Use a `CustomCopy` from Pimcore and manually clone and reset data. This also doesn't completely clone all the data, since we have some dependencies from store-values to Product Unit Definitions. But this is something we cannot solve this way and therefore is simply just not supported. This also fixes copying of Specific Product Price Rules and Quantity Price Rules.

<!-
