### PR TITLE
fixes #1699 cart context returns latest cart even if multiple found

### DIFF
--- a/src/CoreShop/Bundle/OrderBundle/Pimcore/Repository/CartRepository.php
+++ b/src/CoreShop/Bundle/OrderBundle/Pimcore/Repository/CartRepository.php
@@ -70,7 +70,7 @@ class CartRepository extends PimcoreRepository implements CartRepositoryInterfac
 
         $objects = $list->getObjects();
 
-        if (count($objects) === 1 && $objects[0] instanceof CartInterface) {
+        if (count($objects) > 0 && $objects[0] instanceof CartInterface) {
             return $objects[0];
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1699

Here the pull request for CoreShop 2.2
