### PR TITLE
[Cart] fix existing cart initalization on customer login

### DIFF
--- a/src/CoreShop/Bundle/OrderBundle/Pimcore/Repository/CartRepository.php
+++ b/src/CoreShop/Bundle/OrderBundle/Pimcore/Repository/CartRepository.php
@@ -41,6 +41,7 @@ class CartRepository extends PimcoreRepository implements CartRepositoryInterfac
     {
         $list = $this->getList();
         $list->setCondition('customer__id = ? AND name = ? AND order__id is null', [$customer->getId(), $name]);
+        $list->setLimit(1);
         $list->load();
 
         $objects = $list->getObjects();
@@ -58,6 +59,7 @@ class CartRepository extends PimcoreRepository implements CartRepositoryInterfac
         $list->setCondition('customer__id = ? AND store = ? AND order__id is null ', [$customer->getId(), $store->getId()]);
         $list->setOrderKey('o_creationDate');
         $list->setOrder('DESC');
+        $list->setLimit(1);
         $list->load();
 
         $objects = $list->getObjects();
@@ -73,6 +75,7 @@ class CartRepository extends PimcoreRepository implements CartRepositoryInterfac
     {
         $list = $this->getList();
         $list->setCondition('o_id = ? AND order__id is null ', [$id]);
+        $list->setLimit(1);
         $list->load();
 
         $objects = $list->getObjects();

--- a/src/CoreShop/Bundle/OrderBundle/Pimcore/Repository/CartRepository.php
+++ b/src/CoreShop/Bundle/OrderBundle/Pimcore/Repository/CartRepository.php
@@ -37,22 +37,6 @@ class CartRepository extends PimcoreRepository implements CartRepositoryInterfac
         return $carts;
     }
 
-    public function findNamedForCustomer(CustomerInterface $customer, $name): ?OrderInterface
-    {
-        $list = $this->getList();
-        $list->setCondition('customer__id = ? AND name = ? AND order__id is null', [$customer->getId(), $name]);
-        $list->setLimit(1);
-        $list->load();
-
-        $objects = $list->getObjects();
-
-        if (count($objects) === 1 && $objects[0] instanceof OrderInterface) {
-            return $objects[0];
-        }
-
-        return null;
-    }
-
     public function findLatestByStoreAndCustomer(StoreInterface $store, CustomerInterface $customer): ?OrderInterface
     {
         $list = $this->getList();
@@ -75,7 +59,6 @@ class CartRepository extends PimcoreRepository implements CartRepositoryInterfac
     {
         $list = $this->getList();
         $list->setCondition('o_id = ? AND order__id is null ', [$id]);
-        $list->setLimit(1);
         $list->load();
 
         $objects = $list->getObjects();

--- a/src/CoreShop/Component/Order/Repository/CartRepositoryInterface.php
+++ b/src/CoreShop/Component/Order/Repository/CartRepositoryInterface.php
@@ -26,11 +26,6 @@ interface CartRepositoryInterface extends PimcoreRepositoryInterface
      */
     public function findForCustomer(CustomerInterface $customer): array;
 
-    /**
-     * @param string            $name
-     */
-    public function findNamedForCustomer(CustomerInterface $customer, $name): ?OrderInterface;
-
     public function findLatestByStoreAndCustomer(StoreInterface $store, CustomerInterface $customer): ?OrderInterface;
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

specially on findLatestByStoreAndCustomer it can happen that more then one cart exists for the customer, when the user has logged in, he has been shown an empty cart. although several carts exist, the last cart should be loaded.