### PR TITLE
FIX: duplicated unit definition title in product view in admin

### DIFF
--- a/src/CoreShop/Bundle/ProductBundle/Resources/public/pimcore/js/coreExtension/tags/coreShopProductUnitDefinitions.js
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/public/pimcore/js/coreExtension/tags/coreShopProductUnitDefinitions.js
@@ -44,8 +44,11 @@ pimcore.object.tags.coreShopProductUnitDefinitions = Class.create(pimcore.object
             border: true,
             layout: 'fit',
             style: 'margin: 10px 0;',
-            collapsible: true,
-            collapsed: true
+            collapsible: {
+                direction: 'left',
+                collapsed: true,
+                dynamic: true
+            }
         };
 
         this.fieldConfig.datatype = 'layout';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #

Unit Definition collapsible title is no longer duplicated. 
