### PR TITLE
fix: added event.js on ResourceBundle

### DIFF
--- a/src/CoreShop/Bundle/ResourceBundle/Resources/config/pimcore/admin.yml
+++ b/src/CoreShop/Bundle/ResourceBundle/Resources/config/pimcore/admin.yml
@@ -24,6 +24,7 @@ core_shop_resource:
             selector_object: '/bundles/coreshopresource/pimcore/js/selector/object.js'
             selector_selector: '/bundles/coreshopresource/pimcore/js/selector/selector.js'
             resource_creation: '/bundles/coreshopresource/pimcore/js/resource/creation.js'
+            events: '/bundles/coreshopresource/pimcore/js/events.js'
         css:
             resource: '/bundles/coreshopresource/pimcore/css/resource.css'
         editmode_js:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #2189 

Added event.js on ResourceBundle to avoid an undefined event if using the ResourceBundle standalone