### PR TITLE
fix: use only first-level categories in CategoryController::menuAction

### DIFF
--- a/src/CoreShop/Bundle/FrontendBundle/Controller/CategoryController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/CategoryController.php
@@ -58,7 +58,7 @@ class CategoryController extends FrontendController
 
     public function menuAction(): Response
     {
-        $categories = $this->getRepository()->findForStore($this->getContext()->getStore());
+        $categories = $this->getRepository()->findFirstLevelForStore($this->getContext()->getStore());
 
         return $this->render($this->templateConfigurator->findTemplate('Category/_menu.html'), [
             'categories' => $categories,


### PR DESCRIPTION
Else all the categories are used, dumping them all in the main menu by default.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A

By default, category controller menu action will use all the available store categories to render the main menu. This doesn't work as expected since the main menu is rendered directly as if all the categories are root categories.