### PR TITLE
[CoreShopIndexBundle] Add `pimcore.dataobject.postAdd` event to index DataObjects

### DIFF
--- a/src/CoreShop/Bundle/IndexBundle/Resources/config/services/listeners.yml
+++ b/src/CoreShop/Bundle/IndexBundle/Resources/config/services/listeners.yml
@@ -18,6 +18,7 @@ services:
         arguments:
             - '@CoreShop\Component\Index\Service\IndexUpdaterService'
         tags:
+            - { name: kernel.event_listener, event: pimcore.dataobject.postAdd, method: onPostUpdate }
             - { name: kernel.event_listener, event: pimcore.dataobject.postUpdate, method: onPostUpdate }
             - { name: kernel.event_listener, event: pimcore.dataobject.postDelete, method: onPostDelete }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1865

Fix for #1865
