### PR TITLE
Fixed error in SQL in CategoriesReport wrong field name for a categor…

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Report/CategoriesReport.php
+++ b/src/CoreShop/Bundle/CoreBundle/Report/CategoriesReport.php
@@ -127,7 +127,7 @@ class CategoriesReport implements ReportInterface
             SELECT SQL_CALC_FOUND_ROWS
               `categories`.oo_id as categoryId,
               `categories`.o_key as categoryKey,
-              `localizedCategories`.name as categoryName,
+              `localizedCategories`.publicationsCategory as categoryName,
               `orders`.store,
               SUM(orderItems.totalGross) AS sales,
               SUM((orderItems.itemRetailPriceNet - orderItems.itemWholesalePrice) * orderItems.quantity) AS profit,


### PR DESCRIPTION
…yName

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

<!--
I've fixed the wrong field name used for categoryName which caused an error in the SQL query. 
It was error 500 then navigate to Marketing - Reports - Categories report in Pimcore backend admin.
-->
