### PR TITLE
[ResourceBundle] Make stack of classes not extended in CoreBundle working

### DIFF
--- a/src/CoreShop/Bundle/ResourceBundle/CoreExtension/CoreShopRelation.php
+++ b/src/CoreShop/Bundle/ResourceBundle/CoreExtension/CoreShopRelation.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 
 namespace CoreShop\Bundle\ResourceBundle\CoreExtension;
 
+use League\Csv\Exception;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Relations\AbstractRelations;
+use Pimcore\Model\Element;
 
 /**
  * @psalm-suppress InvalidReturnType, InvalidReturnStatement
@@ -68,18 +71,17 @@ class CoreShopRelation extends Data\ManyToOneRelation
         return $this->getParameterTypeDeclaration();
     }
 
-    public function getClasses()
+
+    /**
+     * @param array $classes
+     *
+     * @return $this
+     */
+    public function setClasses($classes)
     {
-        $classes = $this->getCoreShopPimcoreClasses()[$this->stack];
-        $return = [];
+        $this->classes = Element\Service::fixAllowedTypes($this->getCoreShopPimcoreClasses()[$this->stack], 'classes');
 
-        foreach ($classes as $cl) {
-            $return[] = [
-                'classes' => $cl,
-            ];
-        }
-
-        return $return;
+        return $this;
     }
 
     /**

--- a/src/CoreShop/Bundle/ResourceBundle/CoreExtension/CoreShopRelation.php
+++ b/src/CoreShop/Bundle/ResourceBundle/CoreExtension/CoreShopRelation.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace CoreShop\Bundle\ResourceBundle\CoreExtension;
 
-use League\Csv\Exception;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Relations\AbstractRelations;
 use Pimcore\Model\Element;
@@ -70,7 +69,6 @@ class CoreShopRelation extends Data\ManyToOneRelation
     {
         return $this->getParameterTypeDeclaration();
     }
-
 
     /**
      * @param array $classes

--- a/src/CoreShop/Bundle/ResourceBundle/DependencyInjection/Compiler/StackClassesPass.php
+++ b/src/CoreShop/Bundle/ResourceBundle/DependencyInjection/Compiler/StackClassesPass.php
@@ -44,7 +44,7 @@ final class StackClassesPass implements CompilerPassInterface
                     continue;
                 }
 
-                if (in_array($interface, class_implements($definition['classes']['interface']))) {
+                if (in_array($interface, class_implements($definition['classes']['interface'])) || $interface === $definition['classes']['interface']) {
                     $classStack[$alias][] = $definition['classes']['model'];
 
                     $fullClassName = $definition['classes']['model'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

The stack for `coreshop.manufacturer` and `coreshop.address` was not working, because the classes have not been extended in the CoreBundle. Therefore I adjusted the check in the StackClassesPass to also work with not extended classes. 
