### PR TITLE
[StorageListBundle] PimcoreStorageListRepository: Comply to PSR-4 autoloading standards

### DIFF
--- a/src/CoreShop/Bundle/StorageListBundle/Pimcore/Repository/PimcoreStorageListRepository.php
+++ b/src/CoreShop/Bundle/StorageListBundle/Pimcore/Repository/PimcoreStorageListRepository.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  *
  */
 
-namespace CoreShop\Bundle\StorageListBundle\Repository;
+namespace CoreShop\Bundle\StorageListBundle\Pimcore\Repository;
 
 use CoreShop\Bundle\ResourceBundle\Pimcore\PimcoreRepository;
 use CoreShop\Component\StorageList\Model\StorageListInterface;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Composer currently throws following error:
```log
Class CoreShop\Bundle\StorageListBundle\Repository\PimcoreStorageListRepository located in ./vendor/coreshop/core-shop/src/CoreShop/Bundle/StorageListBundle/Pimcore/Repository/PimcoreStorageListRepository.php does not comply with psr-4 autoloading standard. Skipping.
```

With this PR this will no longer be the case.