### PR TITLE
FIX: coreshop_payment_provider editable select, wrong property name

### DIFF
--- a/src/CoreShop/Bundle/PaymentBundle/Resources/config/services/pimcore.yml
+++ b/src/CoreShop/Bundle/PaymentBundle/Resources/config/services/pimcore.yml
@@ -4,6 +4,6 @@ services:
         arguments:
             - 'CoreShop\Bundle\ResourceBundle\CoreExtension\Document\Select'
             - 'coreshop.repository.payment_provider'
-            - 'name'
+            - 'title'
         tags:
             - { name: coreshop.pimcore.document.editable, type: coreshop_payment_provider }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

coreshop_payment_provider editable was using property Named 'name' instead of the 'title'.
