### PR TITLE
Move Cart Subtotal Calculation To Dedicated Cart Processor

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services/cart-processor.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services/cart-processor.yml
@@ -28,6 +28,10 @@ services:
         tags:
             - { name: coreshop.cart_processor, priority: 600 }
 
+    CoreShop\Component\Core\Order\Processor\CartSubtotalProcessor:
+        tags:
+            - { name: coreshop.cart_processor, priority: 580 }
+
     CoreShop\Component\Core\Order\Processor\CartItemsWholesaleProcessor:
         arguments:
             - '@CoreShop\Component\Order\Calculator\PurchasableWholesalePriceCalculatorInterface'

--- a/src/CoreShop/Component/Core/Order/Processor/CartItemsProcessor.php
+++ b/src/CoreShop/Component/Core/Order/Processor/CartItemsProcessor.php
@@ -44,9 +44,6 @@ final class CartItemsProcessor implements CartProcessorInterface
     {
         $context = $this->cartContextResolver->resolveCartContext($cart);
 
-        $subtotalGross = 0;
-        $subtotalNet = 0;
-
         /**
          * @var OrderItemInterface $item
          */
@@ -121,14 +118,6 @@ final class CartItemsProcessor implements CartProcessorInterface
                 $itemDiscount,
                 $context,
             );
-
-            $subtotalGross += $item->getTotal(true);
-            $subtotalNet += $item->getTotal(false);
         }
-
-        $cart->setSubtotal($subtotalGross, true);
-        $cart->setSubtotal($subtotalNet, false);
-
-        $cart->recalculateAdjustmentsTotal();
     }
 }

--- a/src/CoreShop/Component/Core/Order/Processor/CartSubtotalProcessor.php
+++ b/src/CoreShop/Component/Core/Order/Processor/CartSubtotalProcessor.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CoreShop
+ *
+ * This source file is available under two different licenses:
+ *  - GNU General Public License version 3 (GPLv3)
+ *  - CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.org)
+ * @license    https://www.coreshop.org/license     GPLv3 and CCL
+ *
+ */
+
+namespace CoreShop\Component\Core\Order\Processor;
+
+use CoreShop\Component\Core\Model\OrderItemInterface;
+use CoreShop\Component\Order\Model\OrderInterface;
+use CoreShop\Component\Order\Processor\CartProcessorInterface;
+
+final class CartSubtotalProcessor implements CartProcessorInterface
+{
+    public function process(OrderInterface $cart): void
+    {
+        $subtotalGross = 0;
+        $subtotalNet = 0;
+
+        /**
+         * @var OrderItemInterface $item
+         */
+        foreach ($cart->getItems() as $item) {
+            $subtotalGross += $item->getTotal(true);
+            $subtotalNet += $item->getTotal(false);
+        }
+
+        $cart->setSubtotal($subtotalGross, true);
+        $cart->setSubtotal($subtotalNet, false);
+
+        $cart->recalculateAdjustmentsTotal();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | --

This PR allows adding custom cart processors between `CartItemsProcessor` and cart subtotal calculation (`CartSubtotalProcessor`).

Otherwise, it is not possible to add custom adjustments **before** the subtotal **and** adjustments of the cart gets calculated.
