### PR TITLE
Password reset: Clearer form labels

### DIFF
--- a/src/CoreShop/Bundle/CustomerBundle/Form/Type/ResetPasswordType.php
+++ b/src/CoreShop/Bundle/CustomerBundle/Form/Type/ResetPasswordType.php
@@ -27,8 +27,8 @@ class ResetPasswordType extends AbstractType
         $builder
             ->add('password', RepeatedType::class, [
                 'type' => PasswordType::class,
-                'first_options' => ['label' => 'coreshop.form.customer.password'],
-                'second_options' => ['label' => 'coreshop.form.customer.password_repeat'],
+                'first_options' => ['label' => 'coreshop.form.customer.password_new'],
+                'second_options' => ['label' => 'coreshop.form.customer.password_new_repeat'],
             ]);
     }
 

--- a/src/CoreShop/Bundle/CustomerBundle/Form/Type/ResetPasswordType.php
+++ b/src/CoreShop/Bundle/CustomerBundle/Form/Type/ResetPasswordType.php
@@ -27,8 +27,8 @@ class ResetPasswordType extends AbstractType
         $builder
             ->add('password', RepeatedType::class, [
                 'type' => PasswordType::class,
-                'first_options' => ['label' => 'coreshop.form.customer.password_new'],
-                'second_options' => ['label' => 'coreshop.form.customer.password_new_repeat'],
+                'first_options' => ['label' => 'coreshop.form.customer.new_password'],
+                'second_options' => ['label' => 'coreshop.form.customer.new_password_repeat'],
             ]);
     }
 

--- a/src/CoreShop/Bundle/FrontendBundle/Resources/install/pimcore/translations.yml
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/install/pimcore/translations.yml
@@ -1294,20 +1294,6 @@ translations:
           de: 'Passwort wiederholen'
           it: 'Ripeti la password'
 
-  coreshop.form.customer.password_new:
-      languages:
-          de_CH: 'Neues Passwort'
-          en: 'New Password'
-          de: 'Neues Passwort'
-          it: 'Nuovu Password'
-
-  coreshop.form.customer.password_new_repeat:
-      languages:
-          de_CH: 'Neues Passwort wiederholen'
-          en: 'Repeat new Password'
-          de: 'Neues Passwort wiederholen'
-          it: 'Ripeti la nuovu password'
-
   coreshop.form.customer.new_password:
       languages:
           de_CH: 'Neues Passwort'

--- a/src/CoreShop/Bundle/FrontendBundle/Resources/install/pimcore/translations.yml
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/install/pimcore/translations.yml
@@ -1294,6 +1294,20 @@ translations:
           de: 'Passwort wiederholen'
           it: 'Ripeti la password'
 
+  coreshop.form.customer.password_new:
+      languages:
+          de_CH: 'Neues Passwort'
+          en: 'New Password'
+          de: 'Neues Passwort'
+          it: 'Nuovu Password'
+
+  coreshop.form.customer.password_new_repeat:
+      languages:
+          de_CH: 'Neues Passwort wiederholen'
+          en: 'Repeat new Password'
+          de: 'Neues Passwort wiederholen'
+          it: 'Ripeti la nuovu password'
+
   coreshop.form.customer.new_password:
       languages:
           de_CH: 'Neues Passwort'


### PR DESCRIPTION
Currently there is a bit of a UX problem when resetting the password. We had some customers who wondered why they have to type their password when they actually want to reset it. To make it clearer that with the password-reset form it is actually possible to change to a **new** password, this PR changes the field labels.