### PR TITLE
[Product Model] Allow `getIndexableName()` to return null

### DIFF
--- a/src/CoreShop/Component/Core/Model/Product.php
+++ b/src/CoreShop/Component/Core/Model/Product.php
@@ -67,7 +67,7 @@ abstract class Product extends BaseProduct implements ProductInterface
         return $this->getIndexableEnabled($index);
     }
 
-    public function getIndexableName(IndexInterface $index, string $language): string
+    public function getIndexableName(IndexInterface $index, string $language): ?string
     {
         return $this->getName($language);
     }

--- a/src/CoreShop/Component/Index/Model/IndexableInterface.php
+++ b/src/CoreShop/Component/Index/Model/IndexableInterface.php
@@ -50,5 +50,5 @@ interface IndexableInterface
 
     public function getIndexable(IndexInterface $index): bool;
 
-    public function getIndexableName(IndexInterface $index, string $language): string;
+    public function getIndexableName(IndexInterface $index, string $language): ?string;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

This change allows the "getIndexableName()" method to return null, e.g. multiple languages, which have not been filled in yet.