### PR TITLE
fix: paginator prev/next links point to first/last page

### DIFF
--- a/src/CoreShop/Bundle/FrontendBundle/Resources/views/Common/paginator.html.twig
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/views/Common/paginator.html.twig
@@ -20,7 +20,7 @@
             <ul class="pagination">
                 {% if pages.previous is defined %}
                     {% if pages.previous %}
-                        <li class="page-item"><a class="page-link" href="{{ generator.generate_seo_pagination_url(pages.first) }}">«</a></li>
+                        <li class="page-item"><a class="page-link" href="{{ generator.generate_seo_pagination_url(pages.previous) }}">«</a></li>
                     {% endif %}
                 {% endif %}
 
@@ -30,7 +30,7 @@
 
                 {% if pages.next is defined %}
                     {% if pages.next %}
-                        <li class="page-item"><a class="page-link" href="{{ pimcore_url({ page: pages.last }) }}">»</a></li>
+                        <li class="page-item"><a class="page-link" href="{{ pimcore_url({ page: pages.next }) }}">»</a></li>
                     {% endif %}
                 {% endif %}
             </ul>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | NA