### PR TITLE
Slow load / save performance of objects due to serialized data

### DIFF
--- a/src/CoreShop/Component/Taxation/Model/TaxRuleGroup.php
+++ b/src/CoreShop/Component/Taxation/Model/TaxRuleGroup.php
@@ -121,4 +121,13 @@ class TaxRuleGroup extends AbstractResource implements TaxRuleGroupInterface
     {
         return $this->taxRules->contains($taxRule);
     }
+
+    public function __sleep()
+    {
+        $blockedVars = ['taxRules'];
+
+        $vars = get_object_vars($this);
+
+        return array_diff(array_keys($vars), $blockedVars);
+    }
 }


### PR DESCRIPTION
We had the problem that saving and loading products took much longe than Pimcore's default objects. Then we wondered why loading objects was faster when we did not use object caching. The reason was the unserialization of the cached object because there was a lot of unnecessary data in the cache item `object_1234`: 
```
O:45:"AppBundle\Model\DataObject\ArticleDbExtension":147:{
...
some other field data
...
taxRule";O:46:"CoreShop\Component\Taxation\Model\TaxRuleGroup":6:{s:5:"�*�id";i:1;s:7:"�*�name";s:13:"standard_rate";s:11:"�*�taxRules";O:43:"Doctrine\Common\Collections\ArrayCollection":1:{s:53:"�Doctrine\Common\Collections\ArrayCollection�elements";a:2:{i:0;O:37:"CoreShop\Component\Core\Model\TaxRule":8:{s:10:"�*�country";O:52:"Proxies\__CG__\CoreShop\Component\Core\Model\Country":17:{s:17:"__isInitialized__";b:1;s:11:"�*�currency";O:53:"Proxies\__CG__\CoreShop\Component\Core\Model\Currency":9:{s:17:"__isInitialized__";b:1;s:12:"�*�countries";O:43:"Doctrine\Common\Collections\ArrayCollection":1:{s:53:"�Doctrine\Common\Collections\ArrayCollection�elements";a:35:{i:0;O:37:"CoreShop\Component\Core\Model\Country":16:{s:11:"�*�currency";r:907;s:9:"�*�stores";O:43:"Doctrine\Common\Collections\ArrayCollection":1:{s:53:"�Doctrine\Common\Collections\ArrayCollection�elements";a:0:{}}s:5:"�*�id";i:1;s:10:"�*�isoCode";s:2:"AD";s:7:"�*�zone";O:52:"Proxies\__CG__\CoreShop\Component\Address\Model\Zone":7:{s:17:"__isInitialized__";b:1;s:5:"�*�id";i:1;s:7:"�*�name";s:6:"Europe";s:12:"�*�countries";O:43:"Doctrine\Common\Collections\ArrayCollection":1:{s:53:"�Doctrine\Common\Collections\ArrayCollection�elements";a:53:{i:0;r:911;i:1;O:37:"CoreShop\Component\Core\Model\Country":16:{s:11:"�*�currency";O:53:"Proxies\__CG__\CoreShop\Component\Core\Model\Currency":9:{s:17:"__isInitialized__";b:1;s:12:"�*�countries";O:43:"Doctrine\Common\Collections\ArrayCollection":1:{s:53:"�Doctrine\Common\Collections\ArrayCollection�elements";a:1:{i:0;r:924;}}s:5:"�*�id";i:5;s:7:"�*�name";s:3:"Lek";s:10:"�*�isoCode";s:3:"ALL";s:17:"�*�numericIsoCode";i:8;s:9:"�*�symbol";s:3:"ALL";s:15:"�*�creationDate";O:8:"DateTime":3:{s:4:"date";s:26:"2021-04-16 18:57:25.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/Berlin";}s:19:"�*�modificationDate";O:8:"DateTime":3:{s:4:"date";s:26:"2021-04-16 18:57:25.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/Berlin";}}s:9:"�*�stores";O:43:"Doctrine\Common\Collections\ArrayCollection":1:{s:53:"�Doctrine\Common\Collections\ArrayCollection�elements";a:0:{}}s:5:"�*�id";i:6;s:10:"�*�isoCode";s:2:"AL";s:7:"�*�zone";r:917;s:9:"�*�states";O:43:"Doctrine\Common\Collections\ArrayCollection":1:{s:53:"�Doctrine\Common\Collections\ArrayCollection�elements";a:0:{}}s:16:"�*�addressFormat";s:188:"%Text(company);
%Text(salutation); %Text(firstname); %Text(lastname);
%Text(street); %Text(number);
%Text(postcode); %Text(city);
%DataObject(country,{"method" : "getName"}); %Text(phone);";s:14:"�*�salutations";a:2:{i:0;s:3:"mrs";i:1;s:2:"mr";}s:9:"�*�active";b:0;s:15:"�*�creationDate";O:8:"DateTime":3:{s:4:"date";s:26:"2021-04-16 18:57:26.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/Berlin";}s:19:"�*�modificationDate";O:8:"DateTime":3:{s:4:"date";s:26:"2021-04-16 18:57:26.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/Berlin";}s:15:"�*�translations";O:43:"Doctrine\Common\Collections\ArrayCollection":1:{s:53:"�Doctrine\Common\Collections\ArrayCollection�elements";a:7:{s:2:"en";O:51:"CoreShop\Component\Address\Model\CountryTranslation":6:{s:5:"�*�id";i:36;s:7:"�*�name";s:7:"Albania";s:9:"�*�locale";s:2:"en";s:15:"�*�translatable";r:924;s:15:"�*�creationDate";O:8:"DateTime":3:{s:4:"date";s:26:"2021-04-16 00:00:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/Berlin";}s:19:"�*�modificationDate";O:8:"DateTime":3:{s:4:"date";s:26:"2021-04-16 18:57:26.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/Berlin";}}s:2:"de";O:51:"CoreShop\Component\Address\Model\CountryTranslation":6:{s:5:"�*�id";i:37;s:7:"�*�name";s:8:"Albanien";s:9:"�*�locale";s:2:"de";s:15:"�*�translatable";r:924;s:15:"�*�creationDate";O:8:"DateTime":3:{s:4:"date";s:26:"2021-04-16 00:00:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/Berlin";}s:19:"�*�modificationDate";O:8:"DateTime":3:{s:4:"date";s:26:"2021-04-16 18:57:26.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/Berlin";}}s:2:"fr";O:51:"CoreShop\Component\Address\Model\CountryTranslation":6:{s:5:"�*�id";i:38;s:7:"�*�name";s:7:"Albanie";s:9:"�*�locale";s:2:"fr";s:15:"�*�translatable";r:924;s:15:"�*�creationDate";O:8:"DateTime":3:{s:4:"date";s:26:"2021-04-16 00:00:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/Berlin";}s:19:"�*�modificationDate";O:8:"DateTime":3:{s:4:"date";s:26:"2021-04-16 18:57:26.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/Berlin";}}s:2:"pl";O:51:"CoreShop\Component\Address\Model\CountryTranslation":6:{s:5:"�*�id";i:39;s:7:"�*�name";s:7:"Albania";s:9:"�*�locale";s:2:"pl";s:15:"�*�translatable";r:924;s:15:"�*�creationDate";O:8:"DateTime":3:{s:4:"date";s:26:"2021-04-16 00:00:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/Berlin";}s:19:"�*�modificationDate";O:8:"DateTime":3:{s:4:"date";s:26:"2021-04-16 18:57:26.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/Berlin";}}s:2:"da";O:51:"CoreShop\Component\Address\Model\CountryTranslation":6:{s:5:"�*�id";i:40;s:7:"�*�name";s:7:"Albania";s:9:"�*�locale";s:2:"da";s:15:"�*�translatable";r:924;s:15:"�*�creationDate";O:8:"DateTime":3:{s:4:"date";s:26:"2021-04-16 00:00:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/Berlin";}s:19:"�*�modificationDate";O:8:"DateTime":3:{s:4:"date";s:26:"2021-04-16 18:57:26.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/Berlin";}}s:2:"sl";O:51:"CoreShop\Component\Address\Model\CountryTranslation":6:{s:5:"�*�id";i:41;s:7:"�*�name";s:7:"Albania";s:9:"�*�locale";s:2:"sl";s:15:"�*�translatable";r:924;s:15:"�*�creationDate";O:8:"DateTime":3:{s:4:"date";s:26:"2021-04-16 00:00:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/Berlin";}s:19:"�*�modificationDate";O:8:"DateTime":3:{s:4:"date";s:26:"2021-04-16 18:57:26.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/Berlin";}}s:2:"es";O:51:"CoreShop\Component\Address\Model\CountryTranslation":6:{s:5:"�*�id";i:42;s:7:"�*�name";s:7:"Albania";s:9:"�*�locale";s:2:"es";s:15:"�*�translatable";r:924;s:15:"�*�creationDate";O:8:"DateTime":3:{s:4:"date";s:26:"2021-04-16 00:00:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/Berlin";}s:19:"�*�modificationDate";O:8:"DateTime":3:{s:4:"date";s:26:"2021-04-16 18:57:26.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/Berlin";}}}}s:20:"�*�translationsCache";a:0:{}s:16:"�*�currentLocale";s:2:"de";s:21:"�*�currentTranslation";N;s:17:"�*�fallbackLocale";s:2:"de";}i:2;r:905;i:3;O:37:"CoreShop\Component\Core\Model\Country":16:{s:11:"�*�currency";r:907;s:9:"�*�stores";O:43:"Doctrine\Common\Collections\ArrayCollection":1:{s:53:"�Doctrine\Common\Collections\ArrayCollection�elements";a:0:{}}s:5:"�*�id";i:15;s:10:"�*�isoCode";s:2:"AX";s:7:"�*�zone";r:917;s:9:"�*�states";O:43:"Doctrine\Common\Collections\ArrayCollection":1:{s:53:"�Doctrine\Common\Collections\ArrayCollection�elements";a:0:{}}s:16:"�*�addressFormat";s:188:"%Text(company);
%Text(salutation); %Text(firstname); %Text(lastname);
%Text(street); %Text(number);
%Text(postcode); %Text(city);
%DataObject(country,{"method" : "getName"}); %Text(phone);";s:14:"�*�salutations";a:2:{i:0;s:3:"mrs";i:1;s:2:"mr";}s:9:"�*�active";b:0;s:15:"�*�creationDate";O:8:"DateTime":3:{s:4:"date";s:26:"2021-04-16 18:57:26.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/Berlin";}s:19:"�*�modificationDate";O:8:"DateTime":3:{s:4:"date";s:26:"2021-04-16 18:57:26.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/Berlin";}s:15:"�*�translations";O:43:"Doctrine\Common\Collections\ArrayCollection":1:{s:53:"�Doctrine\Common\Collections\ArrayCollection�elements";a:7:{s:2:"en";O:51:"CoreShop\Component\Address\Model\CountryTranslation":6:{s:5:"�*�id";i:99;s:7:"�*�name";s:14:"Åland Islands";s:9:"�*�locale";s:2:"en";s:15:"�*�translatable";r:1061;s:15:"�*�creationDate";O:8:"DateTime":3:{s:4:"date";s:26:"2021-04-16 00:00:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/Berlin";}s:19:"�*�modificationDate";O:8:"DateTime":3:{s:4:"date";s:26:"2021-04-16 18:57:26.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/Berlin";}}s:2:"de";O:51:"CoreShop\Component\Address\Model\CountryTranslation":6:{s:5:"�*�id";i:100;s:7:"�*�name";s:6:"Åland";s:9:"�*�locale";s:2:"de";s:15:"�*�translatable";r:1061;s:15:"�*�creationDate";O:8:"DateTime":3:{s:4:"date";s:26:"2021-04-16 00:00:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:13:"Europe/Berlin";}s:19:"�*�modificationDate";
...
```
And this continued to a total size of 1.2 MB. Unserializing this needed about 50ms. When 100 products get loaded on one page, this sums up to 5s.

In the end this even caused Redis to go out of memory and probably tear down the whole server (for the latter we are not sure). And of course it also caused high load on the cache backend when writing the cache as it is more effort to write 1.2MB than to write 30 KB.

With this PR, the repository data for tax rules doess not get saved to Pimcore's data object cache anymore, resulting in much less cache data.

Resolves #1644