### PR TITLE
[CoreBundle] check for null value in CartStockAvailabilityValidator

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Validator/Constraints/CartStockAvailabilityValidator.php
+++ b/src/CoreShop/Bundle/CoreBundle/Validator/Constraints/CartStockAvailabilityValidator.php
@@ -82,6 +82,10 @@ final class CartStockAvailabilityValidator extends ConstraintValidator
         $product = $cartItem->getProduct();
         $quantity = $cartItem->getDefaultUnitQuantity();
 
+        if (null === $quantity) {
+            $quantity = 0;
+        }
+
         /**
          * @var OrderItemInterface $item
          */

--- a/src/CoreShop/Bundle/CoreBundle/Validator/Constraints/CartStockAvailabilityValidator.php
+++ b/src/CoreShop/Bundle/CoreBundle/Validator/Constraints/CartStockAvailabilityValidator.php
@@ -80,11 +80,7 @@ final class CartStockAvailabilityValidator extends ConstraintValidator
     private function getExistingCartItemQuantityFromCart(OrderInterface $cart, OrderItemInterface $cartItem): float
     {
         $product = $cartItem->getProduct();
-        $quantity = $cartItem->getDefaultUnitQuantity();
-
-        if (null === $quantity) {
-            $quantity = 0;
-        }
+        $quantity = $cartItem->getDefaultUnitQuantity() ?? 0;
 
         /**
          * @var OrderItemInterface $item


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? no

`$cartItem->getDefaultUnitQuantity();` could return null here  and cause a TypeError.