### PR TITLE
After renaming formtypes with coreshop[], form elements where not fou…

### DIFF
--- a/src/CoreShop/Bundle/FrontendBundle/Resources/public/static/js/shop.js
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/public/static/js/shop.js
@@ -69,10 +69,10 @@ $(document).ready(function () {
             return;
         }
 
-        var $invoiceAddress = $addressStep.find('select[name="invoiceAddress"]'),
+        var $invoiceAddress = $addressStep.find('select[name="coreshop[invoiceAddress]"]'),
             $invoicePanel = $addressStep.find('.panel-invoice-address'),
             $invoiceField = $addressStep.find('.invoice-address-selector'),
-            $shippingAddress = $addressStep.find('select[name="shippingAddress"]'),
+            $shippingAddress = $addressStep.find('select[name="coreshop[shippingAddress]"]'),
             $shippingPanel = $addressStep.find('.panel-shipping-address'),
             $shippingField = $addressStep.find('.shipping-address-selector'),
             $shippingAddAddressButton = $shippingPanel.parent().find('.card-footer'),
@@ -126,8 +126,8 @@ $(document).ready(function () {
         $useIasS.on('change', function () {
             if ($(this).is(':checked')) {
                 $shippingField.slideUp();
-                var address = $('select[name=invoiceAddress] option:selected').data('address');
-                var value = $('select[name=invoiceAddress] :selected').val();
+                var address = $('select[name=coreshop[invoiceAddress]] option:selected').data('address');
+                var value = $('select[name=coreshop[invoiceAddress]] :selected').val();
 
                 if (address) {
                     $shippingAddress.val(value).trigger('change');
@@ -171,3 +171,4 @@ $(document).ready(function () {
     };
 
 }(window.shop = window.shop || {}, jQuery));
+


### PR DESCRIPTION
…nd by javascript

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

Fixes renaming from commit
https://github.com/coreshop/CoreShop/commit/8ae0a5f65a6e014daf2e64baa51e69f75da64524

in shop.js

----
German description

Hier werden die Form Input anders benannt:
https://github.com/coreshop/CoreShop/commit/8ae0a5f65a6e014daf2e64baa51e69f75da64524

$form = $this->formFactory->createNamed('coreshop', AddressType::class, $cart, $options);

Damit heißen die nachher auf der Seite z.B. nicht mehr 
 
<select id="coreshop_invoiceAddress" name="invoiceAddress" required="required" class="form-control form-control">
 
sondern 
 
<select id="coreshop_invoiceAddress" name="coreshop[invoiceAddress]" required="required" class="form-control form-control">
 
und werden damit nicht mehr von Javascript in der shop.js gefunden
 
https://github.com/coreshop/CoreShop/blob/264326799dff0a0e38a0611251a7355acf1ba08d/src/CoreShop/Bundle/FrontendBundle/Resources/public/static/js/shop.js#L72

var $invoiceAddress = $addressStep.find('select[name="invoiceAddress"]'),

