### PR TITLE
Handle `null` addresses when persisting customers

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Customer/CustomerManager.php
+++ b/src/CoreShop/Bundle/CoreBundle/Customer/CustomerManager.php
@@ -41,7 +41,7 @@ class CustomerManager implements CustomerManagerInterface
         /**
          * @var AddressInterface[] $addressBackup
          */
-        $addressBackup = $customer->getObjectVar('addresses');
+        $addressBackup = $customer->getObjectVar('addresses') ?? [];
 
         /**
          * @var UserInterface|null $userBackup


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

When the customer that should be persisted in `CustomerManager::persistCustomer()` has no addessses yet, the property may be `null`, which fails when trying to iterate over it. We should fall back to an empty array in this case.
