### PR TITLE
Add layout `price_rules` only once to OrderItem

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Migrations/Version20220817144952.php
+++ b/src/CoreShop/Bundle/CoreBundle/Migrations/Version20220817144952.php
@@ -37,11 +37,11 @@ final class Version20220817144952 extends AbstractMigration implements Container
     {
         $classUpdater = new ClassUpdate($this->container->getParameter('coreshop.model.order_item.pimcore_class_name'));
 
-        if ($classUpdater->hasField('price_rules')) {
+        if ($classUpdater->hasField('priceRuleItems')) {
             return;
         }
 
-        $attributesLayout = [
+        $priceRulesLayout = [
             'fieldtype' => 'panel',
             'labelWidth' => 100,
             'name' => 'price_rules',
@@ -88,7 +88,7 @@ final class Version20220817144952 extends AbstractMigration implements Container
             'locked' => false,
         ];
 
-        $classUpdater->insertLayoutAfter('numbers', $attributesLayout);
+        $classUpdater->insertLayoutAfter('numbers', $priceRulesLayout);
         $classUpdater->save();
     }
 


### PR DESCRIPTION
When deciding if the new layout `price_rules` and field `priceRuleItems` need to be added to the class definition use the field's name for existence check and not the layout's name. Otherwise its existence is not properly detected which leads to multiple inserts if the migration is called multiple times or the field had already been added otherwise.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #2148

<!--

-->
