### PR TITLE
[IndexBundle] process children within same Handler

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -8,6 +8,7 @@
         <directory name="src" />
         <ignoreFiles>
             <file name="src/Kernel.php" />
+            <file name="src/CoreShop/Bundle/ResourceBundle/Doctrine/ORM/EntityMerger.php" />
 
             <directory name="src/CoreShop/Component/Resource/DataHub" />
             <directory name="src/CoreShop/Bundle/*/DataHub" />

--- a/src/CoreShop/Bundle/IndexBundle/Resources/config/services/messenger.yml
+++ b/src/CoreShop/Bundle/IndexBundle/Resources/config/services/messenger.yml
@@ -5,6 +5,5 @@ services:
     CoreShop\Bundle\IndexBundle\Messenger\Handler\IndexMessageHandler:
         arguments:
             - '@CoreShop\Component\Index\Service\IndexUpdaterServiceInterface'
-            - '@messenger.default_bus'
         tags:
             - { name: messenger.message_handler }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  |no
| BC breaks?    | no
| Deprecations? |no

Improves performance. It is faster to handle children in the same Handler, than to lock the Doctrine Messenger Table
