### PR TITLE
Check first if metatitle is not null before setting it SEO TitleExtractor

### DIFF
--- a/src/CoreShop/Component/SEO/Extractor/TitleExtractor.php
+++ b/src/CoreShop/Component/SEO/Extractor/TitleExtractor.php
@@ -36,6 +36,9 @@ final class TitleExtractor implements ExtractorInterface
          */
         Assert::isInstanceOf($object, SEOAwareInterface::class);
 
-        $seoMetadata->setTitle($object->getMetaTitle());
+        $title = $object->getMetaTitle();
+        if ($title !== null) {
+            $seoMetadata->setTitle($title);
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

MetaTitle can be null according to interface `CoreShop\Component\SEO\Model\SEOAwareInterface::getMetaTitle()` but `CoreShop\Component\SEO\Model\SEOMetadataInterface::setTitle()` always requires a string. This PR therefore adds a simple guard