### PR TITLE
fix: Since symfony/http-kernel 5.1: Referencing controllers with a si…

### DIFF
--- a/src/CoreShop/Bundle/FrontendBundle/Resources/views/layout-column.html.twig
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/views/layout-column.html.twig
@@ -5,9 +5,9 @@
     <div class="row">
         <div class="col-md-3">
             {% if category is defined %}
-                {{ render(controller('CoreShop\\Bundle\\FrontendBundle\\Controller\\CategoryController:menuLeftAction', {activeCategory: category})) }}
+                {{ render(controller('CoreShop\\Bundle\\FrontendBundle\\Controller\\CategoryController::menuLeftAction', {activeCategory: category})) }}
             {% else %}
-                {{ render(controller('CoreShop\\Bundle\\FrontendBundle\\Controller\\CategoryController:menuLeftAction')) }}
+                {{ render(controller('CoreShop\\Bundle\\FrontendBundle\\Controller\\CategoryController::menuLeftAction')) }}
             {% endif %}
 
             {% block left %}


### PR DESCRIPTION
…ngle colon is deprecated

 Use "CoreShop\Bundle\FrontendBundle\Controller\CategoryController::menuLeftAction" instead.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A

Fix a Symfony 5.x deprecation.