### PR TITLE
Throw exception if site store isnt found in SiteBasedRequestResolver

### DIFF
--- a/src/CoreShop/Component/Store/Context/RequestBased/SiteBasedRequestResolver.php
+++ b/src/CoreShop/Component/Store/Context/RequestBased/SiteBasedRequestResolver.php
@@ -34,15 +34,19 @@ final class SiteBasedRequestResolver implements RequestResolverInterface
     public function findStore(Request $request): ?StoreInterface
     {
         if (Site::isSiteRequest()) {
-            return $this->storeRepository->findOneBySite(Site::getCurrentSite()->getId());
+            $store = $this->storeRepository->findOneBySite(Site::getCurrentSite()->getId());
+
+            if ($store === null) {
+                throw new StoreNotFoundException();
+            }
+            return $store;
         }
 
         $defaultStore = $this->storeRepository->findStandard();
 
-        if (null === $defaultStore) {
-            throw new StoreNotFoundException();
+        if ($defaultStore) {
+            return $defaultStore;
         }
-
-        return $defaultStore;
+        throw new StoreNotFoundException();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

If you have a custom resolver with a priority lower than SiteBasedRequestResolver and are inside a request flagged as site request it will never come so far as it will return `null` instead of erroring