### PR TITLE
improve payment detail rendering

### DIFF
--- a/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/order/editPayment.js
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/public/pimcore/js/order/editPayment.js
@@ -74,9 +74,18 @@ coreshop.order.order.editPayment = {
                         viewConfig: {
                         enableTextSelection: true
                         },
-                        store: new Ext.data.ArrayStore({
+                        features: [{
+                            ftype: 'rowbody',
+                            getAdditionalData: function(data, idx, record, orig) {
+                                return {
+                                    rowBody: '<div>' + record.get('detail') + '</div>',
+                                    rowBodyCls: record.get('detail') === null ? 'x-hidden' : ''
+                                };
+                            }
+                        }],
+                        store: new Ext.data.Store({
                             data: payment.get('details'),
-                            fields: ['name', 'value']
+                            fields: ['name', 'value', 'detail']
                         }),
                         columns: [
                             {
@@ -88,7 +97,7 @@ coreshop.order.order.editPayment = {
                                 text: 'Value',
                                 dataIndex: 'value',
                                 flex: 2,
-                                renderer: function arg(val, test, test2){
+                                renderer: function arg(val){
                                     return '<div style="white-space: normal;">' + val + '</div>';
                                 }
                             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecation? | no
| Fixed tickets | --

If your payment gateway provides nested details in given payments, the `order/detail` fetch will break (`Warning: Array to string conversion`)

This PR improves the detail grid view, if a detail value is not a simple array, it will be added as JSON encoded data to the grid (row body):

![image](https://user-images.githubusercontent.com/700119/218052377-f9652f2f-eeb0-430a-97b0-b598322c5909.png)
 