### PR TITLE
[CustomerTransformHelper] Use company's name initial as parent folder for companies

### DIFF
--- a/src/CoreShop/Component/Core/Customer/CustomerTransformHelper.php
+++ b/src/CoreShop/Component/Core/Customer/CustomerTransformHelper.php
@@ -88,7 +88,7 @@ final class CustomerTransformHelper implements CustomerTransformHelperInterface
         $company->setParent(
             $this->folderCreationService->createFolderForResource(
                 $company,
-                ['suffix' => mb_strtoupper(mb_substr($customer->getLastname(), 0, 1))],
+                ['suffix' => mb_strtoupper(mb_substr($options['companyData']['name'] ?? '--', 0, 1))],
             ),
         );
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

This PR changes the parent folder for company objects.

**Before:**
```log
└── ...
    └── D                          # Initial of customer's lastname
        └── Example Company        # Company Object
            └── John Doe           # Customer Object
```

**After:**
```log
└── ...
    └── E                          # Initial of company's name
        └── Example Company        # Company Object
            └── John Doe           # Customer Object
```