### PR TITLE
FIX: select from multiselect throws error if no value is pre-selected

### DIFF
--- a/src/CoreShop/Component/Index/Filter/SelectFilterConditionFromMultiselectProcessor.php
+++ b/src/CoreShop/Component/Index/Filter/SelectFilterConditionFromMultiselectProcessor.php
@@ -51,7 +51,7 @@ class SelectFilterConditionFromMultiselectProcessor implements FilterConditionPr
         return [
             'type' => 'select',
             'label' => $condition->getLabel(),
-            'currentValue' => trim($currentFilter[$field], ','),
+            'currentValue' => isset($currentFilter[$field]) ? trim($currentFilter[$field], ',') : null,
             'values' => array_values($values),
             'fieldName' => $field,
             'quantityUnit' => $condition->getQuantityUnit() ? Unit::getById((string)$condition->getQuantityUnit()) : null,
@@ -67,7 +67,9 @@ class SelectFilterConditionFromMultiselectProcessor implements FilterConditionPr
             $value = $condition->getConfiguration()['preSelect'];
         }
 
-        $value = trim($value);
+        if (is_string($value)) {
+            $value = trim($value);
+        }
 
         if (!empty($value)) {
             $value = ',' . $value . ',';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

If you create select from multiselect filter and don't preselect the value exception is thorwn. trim(): Argument #1 ($string) must be of type string, null given.
