### PR TITLE
Error during serialization of OrderInvoice

### DIFF
--- a/src/CoreShop/Bundle/OrderBundle/Resources/config/serializer/Model.OrderInvoice.yml
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/config/serializer/Model.OrderInvoice.yml
@@ -39,6 +39,6 @@ CoreShop\Component\Order\Model\OrderInvoice:
             groups: [Detailed]
         items:
             serialized_name: items
-            exp: object.getItems
+            exp: object.getItems()
             type: array
             groups: [Detailed]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature? | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

During serialization of orderInvoice error appears because serializer can't find property getItems on orderInvoice, getItems is a method
