### PR TITLE
Fixed wrong categories returned when concatenator is AND

### DIFF
--- a/src/CoreShop/Component/Index/Filter/CategoryMultiSelectConditionProcessor.php
+++ b/src/CoreShop/Component/Index/Filter/CategoryMultiSelectConditionProcessor.php
@@ -32,8 +32,9 @@ class CategoryMultiSelectConditionProcessor implements FilterConditionProcessorI
             $field = 'parentCategoryIds';
         }
 
+        $concatenator = $condition->getConfiguration()['concatenator'] ?: 'OR';
         $parsedValues = [];
-        $rawValues = $list->getGroupByValues($field, true);
+        $rawValues = $list->getGroupByValues($field, true, $concatenator == 'AND' ? false : true);
 
         foreach ($rawValues as $v) {
             $explode = explode(',', $v['value']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
 
Category multiselect filter is now dynamic.
