### PR TITLE
fix: logo in _header.html.twig no longer hardcoded

### DIFF
--- a/src/CoreShop/Bundle/FrontendBundle/Resources/views/_header.html.twig
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/views/_header.html.twig
@@ -47,7 +47,7 @@
                 <div class="col-md-6">
                     <div id="logo">
                         <a href="{{ path('coreshop_index') }}">
-                            <img src="/bundles/coreshopfrontend/static/images/logo-full.svg" title="CoreShop" alt="CoreShop" class="img-fluid" width="300px"/>
+                            <img src="{{ asset('bundles/coreshopfrontend/static/images/logo-full.svg') }}" title="CoreShop" alt="CoreShop" class="img-fluid" width="300"/>
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A

Logo path shouldn't be hardcoded here.