### PR TITLE
Make category sort options configurable

### DIFF
--- a/src/CoreShop/Bundle/FrontendBundle/Controller/CategoryController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/CategoryController.php
@@ -36,15 +36,25 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class CategoryController extends FrontendController
 {
-    protected array $validSortProperties = ['name'];
+    protected array $validSortProperties;
 
     protected string $repositoryIdentifier = 'oo_id';
 
     protected string $requestIdentifier = 'category';
 
-    protected string $defaultSortName = 'name';
+    protected string $defaultSortName;
 
-    protected string $defaultSortDirection = 'asc';
+    protected string $defaultSortDirection;
+
+    public function __construct(
+        array $validSortProperties,
+        string $defaultSortName,
+        string $defaultSortDirection
+    ) {
+        $this->validSortProperties = $validSortProperties;
+        $this->defaultSortName = $defaultSortName;
+        $this->defaultSortDirection = $defaultSortDirection;
+    }
 
     public function menuAction(): Response
     {
@@ -132,7 +142,7 @@ class CategoryController extends FrontendController
             $orderDirection = $category->getFilter()->getOrderDirection();
             $orderKey = $category->getFilter()->getOrderKey();
 
-            $sortKey = (empty($orderKey) ? $this->defaultSortName : strtoupper($orderKey)) . '_' . (empty($orderDirection) ? $this->defaultSortDirection : strtoupper($orderDirection));
+            $sortKey = (empty($orderKey) ? $this->defaultSortName : $orderKey) . '_' . (empty($orderDirection) ? $this->defaultSortDirection : $orderDirection);
             $sort = $this->getParameterFromRequest($request, 'sort', $sortKey);
             $sortParsed = $this->parseSorting($sort);
 

--- a/src/CoreShop/Bundle/FrontendBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/FrontendBundle/DependencyInjection/Configuration.php
@@ -47,10 +47,33 @@ final class Configuration implements ConfigurationInterface
                 ->scalarNode('view_bundle')->defaultValue('CoreShopFrontend')->end()
             ->end();
 
+        $this->addCategorySection($rootNode);
         $this->addPimcoreResourcesSection($rootNode);
         $this->addControllerSection($rootNode);
 
         return $treeBuilder;
+    }
+
+    private function addCategorySection(ArrayNodeDefinition $node): void
+    {
+        $node->children()
+            ->arrayNode('category')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->arrayNode('valid_sort_options')
+                        ->defaultValue(['name'])
+                        ->scalarPrototype()->end()
+                    ->end()
+                    ->scalarNode('default_sort_name')->defaultValue('name')->end()
+                    ->scalarNode('default_sort_direction')
+                        ->defaultValue('asc')
+                        ->validate()
+                            ->ifNotInArray(['asc', 'desc'])
+                            ->thenInvalid('Supported values are asc, desc.')
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
     }
 
     private function addControllerSection(ArrayNodeDefinition $node): void

--- a/src/CoreShop/Bundle/FrontendBundle/DependencyInjection/CoreShopFrontendExtension.php
+++ b/src/CoreShop/Bundle/FrontendBundle/DependencyInjection/CoreShopFrontendExtension.php
@@ -40,6 +40,10 @@ final class CoreShopFrontendExtension extends AbstractModelExtension
         $container->setParameter('coreshop.frontend.view_bundle', $configs['view_bundle']);
         $container->setParameter('coreshop.frontend.view_suffix', $configs['view_suffix']);
 
+        $container->setParameter('coreshop.frontend.category.valid_sort_options', $configs['category']['valid_sort_options']);
+        $container->setParameter('coreshop.frontend.category.default_sort_name', $configs['category']['default_sort_name']);
+        $container->setParameter('coreshop.frontend.category.default_sort_direction', $configs['category']['default_sort_direction']);
+
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
     }

--- a/src/CoreShop/Bundle/FrontendBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/config/services.yml
@@ -2,11 +2,6 @@ imports:
     - { resource: services/wishlist.yml }
     - { resource: services_alias.yml }
 
-parameters:
-    coreshop.frontend.category.valid_sort_options: ['name']
-    coreshop.frontend.category.default_sort_name: name
-    coreshop.frontend.category.default_sort_direction: asc
-
 services:
     coreshop.frontend.controller.abstract:
         class: CoreShop\Bundle\FrontendBundle\Controller\FrontendController

--- a/src/CoreShop/Bundle/FrontendBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/config/services.yml
@@ -2,6 +2,11 @@ imports:
     - { resource: services/wishlist.yml }
     - { resource: services_alias.yml }
 
+parameters:
+    coreshop.frontend.category.valid_sort_options: ['name']
+    coreshop.frontend.category.default_sort_name: name
+    coreshop.frontend.category.default_sort_direction: asc
+
 services:
     coreshop.frontend.controller.abstract:
         class: CoreShop\Bundle\FrontendBundle\Controller\FrontendController
@@ -39,3 +44,9 @@ services:
     CoreShop\Bundle\FrontendBundle\Twig\MergeRecursiveExtension:
         tags:
             - { name: twig.extension }
+
+    CoreShop\Bundle\FrontendBundle\Controller\CategoryController:
+        arguments:
+            - '%coreshop.frontend.category.valid_sort_options%'
+            - '%coreshop.frontend.category.default_sort_name%'
+            - '%coreshop.frontend.category.default_sort_direction%'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Valid category sort options are hardcoded in CategoryController. This PR makes them configurable via parameters.