### PR TITLE
Make range filter work with just min or max

### DIFF
--- a/src/CoreShop/Component/Index/Filter/RangeFilterConditionProcessor.php
+++ b/src/CoreShop/Component/Index/Filter/RangeFilterConditionProcessor.php
@@ -88,14 +88,20 @@ class RangeFilterConditionProcessor implements FilterConditionProcessorInterface
         $currentFilter[$field . '-min'] = $valueMin;
         $currentFilter[$field . '-max'] = $valueMax;
 
-        if (null !== $valueMin && null !== $valueMax) {
+        if (null !== $valueMin || null !== $valueMax) {
             $fieldName = $field;
 
             if ($isPrecondition) {
                 $fieldName = 'PRECONDITION_' . $fieldName;
             }
 
-            $list->addCondition(new RangeCondition($field, (float)$valueMin, (float)$valueMax), $fieldName);
+            $condition = new RangeCondition(
+                $field,
+                is_null($valueMin) ? null : (float)$valueMin,
+                is_null($valueMax) ? null : (float)$valueMax
+            );
+
+            $list->addCondition($condition, $fieldName);
         }
 
         return $currentFilter;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Currently the range filter only works if both min and max values are provided. This PR makes it work if just one of those two values is provided.