### PR TITLE
Fix rounding on tax calculation

### DIFF
--- a/src/CoreShop/Component/Taxation/Calculator/TaxRulesTaxCalculator.php
+++ b/src/CoreShop/Component/Taxation/Calculator/TaxRulesTaxCalculator.php
@@ -84,10 +84,10 @@ class TaxRulesTaxCalculator implements TaxCalculatorInterface
         $taxAmount = 0;
         foreach ($this->getTaxRates() as $tax) {
             if ($this->getComputationMethod() == self::ONE_AFTER_ANOTHER_METHOD) {
-                $taxesAmounts[$tax->getId()] = (int) round($price - ($price / (1 + ($tax->getRate() / 100))));
+                $taxesAmounts[$tax->getId()] = (int) round($price - ($price / (1 + ($tax->getRate() / 100))), 2);
                 $price = $price - $taxesAmounts[$tax->getId()];
             } else {
-                $taxesAmounts[$tax->getId()] = (int) round($price - ($price / (1 + ($tax->getRate() / 100))));
+                $taxesAmounts[$tax->getId()] = (int) round($price - ($price / (1 + ($tax->getRate() / 100))), 2);
             }
         }
 
@@ -112,10 +112,10 @@ class TaxRulesTaxCalculator implements TaxCalculatorInterface
 
         foreach ($this->getTaxRates() as $tax) {
             if ($this->getComputationMethod() == self::ONE_AFTER_ANOTHER_METHOD) {
-                $taxesAmounts[$tax->getId()] = (int) round($price * (abs($tax->getRate()) / 100));
+                $taxesAmounts[$tax->getId()] = (int) round($price * (abs($tax->getRate()) / 100), 2);
                 $price = $price + $taxesAmounts[$tax->getId()];
             } else {
-                $taxesAmounts[$tax->getId()] = (int) round(($price * (abs($tax->getRate()) / 100)));
+                $taxesAmounts[$tax->getId()] = (int) round(($price * (abs($tax->getRate()) / 100)), 2);
             }
         }
 


### PR DESCRIPTION
| Q                      | A
| -------------   | ---
| Bug fix?            | yes
| New feature?   | no
| BC breaks?      | no
| Deprecations? | no

For 3 items with € 16.99, the total amount must be € 50.97 and not € 50.98 which is wrong because it does not round correctly.
Then we have 19% tax and the calculation is for the net prices.
It fixes incorrect tax calculations by more accurate tax amount rounding.
The new correct calculation formula is:
taxAmount = round(net price * 1.19, 2) * quantity
In the current implementation calculation was:
taxAmount = round(net price * 1.19) * quantity