### PR TITLE
Added payum payment model fields to coreshop payment model

### DIFF
--- a/src/CoreShop/Bundle/PaymentBundle/Resources/config/doctrine/model/Payment.orm.xml
+++ b/src/CoreShop/Bundle/PaymentBundle/Resources/config/doctrine/model/Payment.orm.xml
@@ -20,6 +20,18 @@
             <gedmo:timestampable on="update"/>
         </field>
 
+        <field name="number" column="number" type="string" nullable="true" />
+
+        <field name="description" column="description" type="string" nullable="true" />
+
+        <field name="clientEmail" column="client_email" type="string" nullable="true" />
+
+        <field name="clientId" column="client_id" type="string" nullable="true" />
+
+        <field name="totalAmount" column="total_amount" type="integer" nullable="true" />
+
+        <field name="currencyCode" column="currency_code" type="string" nullable="true" />
+
         <many-to-one field="paymentProvider" target-entity="CoreShop\Component\Payment\Model\PaymentProviderInterface">
             <join-column name="payment_provider_id" referenced-column-name="id" nullable="true"/>
         </many-to-one>

--- a/src/CoreShop/Component/Payment/Model/Payment.php
+++ b/src/CoreShop/Component/Payment/Model/Payment.php
@@ -73,6 +73,16 @@ class Payment implements PaymentInterface
      */
     protected $description;
 
+    /**
+     * @var string
+     */
+    protected $clientEmail;
+
+    /**
+     * @var string
+     */
+    protected $clientId;
+
     public function getId()
     {
         return $this->id;
@@ -156,5 +166,25 @@ class Payment implements PaymentInterface
     public function setDescription(string $description)
     {
         $this->description = $description;
+    }
+
+    public function getClientEmail()
+    {
+        return $this->clientEmail;
+    }
+
+    public function setClientEmail($clientEmail)
+    {
+        $this->clientEmail = $clientEmail;
+    }
+
+    public function getClientId()
+    {
+        return $this->clientId;
+    }
+
+    public function setClientId($clientId)
+    {
+        $this->clientId = $clientId;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

With Payment model not longer extending Payum/Payment model there is issue with orm mapping. Not all columns are being created in database. Also payment is not working because some fields couldn't be mapped because of that. 
This is proposition for first hand solution so that when someone installs CoreShop 3 payment works.

