### PR TITLE
fix: use asset() helper for logo image

### DIFF
--- a/src/CoreShop/Bundle/OrderBundle/Resources/views/OrderDocumentPrint/header.html.twig
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/views/OrderDocumentPrint/header.html.twig
@@ -4,7 +4,7 @@
 <table class="table borderless">
     <tr>
         <td style="width:50%">
-            <img src="/bundles/coreshopfrontend/static/images/logo.png" title="CoreShop Demo" alt="CoreShop Demo" class="logo" />
+            <img src="{{ asset('bundles/coreshopfrontend/static/images/logo.png') }}" title="CoreShop Demo" alt="CoreShop Demo" class="logo" />
         </td>
         <td class="text-right">
             CoreShop DEMO Address<br/>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A

Same as #1908 .