### PR TITLE
Prevent error when adding new store without currency

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/CoreExtension/StoreValues.php
+++ b/src/CoreShop/Bundle/CoreBundle/CoreExtension/StoreValues.php
@@ -624,10 +624,12 @@ class StoreValues extends Model\DataObject\ClassDefinition\Data implements
                 continue;
             }
 
+            $currency = $store->getCurrency();
+
             //Fill missing stores with empty values
             $storeData[$store->getId()] = [
                 'name' => $store->getName(),
-                'currencySymbol' => $store->getCurrency()->getSymbol(),
+                'currencySymbol' => $currency?->getSymbol() ?? '',
                 'values' => ['price' => 0],
                 'inheritable' => $inheritable,
             ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

When a data object class uses field type `Store Values`, the store may not have a currency set yet.

Steps to reproduce bug:
1. Create product
2. Create new store (it gets created without currency - required field check is only done afterwards when editing existing store
3. Open product from 1.
You will get the error `Uncaught Error: Call to a member function getSymbol() on null`
