### PR TITLE
fix: index table o_classId type fix

### DIFF
--- a/src/CoreShop/Bundle/IndexBundle/Worker/AbstractWorker.php
+++ b/src/CoreShop/Bundle/IndexBundle/Worker/AbstractWorker.php
@@ -307,7 +307,7 @@ abstract class AbstractWorker implements WorkerInterface
             'o_id' => IndexColumnInterface::FIELD_TYPE_INTEGER,
             'oo_id' => IndexColumnInterface::FIELD_TYPE_INTEGER,
             'o_key' => IndexColumnInterface::FIELD_TYPE_STRING,
-            'o_classId' => IndexColumnInterface::FIELD_TYPE_INTEGER,
+            'o_classId' => IndexColumnInterface::FIELD_TYPE_STRING,
             'o_className' => IndexColumnInterface::FIELD_TYPE_STRING,
             'o_virtualObjectId' => IndexColumnInterface::FIELD_TYPE_INTEGER,
             'o_virtualObjectActive' => IndexColumnInterface::FIELD_TYPE_BOOLEAN,

--- a/src/CoreShop/Bundle/IndexBundle/Worker/MysqlWorker.php
+++ b/src/CoreShop/Bundle/IndexBundle/Worker/MysqlWorker.php
@@ -102,7 +102,7 @@ class MysqlWorker extends AbstractWorker
         $table->addColumn('o_key', 'string');
         $table->addColumn('o_virtualObjectId', 'integer');
         $table->addColumn('o_virtualObjectActive', 'boolean');
-        $table->addColumn('o_classId', 'integer');
+        $table->addColumn('o_classId', 'string')->setLength(50);
         $table->addColumn('o_className', 'string');
         $table->addColumn('o_type', 'string');
         $table->addColumn('active', 'boolean');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Since pimcore o_classId is string (varchar(50)) and inside index table o_classId is set to int type, values are not saved correctly inside index table
