### PR TITLE
Fix xvfb error

### DIFF
--- a/src/CoreShop/Bundle/OrderBundle/Renderer/Pdf/WkHtmlToPdf.php
+++ b/src/CoreShop/Bundle/OrderBundle/Renderer/Pdf/WkHtmlToPdf.php
@@ -171,13 +171,7 @@ final class WkHtmlToPdf implements PdfRendererInterface
             $command = $wkHtmlTopPfBinary . $options;
         }
 
-        $process = new Process(
-            [
-                $command,
-                $httpSource,
-                $tmpPdfFile,
-            ]
-        );
+        $process = Process::fromShellCommandline($command . ' ' . $httpSource . ' ' . $tmpPdfFile);
         $process->run();
 
         if (!file_exists($tmpPdfFile)) {
@@ -204,6 +198,6 @@ final class WkHtmlToPdf implements PdfRendererInterface
 
     private function getXvfbBinary(): string
     {
-        return (string)Console::getExecutable('xvfb-run', true);
+        return (string)Console::getExecutable('xvfb-run', false);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The comment in code suggests that XVFB is optional, so getter for XVFB shouldn't throw exception.
`
 // use xvfb if possible
`

Also process needs to be created in a different way.