### PR TITLE
Make URL slugs overwritable

### DIFF
--- a/src/CoreShop/Component/Pimcore/Slug/DataObjectSlugGenerator.php
+++ b/src/CoreShop/Component/Pimcore/Slug/DataObjectSlugGenerator.php
@@ -70,8 +70,10 @@ class DataObjectSlugGenerator implements DataObjectSlugGeneratorInterface
                             // $existingSlug is the slug to be saved from backend
                             $dbSlug = null;
                             if($sluggable instanceof Concrete) {
+                                /** @psalm-suppress InternalMethod */
                                 $dbSlug = $sluggable->retrieveSlugData(['fieldname' => 'slug', 'ownertype' => 'object', 'position' => $language, 'siteId' => $existingSlug->getSiteId()])[0]['slug'] ?? null;
                                 if ($dbSlug === null) {
+                                    /** @psalm-suppress InternalMethod */
                                     $dbSlug = $sluggable->retrieveSlugData(['fieldname' => 'slug', 'ownertype' => 'object', 'position' => $language])[0]['slug'] ?? null; // fallback slug
                                 }
                             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? |no

Currently the URL slugs are always regenerated during saving. There is no way to manually change a URL. 
Even worse, in https://github.com/coreshop/CoreShop/blob/75d7f0b2e8d72b9537c948d896c8e6d2e27bd356/src/CoreShop/Component/Pimcore/Slug/DataObjectSlugGenerator.php#L67-L68
`$newSlug` is the generated one and `$existingSlug` is the one which may have been changed with the objects setter method (`$sluggable->setSlug()`). 
Example:
I have a product with `name=my product` and set the slug in the pimcore backend to be `/en/product-123`. When this gets saved, the slug `/en/my-product` gets generated. With above code not only the manually set slug gets reset to `/en/my-product` but moreover there will also be a redirect generated for `/en/product-123` to `/en/my-product`.

With this PR the URL slug gets generated if none exists but it does not use the generated one when there already is a slug set.