### PR TITLE
Fatal error when saving object with product-specific prices -> EntityMerger got object of wrong class

### DIFF
--- a/src/CoreShop/Bundle/ResourceBundle/Doctrine/ORM/EntityMerger.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Doctrine/ORM/EntityMerger.php
@@ -139,6 +139,14 @@ class EntityMerger
                 //Reset new Data, for some reason the line above resets newData
                 $newData = $class->reflFields[$assoc['fieldName']]->getValue($entity);
 
+                if (!$newCollection instanceof PersistentCollection) {
+                    $newCollection = new PersistentCollection(
+                        $this->em,
+                        $class,
+                        $newCollection
+                    );
+                }
+
                 $this->mergeCollection($origData, $newData, $assoc, static function ($foundEntry) use ($newCollection) {
                     $newCollection->removeElement($foundEntry);
                 }, $visited);


### PR DESCRIPTION
We had a problem that some product objects could not be saved anymore. Fatal Error 
```
[2022-02-14 10:09:11] request.CRITICAL: Uncaught PHP Exception Symfony\Component\ErrorHandler\Error\UndefinedMethodError: "Attempted to call an undefined method named "setOwner" of class "Doctrine\Common\Collections\ArrayCollection"." at /var/www/clients/client1/web1/web/vendor/coreshop/core-shop/src/CoreShop/Bundle/ResourceBundle/Doctrine/ORM/EntityMerger.php line 153 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Attempted to call an undefined method named \"setOwner\" of class \"Doctrine\\Common\\Collections\\ArrayCollection\". at /var/www/clients/client1/web1/web/vendor/coreshop/core-shop/src/CoreShop/Bundle/ResourceBundle/Doctrine/ORM/EntityMerger.php:153)"} []
```
was thrown.

https://github.com/coreshop/CoreShop/blob/ca1d81338a26a01d848860f6b566b6d00592a706/src/CoreShop/Bundle/ResourceBundle/Doctrine/ORM/EntityMerger.php#L124
caused `$newCollection` to be a `Doctrine\Common\Collections\ArrayCollection` afterwards.

This PR backports the change to `EntityMerger` class from 97f743a673f7cdefece6e0cf1c060efb1db82930 - now object can be saved as normal.