### PR TITLE
[ProductVariantTrait] Prevent MySQL syntax error

### DIFF
--- a/src/CoreShop/Component/Variant/Model/ProductVariantTrait.php
+++ b/src/CoreShop/Component/Variant/Model/ProductVariantTrait.php
@@ -32,7 +32,7 @@ trait ProductVariantTrait
     {
         if ($this instanceof Concrete) {
             $list = $this::getList();
-            $list->setCondition('o_path LIKE \'' . $this->getFullPath() . '/%\'');
+            $list->setCondition('o_path LIKE ?', [$this->getFullPath() . '/%']);
             $list->setObjectTypes([AbstractObject::OBJECT_TYPE_VARIANT]);
 
             $variants = $list->getObjects();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

With this PR you no longer receive the following error:

```log
PDOException: SQLSTATE[42000]: Syntax error or access violation: 1064
You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '344 lt/%' AND  object_localized_cs_product_de_CH.o_type IN ('variant')) AND o...' at line 1 in /vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOConnection.php:141

Stack trace:
#0 /vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOConnection.php(141): PDO->query()
#1 /vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOQueryImplementation.php(24): Doctrine\DBAL\Driver\PDOConnection->doQuery()
#2 /vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php(1309): Doctrine\DBAL\Driver\PDOConnection->query()
#3 /vendor/pimcore/pimcore/lib/Db/PimcoreExtensionsTrait.php(92): Doctrine\DBAL\Connection->executeQuery()
#4 /vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php(1119): Pimcore\Db\Connection->executeQuery()
#5 /vendor/pimcore/pimcore/models/DataObject/Listing/Dao.php(117): Doctrine\DBAL\Connection->fetchFirstColumn()
#6 /vendor/pimcore/pimcore/models/DataObject/Listing/Concrete/Dao.php(54): Pimcore\Model\DataObject\Listing\Dao->loadIdList()
#7 /vendor/pimcore/pimcore/models/DataObject/Listing/Dao.php(68): Pimcore\Model\DataObject\Listing\Concrete\Dao->loadIdList()
#8 /vendor/pimcore/pimcore/lib/Model/Listing/AbstractListing.php(528): Pimcore\Model\DataObject\Listing\Dao->load()
#9 /vendor/pimcore/pimcore/models/DataObject/Listing.php(47): Pimcore\Model\Listing\AbstractListing->getData()
#10 /vendor/coreshop/core-shop/src/CoreShop/Component/Variant/Model/ProductVariantTrait.php(38): Pimcore\Model\DataObject\Listing->getObjects()
#11 /vendor/coreshop/core-shop/src/CoreShop/Component/Variant/AttributeCollector.php(107): CoreShop\Component\Core\Model\Product->getVariants()
#12 /var/cache/prod/twig/aa/aaefb7dc88baee27ee0858ba3c72d983.php(37): CoreShop\Component\Variant\AttributeCollector->getAttributesFromObject()
#13 /vendor/twig/twig/src/Template.php(394): __TwigTemplate_79f94ef68cdabe2ae54633b1d4986faa->doDisplay()
#14 /vendor/twig/twig/src/Template.php(367): Twig\Template->displayWithErrorHandling()
#15 /vendor/twig/twig/src/Template.php(379): Twig\Template->display()
#16 /vendor/twig/twig/src/TemplateWrapper.php(40): Twig\Template->render()
#17 /vendor/twig/twig/src/Extension/CoreExtension.php(1323): Twig\TemplateWrapper->render()
#18 /var/cache/prod/twig/22/228941740bcae45cfb000cabf54880a6.php(324): twig_include()
#19 /vendor/twig/twig/src/Template.php(171): __TwigTemplate_67f7e4de1e4152f6297b98785cf5a9be->block_content()
#20 /var/cache/prod/twig/85/85abb83079e518815832c1ac62211bcc.php(83): Twig\Template->displayBlock()
#21 /vendor/twig/twig/src/Template.php(394): __TwigTemplate_4e4b85b00a99d2e37192848febce2802->doDisplay()
#22 /vendor/twig/twig/src/Template.php(367): Twig\Template->displayWithErrorHandling()
#23 /var/cache/prod/twig/22/228941740bcae45cfb000cabf54880a6.php(56): Twig\Template->display()
#24 /vendor/twig/twig/src/Template.php(394): __TwigTemplate_67f7e4de1e4152f6297b98785cf5a9be->doDisplay()
#25 /vendor/twig/twig/src/Template.php(367): Twig\Template->displayWithErrorHandling()
#26 /vendor/twig/twig/src/Template.php(379): Twig\Template->display()
#27 /vendor/twig/twig/src/TemplateWrapper.php(40): Twig\Template->render()
#28 /vendor/twig/twig/src/Environment.php(277): Twig\TemplateWrapper->render()
#29 /vendor/symfony/framework-bundle/Controller/AbstractController.php(258): Twig\Environment->render()
#30 /vendor/symfony/framework-bundle/Controller/AbstractController.php(266): Symfony\Bundle\FrameworkBundle\Controller\AbstractController->renderView()
#31 /vendor/coreshop/core-shop/src/CoreShop/Bundle/FrontendBundle/Controller/ProductController.php(50): Symfony\Bundle\FrameworkBundle\Controller\AbstractController->render()
#32 /vendor/symfony/http-kernel/HttpKernel.php(153): CoreShop\Bundle\FrontendBundle\Controller\ProductController->detailSlugAction()
#33 /vendor/symfony/http-kernel/HttpKernel.php(75): Symfony\Component\HttpKernel\HttpKernel->handleRaw()
#34 /vendor/symfony/http-kernel/Kernel.php(202): Symfony\Component\HttpKernel\HttpKernel->handle()
#35 /public/index.php(25): Symfony\Component\HttpKernel\Kernel->handle()
#36 {main}
```

This happened because some of our products had a `'` in their name and that did not get quoted properly in the MySQL condition.