### PR TITLE
[CoreBundle] Fix fetch of `checkout_finisher` url from request

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Checkout/Step/SummaryCheckoutStep.php
+++ b/src/CoreShop/Bundle/CoreBundle/Checkout/Step/SummaryCheckoutStep.php
@@ -57,7 +57,7 @@ class SummaryCheckoutStep implements CheckoutStepInterface, RedirectCheckoutStep
      */
     public function getResponse(CartInterface $cart, Request $request)
     {
-        $checkoutFinisherUrl = $request->get('checkout_finisher');
+        $checkoutFinisherUrl = $request->get('coreshop')['checkout_finisher'] ?? null;
 
         return new RedirectResponse($checkoutFinisherUrl);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

Followup https://github.com/coreshop/CoreShop/pull/1807#issuecomment-989913502

It should fix the Behat UI failed test of #1812

Instead of taking the value from request we could get the value from the extra data of the form, let me know WDYT @dpfaffenbauer