### PR TITLE
fixes #1699 cart context returns latest cart even if multiple found

### DIFF
--- a/src/CoreShop/Bundle/OrderBundle/Pimcore/Repository/CartRepository.php
+++ b/src/CoreShop/Bundle/OrderBundle/Pimcore/Repository/CartRepository.php
@@ -43,12 +43,11 @@ class CartRepository extends PimcoreRepository implements CartRepositoryInterfac
         $list->setCondition('customer__id = ? AND store = ? AND order__id is null ', [$customer->getId(), $store->getId()]);
         $list->setOrderKey('o_creationDate');
         $list->setOrder('DESC');
-        $list->setLimit(1);
         $list->load();
 
         $objects = $list->getObjects();
 
-        if (count($objects) === 1 && $objects[0] instanceof OrderInterface) {
+        if (count($objects) > 0 && $objects[0] instanceof OrderInterface) {
             return $objects[0];
         }
 

--- a/src/CoreShop/Bundle/OrderBundle/Pimcore/Repository/OrderRepository.php
+++ b/src/CoreShop/Bundle/OrderBundle/Pimcore/Repository/OrderRepository.php
@@ -65,7 +65,7 @@ class OrderRepository extends PimcoreRepository implements OrderRepositoryInterf
 
         $objects = $list->getObjects();
 
-        if (count($objects) === 1 && $objects[0] instanceof OrderInterface) {
+        if (count($objects) > 0 && $objects[0] instanceof OrderInterface) {
             return $objects[0];
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1699 (partial)