### PR TITLE
fix: paginator.html.twig prepends four spaces to URLs

### DIFF
--- a/src/CoreShop/Bundle/FrontendBundle/Resources/views/Common/paginator.html.twig
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/views/Common/paginator.html.twig
@@ -2,16 +2,15 @@
 {% set pages = paginator.getPaginationData %}
 
 {% macro generate_seo_pagination_url(page) %}
-    {% apply spaceless %}
-        {% if page == 1 %}
-            {% set pageUrl = pimcore_url({ page: null }) %}
-        {% else %}
-            {% set pageUrl = pimcore_url({ page: page }) %}
-        {% endif %}
+{% apply spaceless %}
+    {% if page == 1 %}
+        {% set pageUrl = pimcore_url({ page: null }) %}
+    {% else %}
+        {% set pageUrl = pimcore_url({ page: page }) %}
+    {% endif %}
 
-        {{ pageUrl }}
-        {#{{ optimizedUrl }}#}
-    {% endapply %}
+    {{ pageUrl }}
+{% endapply %}
 {% endmacro %}
 
 {% if pages.pageCount > 1 %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A

URLs generated by the paginator by default have 4 spaces prepended to them, like

```html
<a href="    /category?page=2">2</a>
```

This removes the spaces.