### PR TITLE
FIX: extending condition proccesor adds empty tag

### DIFF
--- a/src/CoreShop/Bundle/IndexBundle/DependencyInjection/Compiler/RegisterFilterConditionTypesPass.php
+++ b/src/CoreShop/Bundle/IndexBundle/DependencyInjection/Compiler/RegisterFilterConditionTypesPass.php
@@ -27,6 +27,10 @@ class RegisterFilterConditionTypesPass implements CompilerPassInterface
             $definition = $container->findDefinition($id);
 
             foreach ($attributes as $tag) {
+                if (empty($tag)) {
+                    continue;
+                }
+                
                 $definition->addTag('coreshop.filter.user_condition_type', $tag);
                 $definition->addTag('coreshop.filter.pre_condition_type', $tag);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Extending filter condition processor adds empty tag to definition. It probably isn't imagined to be extended but it should cover that case also.
