### PR TITLE
Profiler fix

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Collector/CurrencyCollector.php
+++ b/src/CoreShop/Bundle/CoreBundle/Collector/CurrencyCollector.php
@@ -45,7 +45,7 @@ final class CurrencyCollector extends DataCollector
 
     public function getCurrency(): ?CurrencyInterface
     {
-        return $this->data['currency'];
+        return $this->data['currency'] ?? null;
     }
 
     public function getCurrencies(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

In case there is no store defined inside constructor code will enter catch part and $this->data will never be set, so the method getCurrency will throw and error and profile wont work
