### PR TITLE
[CoreBundle] Add submit buttons in SummaryType and generate urls in SummaryCheckoutStep

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Form/Type/Checkout/SummaryType.php
+++ b/src/CoreShop/Bundle/CoreBundle/Form/Type/Checkout/SummaryType.php
@@ -16,6 +16,7 @@ namespace CoreShop\Bundle\CoreBundle\Form\Type\Checkout;
 
 use CoreShop\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -29,6 +30,12 @@ final class SummaryType extends AbstractResourceType
                 'constraints' => [new NotBlank(['groups' => $this->validationGroups])],
                 'label' => 'coreshop.ui.accept_terms',
                 'mapped' => false,
+            ])
+            ->add('submitQuote', SubmitType::class, [
+                'label' => 'coreshop.ui.quote',
+            ])
+            ->add('submitOrder', SubmitType::class, [
+                'label' => 'coreshop.ui.buy',
             ]);
     }
 

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services/checkout.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services/checkout.yml
@@ -43,6 +43,7 @@ services:
     CoreShop\Bundle\CoreBundle\Checkout\Step\SummaryCheckoutStep:
         arguments:
             - '@form.factory'
+            - '@router'
 
     # Forms
     CoreShop\Bundle\CoreBundle\Form\Type\Checkout\AddressType:

--- a/src/CoreShop/Bundle/FrontendBundle/Resources/views/Checkout/steps/summary.html.twig
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/views/Checkout/steps/summary.html.twig
@@ -20,25 +20,10 @@
 
         <div class="row">
             <div class="col-12 col-sm-1 offset-sm-10">
-                <button
-                        type="submit"
-                        name="coreshop[checkout_finisher]"
-                        value="{{ path('coreshop_cart_create_qoute') }}"
-                        class="btn btn-success w-100"
-                        {{  coreshop_test_html_attribute('submit-quote') }}
-                >
-                    {{ 'coreshop.ui.quote'|trans }}
-                </button>
+                {{ form_widget(form.submitQuote, coreshop_test_form_attribute('submit-quote')|coreshop_merge_recursive({attr: {class: 'btn btn-success w-100'}})) }}
             </div>
             <div class="col-12 col-sm-1">
-                <button
-                        type="submit"
-                        name="coreshop[checkout_finisher]"
-                        value="{{ path('coreshop_checkout_do') }}"
-                        class="btn btn-success w-100"
-                        {{ coreshop_test_html_attribute('submit-order') }}>
-                    {{ 'coreshop.ui.buy'|trans }}
-                </button>
+                {{ form_widget(form.submitOrder, coreshop_test_form_attribute('submit-order')|coreshop_merge_recursive({attr: {class: 'btn btn-success w-100'}})) }}
             </div>
         </div>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

Followup https://github.com/coreshop/CoreShop/pull/1814#issuecomment-990802721

With this change submit order & submit quote urls are generated in `getResponse()` function of `SummaryCheckoutStep` instead of value of submit buttons
