### PR TITLE
add option 'update-classes' for InstallResourcesCommand

### DIFF
--- a/src/CoreShop/Bundle/ResourceBundle/Command/InstallResourcesCommand.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Command/InstallResourcesCommand.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 
 namespace CoreShop\Bundle\ResourceBundle\Command;
 
+use CoreShop\Bundle\ResourceBundle\Installer\PimcoreClassInstaller;
 use CoreShop\Bundle\ResourceBundle\Installer\ResourceInstallerInterface;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Command\Command;
@@ -50,6 +51,12 @@ EOT
                 InputOption::VALUE_REQUIRED,
                 'Application Name',
             )
+            ->addOption(
+                'update-classes',
+                null,
+                InputOption::VALUE_NONE,
+                'Set this option to update class definitions if they already exist',
+            )
         ;
     }
 
@@ -67,7 +74,11 @@ EOT
             $kernel->getEnvironment(),
         ));
 
-        $this->resourceInstaller->installResources($output, $input->getOption('application-name'));
+        $this->resourceInstaller->installResources(
+            $output,
+            $input->getOption('application-name'),
+            [PimcoreClassInstaller::OPTION_UPDATE_CLASSES => $input->getOption('update-classes')]
+        );
 
         return 0;
     }

--- a/src/CoreShop/Bundle/ResourceBundle/Installer/CompositeResourceInstaller.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Installer/CompositeResourceInstaller.php
@@ -32,7 +32,7 @@ class CompositeResourceInstaller implements ResourceInstallerInterface
     {
         foreach ($this->serviceRegistry->all() as $installer) {
             if ($installer instanceof ResourceInstallerInterface) {
-                $installer->installResources($output, $applicationName);
+                $installer->installResources($output, $applicationName, $options);
             }
         }
     }

--- a/src/CoreShop/Bundle/ResourceBundle/Installer/PimcoreClassInstaller.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Installer/PimcoreClassInstaller.php
@@ -26,6 +26,8 @@ use Symfony\Component\HttpKernel\KernelInterface;
 
 final class PimcoreClassInstaller implements PimcoreClassInstallerInterface
 {
+    public const OPTION_UPDATE_CLASSES = 'update-classes';
+
     private array $installedClasses = [];
 
     private array $installedCollections = [];
@@ -103,7 +105,11 @@ final class PimcoreClassInstaller implements PimcoreClassInstallerInterface
             foreach ($classes as $identifier => $class) {
                 $progress->setMessage(sprintf('Install Class %s (%s)', $class['model'], $class['file']));
 
-                $this->installedClasses[$identifier] = $this->classInstaller->createClass($class['file'], $class['model']);
+                $this->installedClasses[$identifier] = $this->classInstaller->createClass(
+                    $class['file'],
+                    $class['model'],
+                    $options[self::OPTION_UPDATE_CLASSES] ?? false,
+                );
 
                 $progress->advance();
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

Add command option `update-classes` to the `InstallResourcesCommand` (`coreshop:resources:install`) to have the possiblity to update Pimcore class definitions.

When the command is executed, configuration from a bundles dependency injection (`Configuration.php`) is used to read in exported json files and to update the definition files for Pimcore.

In the current process, field definitions and objectbrick definitions are always updated, but class definitions never. So i thought why not have an option for classes as well.