### PR TITLE
[CustomerAssignment] Fix typo when passing the company ID to the router

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Resources/public/pimcore/js/customer/customerToExistingCompanyAssignment.js
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/public/pimcore/js/customer/customerToExistingCompanyAssignment.js
@@ -175,7 +175,7 @@ coreshop.core.customer.customerToCompanyAssigner = Class.create(coreshop.core.cu
         };
 
         this.submitForm(
-            Routing.generate('coreshop_admin_customer_company_modifier_dispatch_existing_assignment', {customerId: this.customerId, companyId: this.comapnyId}),
+            Routing.generate('coreshop_admin_customer_company_modifier_dispatch_existing_assignment', {customerId: this.customerId, companyId: this.companyId}),
             submitValues,
             windowPanel
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Before this PR the following URL is generated:
```log
/admin/coreshop/customer-company-modifier/dispatch-existing-assignment/16685/undefined
```

Which leads to following error:
```log
CoreShop\Bundle\CoreBundle\Controller\CustomerTransformerController::dispatchExistingAssignmentAction():
Argument #3 ($companyId) must be of type int, string given
```

With this PR, the correct company ID gets passed to the router and there generates the correct URL.