### PR TITLE
[Pimcore UI] Make default Product Unit unselectable

### DIFF
--- a/src/CoreShop/Bundle/ProductBundle/Controller/ProductUnitDefinitionsController.php
+++ b/src/CoreShop/Bundle/ProductBundle/Controller/ProductUnitDefinitionsController.php
@@ -37,7 +37,9 @@ class ProductUnitDefinitionsController extends ResourceController
         /** @var ProductInterface $product */
         $product = $repository->find($this->getParameterFromRequest($request, 'productId'));
 
-        $definitions = $this->getUnitDefinitionsForProduct($product, 'all');
+        if ($product instanceof ProductInterface) {
+            $definitions = $this->getUnitDefinitionsForProduct($product, 'all');
+        }
 
         return $this->viewHandler->handle($definitions);
     }

--- a/src/CoreShop/Bundle/ProductBundle/Resources/public/pimcore/js/coreExtension/tags/coreShopProductUnitDefinitions.js
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/public/pimcore/js/coreExtension/tags/coreShopProductUnitDefinitions.js
@@ -118,6 +118,13 @@ pimcore.object.tags.coreShopProductUnitDefinitions = Class.create(pimcore.object
 
         this.component.expand();
 
+        // Add empty record to store to prevent always filling in product unit
+        this.unitStore.insert(0, [{
+            'fullLabel': '',
+            'id': null,
+            'name': '',
+        }]);
+
         this.unitBuilder = new coreshop.product.unit.builder(this.unitStore, this.fieldConfig, this.data, this.object.id);
         this.component.add([this.unitBuilder.getForm()]);
 

--- a/src/CoreShop/Bundle/ProductBundle/Resources/public/pimcore/js/product/units/builder.js
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/public/pimcore/js/product/units/builder.js
@@ -401,6 +401,7 @@ coreshop.product.unit.builder = Class.create({
                 typeAhead: false,
                 editable: false,
                 forceSelection: true,
+                allowBlank: true,
                 queryMode: 'local',
                 displayField: 'fullLabel',
                 valueField: 'id',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #2040

I'm not 100% sure if this is the correct place to fix the issue of not having an empty entry in the store. @dpfaffenbauer Could you please check and advise if there's a "better way" of adding an empty entry to a CoreShop resource list.
Thanks!