### PR TITLE
Fix multiselect filter when work with array

### DIFF
--- a/src/CoreShop/Component/Index/Filter/MultiselectFilterConditionProcessor.php
+++ b/src/CoreShop/Component/Index/Filter/MultiselectFilterConditionProcessor.php
@@ -53,7 +53,7 @@ class MultiselectFilterConditionProcessor implements FilterConditionProcessorInt
 
         $currentFilter[$field] = $values;
 
-        if ($values === static::EMPTY_STRING) {
+        if ($values === static::EMPTY_STRING || [] === $values) {
             $values = null;
         }
 

--- a/src/CoreShop/Component/Index/Filter/MultiselectFilterConditionProcessor.php
+++ b/src/CoreShop/Component/Index/Filter/MultiselectFilterConditionProcessor.php
@@ -53,7 +53,7 @@ class MultiselectFilterConditionProcessor implements FilterConditionProcessorInt
 
         $currentFilter[$field] = $values;
 
-        if ($values === static::EMPTY_STRING || [] === $values) {
+        if ($values === static::EMPTY_STRING) {
             $values = null;
         }
 

--- a/src/CoreShop/Component/Index/Filter/SelectFilterConditionFromMultiselectProcessor.php
+++ b/src/CoreShop/Component/Index/Filter/SelectFilterConditionFromMultiselectProcessor.php
@@ -56,10 +56,17 @@ class SelectFilterConditionFromMultiselectProcessor implements FilterConditionPr
             }
         }
 
+        /** @var $currentValue int|string|array|null */
+        $currentValue = $currentFilter[$field] ?? null;
+
+        if (is_string($currentValue)) {
+            $currentValue = trim($currentValue, ',');
+        }
+
         return [
             'type' => 'select',
             'label' => $condition->getLabel(),
-            'currentValue' => isset($currentFilter[$field]) ? trim($currentFilter[$field], ',') : null,
+            'currentValue' => $currentValue,
             'values' => array_values($values),
             'fieldName' => $field,
             'quantityUnit' => $condition->getQuantityUnit() ? Unit::getById($condition->getQuantityUnit()) : null,

--- a/src/CoreShop/Component/Index/Filter/SelectFilterConditionFromMultiselectProcessor.php
+++ b/src/CoreShop/Component/Index/Filter/SelectFilterConditionFromMultiselectProcessor.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 
 namespace CoreShop\Component\Index\Filter;
 
+use CoreShop\Component\Index\Condition\InCondition;
 use CoreShop\Component\Index\Condition\LikeCondition;
 use CoreShop\Component\Index\Listing\ListingInterface;
 use CoreShop\Component\Index\Model\FilterConditionInterface;
@@ -87,17 +88,18 @@ class SelectFilterConditionFromMultiselectProcessor implements FilterConditionPr
         }
 
         if (!empty($value)) {
-            $value = ',' . $value . ',';
 
-            $currentFilter[$field] = $value;
+            $fieldName = $isPrecondition ? 'PRECONDITION_' . $field : $field;
 
-            $fieldName = $field;
+            if (is_array($value)) {
+                $list->addCondition(new InCondition($field, $value), $fieldName);
+            } else {
+                $value = ',' . $value . ',';
 
-            if ($isPrecondition) {
-                $fieldName = 'PRECONDITION_' . $fieldName;
+                $currentFilter[$field] = $value;
+
+                $list->addCondition(new LikeCondition($field, 'both', $value), $fieldName);
             }
-
-            $list->addCondition(new LikeCondition($field, 'both', $value), $fieldName);
         }
 
         return $currentFilter;

--- a/src/CoreShop/Component/Index/Filter/SelectFilterConditionFromMultiselectProcessor.php
+++ b/src/CoreShop/Component/Index/Filter/SelectFilterConditionFromMultiselectProcessor.php
@@ -57,7 +57,6 @@ class SelectFilterConditionFromMultiselectProcessor implements FilterConditionPr
             }
         }
 
-        /** @var $currentValue int|string|array|null */
         $currentValue = $currentFilter[$field] ?? null;
 
         if (is_string($currentValue)) {


### PR DESCRIPTION
There was a problem with the display of the multiselect filter on the frontend.
During the analysis, it turned out that the multiselect processor extracts all possible options for a specific field and then works with the array.
The current kernel code did not assume this.

I've made corrections to imply that the selected filter value can be not only a string or a number, but it can also be an array.