### PR TITLE
[VariantBundle] Serializer: Allow $innerObject to be null

### DIFF
--- a/src/CoreShop/Bundle/VariantBundle/Twig/Extension/VariantExtension.php
+++ b/src/CoreShop/Bundle/VariantBundle/Twig/Extension/VariantExtension.php
@@ -76,7 +76,7 @@ final class VariantExtension extends AbstractExtension
         return $this->serializer->normalize($attributeGroups, 'json', [
             'groups' => $groups,
             AbstractNormalizer::CALLBACKS => [
-                'valueColor' => static function (string $innerObject) {
+                'valueColor' => static function (?string $innerObject) {
                     return $innerObject;
                 },
             ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

With this PR the value of `$innerObject` is allowed to be null when serializing a variant group. This prevents throwing an error when rendering the product detail page and thus makes this process more flexible.