### PR TITLE
feat: add dirname() and basename() to expression function provider

### DIFF
--- a/src/CoreShop/Component/Pimcore/ExpressionLanguage/PHPFunctionsProvider.php
+++ b/src/CoreShop/Component/Pimcore/ExpressionLanguage/PHPFunctionsProvider.php
@@ -47,6 +47,8 @@ class PHPFunctionsProvider implements ExpressionFunctionProviderInterface
             ExpressionFunction::fromPHP('implode'),
             ExpressionFunction::fromPHP('is_array'),
             ExpressionFunction::fromPHP('count'),
+            ExpressionFunction::fromPHP('dirname'),
+            ExpressionFunction::fromPHP('basename'),
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A

These functions are a common requirement if your expressions deal with paths.