### PR TITLE
Allow null as Parameter

### DIFF
--- a/src/CoreShop/Bundle/OrderBundle/Pimcore/Repository/OrderRepository.php
+++ b/src/CoreShop/Bundle/OrderBundle/Pimcore/Repository/OrderRepository.php
@@ -40,7 +40,7 @@ class OrderRepository extends PimcoreRepository implements OrderRepositoryInterf
         return $carts;
     }
 
-    public function findByCartId(int $id): ?OrderInterface
+    public function findByCartId(?int $id): ?OrderInterface
     {
         $list = $this->getList();
         $list->setCondition('o_id = ? AND saleState = ? ', [$id, OrderSaleStates::STATE_CART]);

--- a/src/CoreShop/Component/Order/Repository/OrderRepositoryInterface.php
+++ b/src/CoreShop/Component/Order/Repository/OrderRepositoryInterface.php
@@ -23,7 +23,7 @@ interface OrderRepositoryInterface extends PimcoreRepositoryInterface
 {
     public function findCartByCustomer(CustomerInterface $customer): array;
 
-    public function findByCartId(int $id): ?OrderInterface;
+    public function findByCartId(?int $id): ?OrderInterface;
 
     public function findLatestCartByStoreAndCustomer(StoreInterface $store, CustomerInterface $customer): ?OrderInterface;
 

--- a/src/CoreShop/Component/Product/Model/ProductUnitDefinitions.php
+++ b/src/CoreShop/Component/Product/Model/ProductUnitDefinitions.php
@@ -113,7 +113,7 @@ class ProductUnitDefinitions extends AbstractResource implements ProductUnitDefi
         return $this->unitDefinitions;
     }
 
-    public function getUnitDefinition(string $identifier)
+    public function getUnitDefinition(?string $identifier)
     {
         $result = null;
 

--- a/src/CoreShop/Component/Product/Model/ProductUnitDefinitionsInterface.php
+++ b/src/CoreShop/Component/Product/Model/ProductUnitDefinitionsInterface.php
@@ -50,7 +50,7 @@ interface ProductUnitDefinitionsInterface extends ResourceInterface
     /**
      * @return ProductUnitDefinitionInterface|null
      */
-    public function getUnitDefinition(string $identifier);
+    public function getUnitDefinition(?string $identifier);
 
     public function addAdditionalUnitDefinition(ProductUnitDefinitionInterface $unitDefinition);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Allow null as parameter, because that is what happens if you access the shop without an existing cart or if you try to add a new product unit definition.