### PR TITLE
Add isEqual() for product-specific price rules

### DIFF
--- a/src/CoreShop/Bundle/ProductBundle/CoreExtension/ProductSpecificPriceRules.php
+++ b/src/CoreShop/Bundle/ProductBundle/CoreExtension/ProductSpecificPriceRules.php
@@ -263,12 +263,6 @@ class ProductSpecificPriceRules extends Data implements
             return 'empty';
         }
 
-        $output = '';
-        /** @var ProductSpecificPriceRuleInterface $priceRule */
-        foreach($data as $priceRule) {
-            $output .= ;
-        }
-
         return sprintf('Rules: %s', count($data));
     }
 

--- a/src/CoreShop/Bundle/ProductBundle/CoreExtension/ProductSpecificPriceRules.php
+++ b/src/CoreShop/Bundle/ProductBundle/CoreExtension/ProductSpecificPriceRules.php
@@ -27,15 +27,18 @@ use JMS\Serializer\SerializationContext;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\DataObject\LazyLoadedFieldsInterface;
+use Pimcore\Model\DataObject\Traits\SimpleComparisonTrait;
 use Webmozart\Assert\Assert;
 
 class ProductSpecificPriceRules extends Data implements
     Data\CustomResourcePersistingInterface,
     Data\CustomVersionMarshalInterface,
     CustomRecyclingMarshalInterface,
-    CustomDataCopyInterface
+    CustomDataCopyInterface,
+    Data\EqualComparisonInterface
 {
     use TempEntityManagerTrait;
+    use SimpleComparisonTrait;
 
     /**
      * Static type of this element.
@@ -258,6 +261,12 @@ class ProductSpecificPriceRules extends Data implements
     {
         if (!is_array($data)) {
             return 'empty';
+        }
+
+        $output = '';
+        /** @var ProductSpecificPriceRuleInterface $priceRule */
+        foreach($data as $priceRule) {
+            $output .= ;
         }
 
         return sprintf('Rules: %s', count($data));

--- a/src/CoreShop/Bundle/ProductBundle/CoreExtension/ProductSpecificPriceRules.php
+++ b/src/CoreShop/Bundle/ProductBundle/CoreExtension/ProductSpecificPriceRules.php
@@ -518,24 +518,4 @@ class ProductSpecificPriceRules extends Data implements
     {
         return $this->getContainer()->getParameter('coreshop.product_specific_price_rule.conditions');
     }
-
-    public function getParameterTypeDeclaration(): ?string
-    {
-        return '?array';
-    }
-
-    public function getReturnTypeDeclaration(): ?string
-    {
-        return '?array';
-    }
-
-    public function getPhpdocInputType(): ?string
-    {
-        return ProductSpecificPriceRuleInterface::class.'[]';
-    }
-
-    public function getPhpdocReturnType(): ?string
-    {
-        return ProductSpecificPriceRuleInterface::class.'[]';
-    }
 }

--- a/src/CoreShop/Bundle/ProductBundle/CoreExtension/ProductSpecificPriceRules.php
+++ b/src/CoreShop/Bundle/ProductBundle/CoreExtension/ProductSpecificPriceRules.php
@@ -17,6 +17,7 @@ use CoreShop\Bundle\ResourceBundle\CoreExtension\TempEntityManagerTrait;
 use CoreShop\Bundle\ResourceBundle\Doctrine\ORM\EntityMerger;
 use CoreShop\Component\Pimcore\BCLayer\CustomDataCopyInterface;
 use CoreShop\Component\Pimcore\BCLayer\CustomRecyclingMarshalInterface;
+use CoreShop\Component\Pimcore\BCLayer\EqualComparisonInterface;
 use CoreShop\Component\Product\Model\ProductInterface;
 use CoreShop\Component\Product\Model\ProductSpecificPriceRuleInterface;
 use CoreShop\Component\Product\Repository\ProductSpecificPriceRuleRepositoryInterface;
@@ -35,7 +36,7 @@ class ProductSpecificPriceRules extends Data implements
     Data\CustomVersionMarshalInterface,
     CustomRecyclingMarshalInterface,
     CustomDataCopyInterface,
-    Data\EqualComparisonInterface
+    EqualComparisonInterface
 {
     use TempEntityManagerTrait;
     use SimpleComparisonTrait;

--- a/src/CoreShop/Bundle/ProductBundle/CoreExtension/ProductSpecificPriceRules.php
+++ b/src/CoreShop/Bundle/ProductBundle/CoreExtension/ProductSpecificPriceRules.php
@@ -517,4 +517,24 @@ class ProductSpecificPriceRules extends Data implements
     {
         return $this->getContainer()->getParameter('coreshop.product_specific_price_rule.conditions');
     }
+
+    public function getParameterTypeDeclaration(): ?string
+    {
+        return '?array';
+    }
+
+    public function getReturnTypeDeclaration(): ?string
+    {
+        return '?array';
+    }
+
+    public function getPhpdocInputType(): ?string
+    {
+        return ProductSpecificPriceRuleInterface::class.'[]';
+    }
+
+    public function getPhpdocReturnType(): ?string
+    {
+        return ProductSpecificPriceRuleInterface::class.'[]';
+    }
 }

--- a/src/CoreShop/Component/Pimcore/BCLayer/EqualComparisonInterface.php
+++ b/src/CoreShop/Component/Pimcore/BCLayer/EqualComparisonInterface.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * CoreShop.
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.org)
+ * @license    https://www.coreshop.org/license     GNU General Public License version 3 (GPLv3)
+ */
+
+namespace CoreShop\Component\Pimcore\BCLayer;
+
+if (interface_exists(\Pimcore\Model\DataObject\ClassDefinition\Data\EqualComparisonInterface::class)) {
+    interface EqualComparisonInterface extends \Pimcore\Model\DataObject\ClassDefinition\Data\EqualComparisonInterface
+    {
+    }
+} else {
+    interface EqualComparisonInterface
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

This PR implements the `isEqual()` method for product-specific price rules.