### PR TITLE
[Release] 3.0.0

### DIFF
--- a/CHANGELOG-3.0.x.md
+++ b/CHANGELOG-3.0.x.md
@@ -1,3 +1,23 @@
+# 3.0.0
+
+CoreShop is now Licenced under CCL and GPLv3! (https://github.com/coreshop/CoreShop/pull/2061)
+
+## Feature
+ - [IndexBundle] clone index, change default name of cloned item (https://github.com/coreshop/CoreShop/pull/2056)
+ - [CartPriceRules] introduce feature to allow cart-price rules based on cart-items (https://github.com/coreshop/CoreShop/pull/2057, https://github.com/coreshop/CoreShop/pull/2060)
+ - [Wishlist] Introduce a persisted wishlist - StorageListBundle now works as a base for Order and Wishlist (https://github.com/coreshop/CoreShop/pull/2030, https://github.com/coreshop/CoreShop/pull/2066)
+ - [Reports] Support filtering for order type (https://github.com/coreshop/CoreShop/pull/2055)
+ - [Symfony] fix Injecting @session is deprecated with Symfony (https://github.com/coreshop/CoreShop/pull/2035)
+ - [AccessManagement] prepare CoreShop for advanced access-management (https://github.com/coreshop/CoreShop/pull/2063)
+ - [Pimcore] 10.5 as min requirement (https://github.com/coreshop/CoreShop/pull/2067)
+
+## Bugs
+ - [VariantBundle] Serializer: Allow $innerObject to be null (https://github.com/coreshop/CoreShop/pull/2058, https://github.com/coreshop/CoreShop/pull/2069)
+ - [DataHub] Fix non unique typename (https://github.com/coreshop/CoreShop/pull/2004)
+ - [Translations] Update admin-translations.yml (https://github.com/coreshop/CoreShop/pull/2064)
+ - [Pimcore UI] Make default Product Unit unselectable (https://github.com/coreshop/CoreShop/pull/2065)
+ - [Variant] allow recursive attributes and variants (https://github.com/coreshop/CoreShop/pull/2068)
+
 # 3.0.0-beta.5
  > This will be the last BETA for the final release.
 

--- a/src/CoreShop/Bundle/CoreBundle/Application/Version.php
+++ b/src/CoreShop/Bundle/CoreBundle/Application/Version.php
@@ -30,12 +30,12 @@ final class Version
 
     public static function getVersion(): string
     {
-        return sprintf(
-            '%s.%s.%s-%s',
-            self::MAJOR_VERSION,
-            self::MINOR_VERSION,
-            self::RELEASE_VERSION,
-            self::EXTRA_VERSION,
-        );
+        $version = sprintf('%s.%s.%s', self::MAJOR_VERSION, self::MINOR_VERSION, self::RELEASE_VERSION);
+
+        if (self::EXTRA_VERSION !== '') {
+            $version = sprintf('%s-%s', $version, self::EXTRA_VERSION);
+        }
+
+        return $version;
     }
 }

--- a/src/CoreShop/Bundle/CoreBundle/Application/Version.php
+++ b/src/CoreShop/Bundle/CoreBundle/Application/Version.php
@@ -26,7 +26,7 @@ final class Version
 
     public const RELEASE_VERSION = '0';
 
-    public const EXTRA_VERSION = 'beta.5';
+    public const EXTRA_VERSION = '';
 
     public static function getVersion(): string
     {


### PR DESCRIPTION
🎉  🍻 

This it it, the final release of CoreShop 3.0.0. After more than 2 years of development, we finally made it with a final release to Pimcore X. Took a bit longer than we thought, but good things need time.

# What are the biggest newest changes
## Order DataObject is now Cart and Quote
Conceptually, the Order, Cart and Quote are the same. They hold the same amount of information, they are calculated the same and work the same. So why differentiate the 3? With CoreShop 3 we now see them as one and use them as one. The way to differentiate between them is with a State. The Workflow State Machine can change the Status from Cart to Order or Quote.

## Variants
CoreShop never really solved the Variant Selection Problem. Reason was that the concept of Variants can be quite difficult with Pimcore. With CoreShop 3.0 we introduce a simple solution to configure and display Variants in Frontend. Simply use the AttributeGroups and Attributes on your DataObjects and Variants and let CoreShop do the rest.

## Tests
CoreShop always used Test Suites to validate itself. From PHPUnit, to BEHAT to PHPSTAN. With this Release, we also have 
automated Frontend Tests of CoreShops FrontendBundle. For every Pull Request made, we spin up a Webserver and a Browser that clicks through the Website and tests it. Best part: It uses Behat with Gherkin to describe the test-case in a human readable way.

Alongside that, we do static analysis of the Code with PHPSTAN and now PSALM too. Two is better :)

## Pimcore X 
As already mentioned, with this 3.0.0 final Release, CoreShop now is compatible with Pimcore X. To be more specific, with Pimcore 10.5.  

## Wishlist, StorageList
A huge new addition is the persisted Wishlist. A Wishlist works quite similar to a cart. Therefore we decided to refactor the Wishlist and Order to use the same underlying Functionalities and therefore work quite the same.

## Order Item Rules
With CoreShop 3.0.0 you can now define Cart Price Rules based on Order Items. That means, you can precisely fine-tune how and on which Items you apply discounts or surcharges on. 

## License
CoreShop 3.0.0 is now licensed under GPLv2 and CCL (CoreShop Commercial License)
