### PR TITLE
use correct parent for virtual object active state

### DIFF
--- a/src/CoreShop/Bundle/IndexBundle/Worker/AbstractWorker.php
+++ b/src/CoreShop/Bundle/IndexBundle/Worker/AbstractWorker.php
@@ -103,7 +103,7 @@ abstract class AbstractWorker implements WorkerInterface
             }
 
             $virtualObjectId = $parent->getId();
-            $virtualObjectActive = $parent->getIndexableEnabled($index);
+            $virtualObjectActive = $parent instanceof IndexableInterface ? $parent->getIndexableEnabled($index) : false;
         }
 
         $data = [

--- a/src/CoreShop/Bundle/IndexBundle/Worker/AbstractWorker.php
+++ b/src/CoreShop/Bundle/IndexBundle/Worker/AbstractWorker.php
@@ -103,7 +103,7 @@ abstract class AbstractWorker implements WorkerInterface
             }
 
             $virtualObjectId = $parent->getId();
-            $virtualObjectActive = $object->getIndexableEnabled($index);
+            $virtualObjectActive = $parent->getIndexableEnabled($index);
         }
 
         $data = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no
| Fixed tickets | --

