### PR TITLE
#1613 TagManagerEnhancedEcommerce

### DIFF
--- a/src/CoreShop/Bundle/TrackingBundle/Resources/views/Tracking/gtm/enhanced/checkout.js.twig
+++ b/src/CoreShop/Bundle/TrackingBundle/Resources/views/Tracking/gtm/enhanced/checkout.js.twig
@@ -1,1 +1,1 @@
-dataLayer.push({ 'event': 'csCheckout', 'checkout': {{ actionData|json_encode()|raw }} });
+dataLayer.push({'event': 'csCheckout', 'ecommerce': {'checkout': {{ actionData|json_encode()|raw }} }});

--- a/src/CoreShop/Bundle/TrackingBundle/Resources/views/Tracking/gtm/enhanced/checkout_complete.js.twig
+++ b/src/CoreShop/Bundle/TrackingBundle/Resources/views/Tracking/gtm/enhanced/checkout_complete.js.twig
@@ -1,1 +1,1 @@
-dataLayer.push({'ecommerce' : { 'purchase' : {{ actionData|json_encode()|raw }} } });
+dataLayer.push({'event': 'csPurchase', 'ecommerce' : { 'purchase' : {{ actionData|json_encode()|raw }} } });

--- a/src/CoreShop/Bundle/TrackingBundle/Resources/views/Tracking/gtm/enhanced/product_impression.js.twig
+++ b/src/CoreShop/Bundle/TrackingBundle/Resources/views/Tracking/gtm/enhanced/product_impression.js.twig
@@ -1,1 +1,1 @@
-dataLayer.push({'ecommerce' : {{ actionData|json_encode()|raw }} });
+dataLayer.push({'event': 'csProductImpressions', 'ecommerce' : {{ actionData|json_encode()|raw }} });

--- a/src/CoreShop/Bundle/TrackingBundle/Resources/views/Tracking/gtm/enhanced/product_view.js.twig
+++ b/src/CoreShop/Bundle/TrackingBundle/Resources/views/Tracking/gtm/enhanced/product_view.js.twig
@@ -1,1 +1,1 @@
-dataLayer.push({'ecommerce': {'detail': {{ actionData|json_encode()|raw }} }});
+dataLayer.push({'event': 'csProductDetailImpressions', 'ecommerce': {'detail': {{ actionData|json_encode()|raw }} }});

--- a/src/CoreShop/Bundle/TrackingBundle/Tracker/Google/TagManager/TagManagerEnhancedEcommerce.php
+++ b/src/CoreShop/Bundle/TrackingBundle/Tracker/Google/TagManager/TagManagerEnhancedEcommerce.php
@@ -154,7 +154,7 @@ class TagManagerEnhancedEcommerce extends AbstractEcommerceTracker
     {
         $this->ensureDataLayer();
 
-        $product['quantity'] = 1;
+        $product['quantity'] = $quantity;
 
         $actionData = [$action => []];
 
@@ -177,7 +177,7 @@ class TagManagerEnhancedEcommerce extends AbstractEcommerceTracker
         return [
             'id' => $actionData['id'],
             'affiliation' => $actionData['affiliation'] ?: '',
-            'total' => $actionData['total'],
+            'revenue' => $actionData['total'],
             'tax' => $actionData['totalTax'],
             'shipping' => $actionData['shipping'],
             'currency' => $actionData['currency'],
@@ -190,11 +190,7 @@ class TagManagerEnhancedEcommerce extends AbstractEcommerceTracker
             'id' => $item['id'],
             'name' => $item['name'],
             'category' => $item['category'],
-            'brand' => $item['brand'],
-            'variant' => $item['variant'],
             'price' => round($item['price'], 2),
-            'quantity' => $item['quantity'] ?: 1,
-            'list_position' => $item['position'],
         ]);
     }
 


### PR DESCRIPTION
fixing some of the listed issues in the ticket
Fixed:
- trackCheckoutComplete - Rename total to revenue
- trackProductImpression - remove quantity, brand, position, attribute
- trackCartAdd - quantity is hardcoded to 1. Use $quantity instead

Template issues
- product_impression.js.twig
- product_view.js.twig
- checkout.js.twig
- checkout_complete.js.twig

Not fixed:
- trackProductImpression - submit impression as multi- instead of single-array
- trackCartAdd - price attribute: I'm not sure about that but I think we need to use the cart item price instead of product price (which often can't be determinate (because of complex variant structure etc.)
- trackCartRemove

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1613 

TagManagerEnhancedEcommerce
fixing some of the listed issues in the ticket #1613 
Fixed:
- trackCheckoutComplete - Rename total to revenue
- trackProductImpression - remove quantity, brand, position, attribute
- trackCartAdd - quantity is hardcoded to 1. Use $quantity instead

Template issues
- product_impression.js.twig
- product_view.js.twig
- checkout.js.twig
- checkout_complete.js.twig


Not fixed:
- trackProductImpression - submit impression as multi- instead of single-array
- trackCartAdd - price attribute: I'm not sure about that but I think we need to use the cart item price instead of product price (which often can't be determinate (because of complex variant structure etc.)
- trackCartRemove
