### PR TITLE
[Reports] Add index for CoreShopOrder.orderDate to improve report performance

### DIFF
--- a/src/CoreShop/Bundle/OrderBundle/Resources/install/pimcore/classes/CoreShopOrder.json
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/install/pimcore/classes/CoreShopOrder.json
@@ -193,7 +193,7 @@
                                 "tooltip": "",
                                 "mandatory": false,
                                 "noteditable": true,
-                                "index": false,
+                                "index": true,
                                 "locked": false,
                                 "style": "",
                                 "permissions": null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Reports always filter on `orderDate` in https://github.com/coreshop/CoreShop/blob/2adc887c4fec31079a4e6ed896532b610526cbbc/src/CoreShop/Bundle/CoreBundle/Report/CategoriesReport.php#L97
and
https://github.com/coreshop/CoreShop/blob/2adc887c4fec31079a4e6ed896532b610526cbbc/src/CoreShop/Bundle/CoreBundle/Report/CategoriesReport.php#L107-L108

Without an index on the `orderDate` field loading report data is really slow.

__Before this PR__
```mysql
explain SELECT SQL_CALC_FOUND_ROWS
`categories`.oo_id as categoryId,
`categories`.o_key as categoryKey,
`localizedCategories`.publicationsCategory as categoryName,
`orders`.store,
SUM(orderItems.totalGross) AS sales,
SUM((orderItems.itemRetailPriceNet - orderItems.itemWholesalePrice) * orderItems.quantity) AS profit,
SUM(orderItems.quantity) AS `quantityCount`,
COUNT(orderItems.product__id) AS `orderCount`
FROM object_63 AS categories
INNER JOIN object_localized_query_63_en AS localizedCategories ON localizedCategories.ooo_id = categories.oo_id 
INNER JOIN dependencies AS catProductDependencies ON catProductDependencies.sourcetype = "object"  AND catProductDependencies.sourceId = categories.oo_id
INNER JOIN object_query_79 AS orderItems ON orderItems.product__id = catProductDependencies.targetId
INNER JOIN object_relations_78 AS orderRelations ON orderRelations.dest_id = orderItems.oo_id AND orderRelations.fieldname = "items"
INNER JOIN object_query_78 AS `orders` ON `orders`.oo_id = orderRelations.src_id
WHERE orders.store = 1 AND orders.orderDate > '1672527600' AND orders.orderDate < '1703977200' AND orderItems.product__id IS NOT NULL
GROUP BY categories.oo_id
ORDER BY quantityCount DESC
LIMIT 0,50;
```

id | select_type | table | type | possible_keys | key | key_len | ref | rows | Extra
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | SIMPLE | object_query_63 | index | PRIMARY | p_index_oldLiveId | 9 | NULL | 844 | Using index; Using temporary; Using filesort
1 | SIMPLE | localizedCategories | ref | PRIMARY | PRIMARY | 4 | horizont_local.object_query_63.oo_id | 1 |  
1 | SIMPLE | catProductDependencies | ref | combi | combi | 5 | const,horizont_local.object_query_63.oo_id | 1 | Using where; Using index
1 | SIMPLE | objects | eq_ref | PRIMARY | PRIMARY | 4 | horizont_local.object_query_63.oo_id | 1 | Using where
1 | SIMPLE | orderRelations | ALL | forward_lookup,reverse_lookup,fieldname | NULL | NULL | NULL | 17228 | Using where; Using join buffer (flat, BNL join)
1 | SIMPLE | orders | eq_ref | PRIMARY | PRIMARY | 4 | horizont_local.orderRelations.src_id | 1 | Using where
1 | SIMPLE | orderItems | eq_ref | PRIMARY | PRIMARY | 4 | horizont_local.orderRelations.dest_id | 1 | Using where

Runtime: 54 seconds


__With this PR__

id | select_type | table | type | possible_keys | key | key_len | ref | rows | Extra
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | SIMPLE | orders | range | PRIMARY,p_index_orderDate | p_index_orderDate | 9 | NULL | 16 | Using index condition; Using where; Using temporary; Using filesort
1 | SIMPLE | orderRelations | ref | forward_lookup,reverse_lookup,fieldname | forward_lookup | 4 | horizont_local.orders.oo_id | 3 | Using where
1 | SIMPLE | orderItems | eq_ref | PRIMARY | PRIMARY | 4 | horizont_local.orderRelations.dest_id | 1 | Using where
1 | SIMPLE | localizedCategories | ALL | PRIMARY | NULL | NULL | NULL | 955 | Using join buffer (flat, BNL join)
1 | SIMPLE | object_query_63 | eq_ref | PRIMARY | PRIMARY | 4 | horizont_local.localizedCategories.ooo_id | 1 | Using index
1 | SIMPLE | catProductDependencies | ref | combi | combi | 5 | const,horizont_local.localizedCategories.ooo_id | 1 | Using where; Using index
1 | SIMPLE | objects | eq_ref | PRIMARY | PRIMARY | 4 | horizont_local.localizedCategories.ooo_id | 1 | Using where

Runtime: 0.129 seconds