### PR TITLE
FIX:double click on field group adds them to indices

### DIFF
--- a/src/CoreShop/Bundle/IndexBundle/Resources/public/pimcore/js/index/fields.js
+++ b/src/CoreShop/Bundle/IndexBundle/Resources/public/pimcore/js/index/fields.js
@@ -270,7 +270,17 @@ coreshop.index.fields = Class.create({
         });
 
         tree.addListener('itemdblclick', function (tree, record, item, index, e, eOpts) {
-            if (!record.data.root && record.datatype !== 'layout' && record.data.dataType !== 'localizedfields') {
+            if (
+                !record.data.root &&
+                (
+                    record.datatype &&
+                    record.datatype !== 'layout'
+                ) ||
+                (
+                    record.data.dataType &&
+                    record.data.dataType !== 'localizedfields'
+                )
+            ) {
                 var copy = Ext.apply({}, record.data);
 
                 copy.id = Ext.id();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

You can double click field groups and add them to indexed fields.

