### PR TITLE
Require at least php 8 via composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,6 +84,7 @@
     "coreshop/messenger-bundle": "self.version"
   },
   "require": {
+    "php": "^8.0",
     "ext-json": "*",
     "dachcom-digital/emailizr": "^2.0.0",
     "doctrine/data-fixtures": "^1.5",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Coreshop uses PHP8 language features and therefore should require it via `composer.json`.
This also has the nice benefit that at least in PHPStorm the language level is automatically pushed up to 8.0