### PR TITLE
[Store select / multiselect] Support getOptions() via option provider

### DIFF
--- a/src/CoreShop/Bundle/StoreBundle/CoreExtension/Store.php
+++ b/src/CoreShop/Bundle/StoreBundle/CoreExtension/Store.php
@@ -51,6 +51,6 @@ class Store extends Select
 
     public function getOptionsProviderClass()
     {
-        return StoreOptionProvider::class;
+        return '@'.StoreOptionProvider::class;
     }
 }

--- a/src/CoreShop/Bundle/StoreBundle/CoreExtension/Store.php
+++ b/src/CoreShop/Bundle/StoreBundle/CoreExtension/Store.php
@@ -48,4 +48,9 @@ class Store extends Select
     {
         return true;
     }
+
+    public function getOptionsProviderClass()
+    {
+        return StoreOptionProvider::class;
+    }
 }

--- a/src/CoreShop/Bundle/StoreBundle/CoreExtension/StoreMultiselect.php
+++ b/src/CoreShop/Bundle/StoreBundle/CoreExtension/StoreMultiselect.php
@@ -27,4 +27,9 @@ class StoreMultiselect extends Multiselect
      * @var string
      */
     public $fieldtype = 'coreShopStoreMultiselect';
+
+    public function getOptionsProviderClass()
+    {
+        return '@'.StoreOptionProvider::class;
+    }
 }

--- a/src/CoreShop/Bundle/StoreBundle/CoreExtension/StoreOptionProvider.php
+++ b/src/CoreShop/Bundle/StoreBundle/CoreExtension/StoreOptionProvider.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.org)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Bundle\StoreBundle\CoreExtension;
+
+use CoreShop\Bundle\StoreBundle\Doctrine\ORM\StoreRepository;
+use Pimcore\Model\DataObject\ClassDefinition\Data;
+use Pimcore\Model\DataObject\ClassDefinition\DynamicOptionsProvider\SelectOptionsProviderInterface;
+
+class StoreOptionProvider implements SelectOptionsProviderInterface
+{
+    /** @var StoreRepository */
+    private $repository;
+
+    /**
+     * @param StoreRepository $repository
+     */
+    public function __construct(StoreRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * @param array $context
+     * @param Data $fieldDefinition
+     * @return array
+     */
+    public function getOptions($context, $fieldDefinition)
+    {
+        $options = [];
+        $stores = $this->repository->getAll();
+        foreach($stores as $store) {
+            $options[] = [
+                'key' => $store->getName(),
+                'value' => $store->getId()
+            ];
+        }
+
+        return $options;
+    }
+
+    /**
+     * Returns the value which is defined in the 'Default value' field
+     * @param array $context
+     * @param Data $fieldDefinition
+     * @return null
+     */
+    public function getDefaultValue($context, $fieldDefinition)
+    {
+        return null;
+    }
+
+    /**
+     * @param array $context
+     * @param Data $fieldDefinition
+     * @return bool
+     */
+    public function hasStaticOptions($context, $fieldDefinition)
+    {
+        return true;
+    }
+}

--- a/src/CoreShop/Bundle/StoreBundle/CoreExtension/StoreOptionProvider.php
+++ b/src/CoreShop/Bundle/StoreBundle/CoreExtension/StoreOptionProvider.php
@@ -18,15 +18,8 @@ use Pimcore\Model\DataObject\ClassDefinition\DynamicOptionsProvider\SelectOption
 
 class StoreOptionProvider implements SelectOptionsProviderInterface
 {
-    /** @var StoreRepository */
-    private $repository;
-
-    /**
-     * @param StoreRepository $repository
-     */
-    public function __construct(StoreRepository $repository)
+    public function __construct(private StoreRepository $repository)
     {
-        $this->repository = $repository;
     }
 
     /**

--- a/src/CoreShop/Bundle/StoreBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/StoreBundle/Resources/config/services.yml
@@ -49,3 +49,7 @@ services:
             - '@coreshop.repository.store'
         tags:
             - { name: coreshop.context.store.request_based.resolver, priority: 100 }
+
+    CoreShop\Bundle\StoreBundle\CoreExtension\StoreOptionProvider:
+        arguments:
+            - '@coreshop.repository.store'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

Currently it is not possible to fetch the available options for store select / multiselect field types as you would normally do for Pimcore default select / multiselect fields via 
```php
$object->getClass()->getFieldDefinition('store')->getOptions(); // returns always null
DataObject\Service::getOptionsForSelectField($object, "store"); // also returns always null
```
This is currently always `null` as the logic for fetching the available options is only implemented in JS, see https://github.com/coreshop/CoreShop/blob/99bbb0c927d2cc57ca81bd3b03dbd5805a6172c8/src/CoreShop/Bundle/StoreBundle/Resources/public/pimcore/js/coreExtension/tags/coreShopStoreMultiselect.js#L17 and https://github.com/coreshop/CoreShop/blob/99bbb0c927d2cc57ca81bd3b03dbd5805a6172c8/src/CoreShop/Bundle/ResourceBundle/Resources/public/pimcore/js/coreExtension/tags/multiselect.js#L23

It works currently only because Pimcore does not check if the set option is actually available in `Select::checkValidity()` / `Multiselect::checkValidity()` in https://github.com/pimcore/pimcore/blob/d0b5dc0d78392ee2d4012d228214901fd1080076/models/DataObject/ClassDefinition/Data/Select.php#L373
But this may change and nevertheless it is a good idea to support the same logic like Pimcore's default field types do.