### PR TITLE
feat: use the index for categories to allow fine tuning the menus

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Pimcore/Repository/CategoryRepository.php
+++ b/src/CoreShop/Bundle/CoreBundle/Pimcore/Repository/CategoryRepository.php
@@ -26,10 +26,7 @@ class CategoryRepository extends BaseCategoryRepository implements CategoryRepos
     {
         $list = $this->getList();
         $list->setCondition('stores LIKE ?', ['%,' . $store->getId() . ',%']);
-        $list->setOrderKey(
-            'o_index ASC, o_key ASC',
-            false
-        );
+        $this->setSortingForListingWithoutCategory($list);
 
         return $list->getObjects();
     }
@@ -38,10 +35,8 @@ class CategoryRepository extends BaseCategoryRepository implements CategoryRepos
     {
         $list = $this->getList();
         $list->setCondition('parentCategory__id is null AND stores LIKE "%,' . $store->getId() . ',%"');
-        $list->setOrderKey(
-            'o_index ASC, o_key ASC',
-            false
-        );
+
+        $this->setSortingForListingWithoutCategory($list);
 
         return $list->getObjects();
     }
@@ -116,7 +111,7 @@ class CategoryRepository extends BaseCategoryRepository implements CategoryRepos
     private function setSortingForListingWithoutCategory(Listing $list): void
     {
         $list->setOrderKey(
-            'o_key ASC',
+            'o_index ASC, o_key ASC',
             false
         );
     }

--- a/src/CoreShop/Bundle/CoreBundle/Pimcore/Repository/CategoryRepository.php
+++ b/src/CoreShop/Bundle/CoreBundle/Pimcore/Repository/CategoryRepository.php
@@ -26,7 +26,10 @@ class CategoryRepository extends BaseCategoryRepository implements CategoryRepos
     {
         $list = $this->getList();
         $list->setCondition('stores LIKE ?', ['%,' . $store->getId() . ',%']);
-        $this->setSortingForListingWithoutCategory($list);
+        $list->setOrderKey(
+            'o_index ASC, o_key ASC',
+            false
+        );
 
         return $list->getObjects();
     }
@@ -35,8 +38,10 @@ class CategoryRepository extends BaseCategoryRepository implements CategoryRepos
     {
         $list = $this->getList();
         $list->setCondition('parentCategory__id is null AND stores LIKE "%,' . $store->getId() . ',%"');
-
-        $this->setSortingForListingWithoutCategory($list);
+        $list->setOrderKey(
+            'o_index ASC, o_key ASC',
+            false
+        );
 
         return $list->getObjects();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A

The `findForStore()` and `findFirstLevelForStore()` (see #1914) are used for menus. It makes sense to default to the `o_index` sort which allows customizing the order of items in the menu. If not desired, it can be reset to the A-Z sort by Pimcore.