### PR TITLE
[Menu] Use correct permission definition for product unit menu item

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Menu/MainMenuBuilder.php
+++ b/src/CoreShop/Bundle/CoreBundle/Menu/MainMenuBuilder.php
@@ -289,7 +289,7 @@ class MainMenuBuilder implements MenuBuilderInterface
         $productsMenu
             ->addChild('coreshop_product_units')
             ->setLabel('coreshop_product_units')
-            ->setAttribute('permission', 'coreshop_product_unit')
+            ->setAttribute('permission', 'coreshop_permission_product_unit')
             ->setAttribute('iconCls', 'coreshop_nav_icon_product_units')
             ->setAttribute('resource', 'coreshop.product')
             ->setAttribute('function', 'product_unit')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

This PR fixes the permission for the product unit menu item configured through user permissions.