### PR TITLE
fix: process conditions after the paginator

### DIFF
--- a/src/CoreShop/Bundle/FrontendBundle/Controller/CategoryController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/CategoryController.php
@@ -149,14 +149,14 @@ class CategoryController extends FrontendController
             $filteredList->setOrderKey($sortParsed['name']);
             $filteredList->setOrder($sortParsed['direction']);
 
-            $currentFilter = $this->get(FilterProcessorInterface::class)->processConditions($category->getFilter(), $filteredList, $request->query);
-            $preparedConditions = $this->get(FilterProcessorInterface::class)->prepareConditionsForRendering($category->getFilter(), $filteredList, $currentFilter);
-
             $paginator = $this->getPaginator()->paginate(
                 $filteredList,
                 $page,
                 $perPage
             );
+
+            $currentFilter = $this->get(FilterProcessorInterface::class)->processConditions($category->getFilter(), $filteredList, $request->query);
+            $preparedConditions = $this->get(FilterProcessorInterface::class)->prepareConditionsForRendering($category->getFilter(), $filteredList, $currentFilter);
 
             $viewParameters['list'] = $filteredList;
             $viewParameters['filter'] = $category->getFilter();


### PR DESCRIPTION
Reordering this allows for an optimization in some cases.

For example, when using an ES search here, you'll want to do the query and load the possible filter values in the same query. The query needs limit/offset for the items, but doesn't need it for filter values. Making the paginator run first allows us to inject the current limit/offset in the query early and we don't need to run it twice.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A