### PR TITLE
Email field required on request reset password form

### DIFF
--- a/src/CoreShop/Bundle/UserBundle/Form/Type/RequestResetPasswordType.php
+++ b/src/CoreShop/Bundle/UserBundle/Form/Type/RequestResetPasswordType.php
@@ -19,6 +19,7 @@ use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\NotBlank;
 
 class RequestResetPasswordType extends AbstractType
 {
@@ -29,6 +30,9 @@ class RequestResetPasswordType extends AbstractType
 
         $builder->add($identifier, $typeClass, [
             'label' => sprintf('coreshop.form.customer.%s', $identifier),
+            'constraints' => [
+                new NotBlank()
+            ],
         ]);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Currently you can submit blank value for email on request password reset form and  submitting blank value causes exception.
