### PR TITLE
fix: generate the correct menu route

### DIFF
--- a/src/CoreShop/Bundle/IndexBundle/EventListener/AdminJavascriptListener.php
+++ b/src/CoreShop/Bundle/IndexBundle/EventListener/AdminJavascriptListener.php
@@ -35,7 +35,7 @@ final class AdminJavascriptListener implements EventSubscriberInterface
     public function getAdminJavascript(PathsEvent $event): void
     {
         $event->setPaths(array_merge($event->getPaths(), [
-            $this->router->generate('coreshop_menu', ['type' => 'coreshop.main']),
+            $this->router->generate('coreshop_menu', ['type' => 'coreshop.index']),
         ]));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1809 

This change fixes the generation of the wrong menu route (`coreshop.index` instead of `coreshop.main`).