### PR TITLE
Order subtotal is wrong when items has adjustments

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services/cart-processor.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services/cart-processor.yml
@@ -88,4 +88,4 @@ services:
         arguments:
             - '@CoreShop\Component\Currency\Converter\CurrencyConverterInterface'
         tags:
-            - { name: coreshop.cart_processor, priority: 100 }
+            - { name: coreshop.cart_processor, priority: 581 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

When an order item has adjustments, the total of the order item consists of the item price PLUS the adjumentment amounts, see https://github.com/coreshop/CoreShop/blob/19b01dd1576fdb5b6baca56d410c921972755e47/src/CoreShop/Component/Order/Model/OrderItem.php#L596-L600

In https://github.com/coreshop/CoreShop/blob/19b01dd1576fdb5b6baca56d410c921972755e47/src/CoreShop/Component/Core/Order/Processor/CartSubtotalProcessor.php#L25-L44 the subtotal of the order gets calculated by the total of the order items. The problem is that this cart processor has higher priority than the `CartCurrencyConversionProcessor` - and so the `CartSubtotalProcessor` gets processed before the `CartCurrencyConversionProcessor`. While the name does not make it immediately obvious this `CartCurrencyConversionProcessor` is responsible to add the item adjustments to their total:
1. The adjuments get looped in https://github.com/coreshop/CoreShop/blob/19b01dd1576fdb5b6baca56d410c921972755e47/src/CoreShop/Component/Core/Order/Processor/CartCurrencyConversionProcessor.php#L98-L106, `setAmount` gets called
2. https://github.com/coreshop/CoreShop/blob/19b01dd1576fdb5b6baca56d410c921972755e47/src/CoreShop/Component/Order/Model/Adjustment.php#L53 triggers recalculation of adjustments
3. via https://github.com/coreshop/CoreShop/blob/19b01dd1576fdb5b6baca56d410c921972755e47/src/CoreShop/Component/Order/Model/AdjustableTrait.php#L207 we get to https://github.com/coreshop/CoreShop/blob/19b01dd1576fdb5b6baca56d410c921972755e47/src/CoreShop/Component/Order/Model/OrderItem.php#L596-L600

In current state the subtotal of the order consists of the subtotal of the items WITHOUT their adjustments.

Here is a script to demonstrate the problem:
```php
<?php
use CoreShop\Component\Order\Cart\CartModifierInterface;
use CoreShop\Component\Order\Manager\CartManagerInterface;
use CoreShop\Component\Order\OrderInvoiceStates;
use CoreShop\Component\Order\OrderPaymentStates;
use CoreShop\Component\Order\OrderSaleStates;
use CoreShop\Component\Order\OrderShipmentStates;
use CoreShop\Component\Order\OrderStates;
use Pimcore\Model\DataObject\Fieldcollection;
use Pimcore\Model\DataObject\Fieldcollection\Data\CoreShopAdjustment;

$product = Pimcore\Model\DataObject\Product::getById(40211);
$cartItem = \Pimcore::getContainer()->get('coreshop.factory.order_item')->createWithPurchasable($product);
$cartItem->setQuantity(1);

$currency = \Pimcore::getContainer()->get('coreshop.repository.currency')->getByCode('EUR');
$store = \Pimcore::getContainer()->get('coreshop.repository.store')->findStandard();

$cart = new Pimcore\Model\DataObject\CoreShopOrder();
$cart->setKey(uniqid());
$cart->setPublished(true);
$cart->setSaleState(OrderSaleStates::STATE_CART);
$cart->setOrderState(OrderStates::STATE_INITIALIZED);
$cart->setShippingState(OrderShipmentStates::STATE_NEW);
$cart->setPaymentState(OrderPaymentStates::STATE_NEW);
$cart->setInvoiceState(OrderInvoiceStates::STATE_NEW);
$cart->setCurrency($currency);
$cart->setStore($store);

$contextResolver = \Pimcore::getContainer()->get('CoreShop\Component\Order\Cart\CartContextResolverInterface');
$contextResolver->resolveCartContext($cart);


$adjustments = new Fieldcollection();

$adjustment = new CoreShopAdjustment();
$adjustment->setTypeIdentifier('adjustment');
$adjustment->setLabel('adjustment');

$price = 1000;

$adjustment->setPimcoreAmountNet($price);

$rate = 19;
$adjustment->setPimcoreAmountGross($price + $price*$rate/100);

$adjustments->add($adjustment);

$cartItem->setAdjustmentItems($adjustments);

\Pimcore::getContainer()->get(CartModifierInterface::class)->addToList($cart, $cartItem);
\Pimcore::getContainer()->get(CartManagerInterface::class)->persistCart($cart);

dump($cart->getSubtotal(false));

foreach($cart->getItems() as $item) {
    dump($item->getTotal(false));
}
```
The outputs are different. 
Of course it is not immediately obvious that an order's subtotal should equal the sum of the order item totals (and not the order item subtotals). But with the current approach the order item adjustments are simply ignored when calculating order subtotals (and follow-up calculations).

Current result:
<img width="1132" alt="Снимок экрана 2023-04-13 в 18 41 57" src="https://user-images.githubusercontent.com/8749138/231820052-695ca24b-861b-437c-99d9-380cf80b4288.png">

Expected result:
<img width="1135" alt="Снимок экрана 2023-04-13 в 18 36 41" src="https://user-images.githubusercontent.com/8749138/231820159-0c741185-faf2-475a-85a2-cc908410ca18.png">
