### PR TITLE
create URL slugs only for valid coreshop sites/stores

### DIFF
--- a/src/CoreShop/Bundle/PimcoreBundle/EventListener/SluggableListener.php
+++ b/src/CoreShop/Bundle/PimcoreBundle/EventListener/SluggableListener.php
@@ -55,6 +55,7 @@ final class SluggableListener implements EventSubscriberInterface
             }
 
             $found = false;
+            $key = null;
             foreach($urlSlugs as $key => $urlSlug) {
                 if($urlSlug->getSiteId() === 0) {
                     $found = true;
@@ -82,7 +83,7 @@ final class SluggableListener implements EventSubscriberInterface
         }
     }
 
-    private function generateUniqueSlug(Concrete $object, string $language) : string
+    private function generateUniqueSlug(SluggableInterface $object, string $language) : string
     {
         $slug = $this->slugger->slug($object, $language);
 

--- a/src/CoreShop/Bundle/PimcoreBundle/EventListener/SluggableListener.php
+++ b/src/CoreShop/Bundle/PimcoreBundle/EventListener/SluggableListener.php
@@ -34,7 +34,8 @@ final class SluggableListener implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            DataObjectEvents::PRE_UPDATE => 'preUpdate'
+            DataObjectEvents::PRE_UPDATE => 'preUpdate',
+            DataObjectEvents::PRE_ADD => 'preUpdate'
         ];
     }
 

--- a/src/CoreShop/Bundle/PimcoreBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/PimcoreBundle/Resources/config/services.yml
@@ -68,7 +68,6 @@ services:
     CoreShop\Bundle\PimcoreBundle\EventListener\SluggableListener:
         arguments:
             - '@CoreShop\Component\Pimcore\Slug\SluggableSluggerInterface'
-            - '@coreshop.repository.store'
         tags:
             - { name: kernel.event_subscriber }
 

--- a/src/CoreShop/Bundle/PimcoreBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/PimcoreBundle/Resources/config/services.yml
@@ -68,6 +68,7 @@ services:
     CoreShop\Bundle\PimcoreBundle\EventListener\SluggableListener:
         arguments:
             - '@CoreShop\Component\Pimcore\Slug\SluggableSluggerInterface'
+            - '@coreshop.repository.store'
         tags:
             - { name: kernel.event_subscriber }
 

--- a/src/CoreShop/Component/Pimcore/Slug/SluggableInterface.php
+++ b/src/CoreShop/Component/Pimcore/Slug/SluggableInterface.php
@@ -19,9 +19,14 @@ use Pimcore\Model\DataObject\Data\UrlSlug;
 interface SluggableInterface
 {
     /**
-     * @return int
+     * @return int|string|null
      */
     public function getId();
+
+    /**
+     * @return string
+     */
+    public function getKey();
 
     /**
      * @return UrlSlug[]

--- a/src/CoreShop/Component/Pimcore/Slug/SluggableLinkGenerator.php
+++ b/src/CoreShop/Component/Pimcore/Slug/SluggableLinkGenerator.php
@@ -44,6 +44,9 @@ class SluggableLinkGenerator implements LinkGeneratorInterface
         );
 
         foreach ($slugs as $possibleSlug) {
+            if ($possibleSlug->getSiteId() === 0) {
+                $fallbackSlug = $possibleSlug;
+            }
             if ($possibleSlug->getSiteId() === ($site ? $site->getId() : 0)) {
                 $slug = $possibleSlug;
 
@@ -51,10 +54,10 @@ class SluggableLinkGenerator implements LinkGeneratorInterface
             }
         }
 
-        if (null === $slug) {
+        if (null === $slug && null === $fallbackSlug) {
             throw new \InvalidArgumentException(sprintf('No Valid Slug found for object "%s"', $object->getFullPath()));
         }
 
-        return $slug->getSlug();
+        return $slug ? $slug->getSlug() : $fallbackSlug->getSlug();
     }
 }

--- a/src/CoreShop/Component/Pimcore/Slug/SluggableLinkGenerator.php
+++ b/src/CoreShop/Component/Pimcore/Slug/SluggableLinkGenerator.php
@@ -37,6 +37,7 @@ class SluggableLinkGenerator implements LinkGeneratorInterface
 
         $slugs = $object->getSlug($params['_locale'] ?? null);
         $slug = null;
+        $fallbackSlug = null;
         $site = $params['site'] ?? (
             $this->requestStack->getMainRequest() ?
                 $this->siteResolver->getSite($this->requestStack->getMainRequest()) :

--- a/src/CoreShop/Component/Pimcore/Slug/SluggableSlugger.php
+++ b/src/CoreShop/Component/Pimcore/Slug/SluggableSlugger.php
@@ -25,7 +25,7 @@ class SluggableSlugger implements SluggableSluggerInterface
 
     public function slug(SluggableInterface $sluggable, string $locale, string $suffix = null): string
     {
-        $name = $sluggable->getNameForSlug($locale) ?: (string)$sluggable->getId();
+        $name = $sluggable->getNameForSlug($locale) ?: $sluggable->getKey();
 
         if (!$name) {
             throw new SlugNotPossibleException('name is empty');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #2023

CoreShop automatically creates the URL slugs for the products.
With this PR only slugs for available sites/store are considered. 

I have not changed the rest of the logic, that means other entries will be deleted.
Is this intentional?

To note:
In the URL slug definition of Pimcore there is an option "Available Sites" which is ignored in this PR as well in the current CoreShop version.

