### PR TITLE
[ResourceBundle] allow easier custom resources

### DIFF
--- a/src/CoreShop/Bundle/ResourceBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/ResourceBundle/DependencyInjection/Configuration.php
@@ -16,7 +16,9 @@ namespace CoreShop\Bundle\ResourceBundle\DependencyInjection;
 
 use CoreShop\Bundle\ResourceBundle\Controller\ResourceController;
 use CoreShop\Bundle\ResourceBundle\CoreShopResourceBundle;
+use CoreShop\Bundle\ResourceBundle\Pimcore\PimcoreRepository;
 use CoreShop\Component\Resource\Factory\Factory;
+use CoreShop\Component\Resource\Factory\PimcoreFactory;
 use CoreShop\Component\Resource\Translation\Provider\TranslationLocaleProviderInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -72,6 +74,33 @@ final class Configuration implements ConfigurationInterface
                                             ->scalarNode('controller')->defaultValue(ResourceController::class)->cannotBeEmpty()->end()
                                             ->scalarNode('repository')->cannotBeEmpty()->end()
                                             ->scalarNode('factory')->defaultValue(Factory::class)->end()
+                                        ->end()
+                                    ->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+                ->arrayNode('pimcore')
+                    ->useAttributeAsKey('name')
+                        ->arrayPrototype()
+                            ->children()
+                                ->variableNode('options')->end()
+                                ->arrayNode('path')
+                                    ->useAttributeAsKey('name')
+                                    ->prototype('scalar')->end()
+                                ->end()
+                                ->arrayNode('classes')
+                                    ->children()
+                                        ->scalarNode('model')->isRequired()->cannotBeEmpty()->end()
+                                        ->scalarNode('interface')->cannotBeEmpty()->end()
+                                        ->scalarNode('repository')->cannotBeEmpty()->defaultValue(PimcoreRepository::class)->end()
+                                        ->scalarNode('factory')->defaultValue(PimcoreFactory::class)->end()
+                                        ->scalarNode('install_file')->end()
+                                        ->scalarNode('type')->defaultValue(CoreShopResourceBundle::PIMCORE_MODEL_TYPE_OBJECT)->end()
+                                        ->arrayNode('pimcore_controller')
+                                            ->useAttributeAsKey('name')
+                                            ->prototype('scalar')->end()
                                         ->end()
                                     ->end()
                                 ->end()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  | yes/
| BC breaks?    | no
| Deprecations? |no

Allows you to define custom resources without the need of a DI Extension like:

**Pimcore Models**

```
core_shop_resource:
    pimcore:
        app.test:
            path:
                test: test
            classes:
                model: Pimcore\Model\DataObject\Test
                interface: App\Model\TestInterface
```

**Doctrine Entities** 

```
core_shop_resource:
    resource:
        app.doctrine_test:
            classes:
                model: App\Entity\DoctrineTest
                interface: App\Model\DoctrineTestInterface
                repository: CoreShop\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository
```

You than have access to services like factory or repository like:

```
$container->get('app.repository.test');
$container->get('app.repository.doctrine_test');

$container->get('app.factory.test');
$container->get('app.factory.doctrine_test');
```