### PR TITLE
fix: make IndexProcess compatible with the interface

### DIFF
--- a/src/CoreShop/Bundle/IndexBundle/ProcessManager/IndexProcess.php
+++ b/src/CoreShop/Bundle/IndexBundle/ProcessManager/IndexProcess.php
@@ -19,7 +19,7 @@ use ProcessManagerBundle\Process\Pimcore;
 
 final class IndexProcess extends Pimcore
 {
-    public function run(ExecutableInterface $executable, array $params = null)
+    public function run(ExecutableInterface $executable, array $params = null): int
     {
         $settings = $executable->getSettings();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A

Currently it throws an exception that the method signature is incompatible.
