### PR TITLE
Adjusted locale switcher for internal shop pages without translations

### DIFF
--- a/src/CoreShop/Bundle/FrontendBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/config/services.yml
@@ -21,6 +21,7 @@ services:
             - '@Pimcore\Model\Document\Service'
             - '@CoreShop\Component\Core\Context\ShopperContextInterface'
             - '@Symfony\Component\HttpFoundation\RequestStack'
+            - '@service_container'
         tags:
             - { name: twig.extension }
 

--- a/src/CoreShop/Bundle/FrontendBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/config/services.yml
@@ -21,7 +21,7 @@ services:
             - '@Pimcore\Model\Document\Service'
             - '@CoreShop\Component\Core\Context\ShopperContextInterface'
             - '@Symfony\Component\HttpFoundation\RequestStack'
-            - '@service_container'
+            - '@router'
         tags:
             - { name: twig.extension }
 

--- a/src/CoreShop/Bundle/FrontendBundle/Twig/LocaleSwitcherExtension.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Twig/LocaleSwitcherExtension.php
@@ -92,7 +92,7 @@ final class LocaleSwitcherExtension extends AbstractExtension
                 $route = $this->getMainRequest()->attributes->get('_route');
                 $staticRoute = Staticroute::getByName($route);
                 $params = [];
-                if (strpos($staticRoute->getVariables(), '_locale')) {
+                if ( str_contains($staticRoute->getVariables(), '_locale') ) {
                     $params = ['_locale' => $language];
                 }
                 $link = $this->container->get('router')->generate($route, $params);

--- a/src/CoreShop/Bundle/FrontendBundle/Twig/LocaleSwitcherExtension.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Twig/LocaleSwitcherExtension.php
@@ -23,6 +23,7 @@ use CoreShop\Component\Pimcore\Slug\SluggableInterface;
 use Pimcore\Model\DataObject\Data\UrlSlug;
 use Pimcore\Model\Document;
 use Pimcore\Model\Site;
+use Pimcore\Model\Staticroute;
 use Pimcore\Tool;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -89,8 +90,12 @@ final class LocaleSwitcherExtension extends AbstractExtension
             $link = '';
             if ($this->getMainRequest()->attributes->get('pimcore_request_source') === 'staticroute') {
                 $route = $this->getMainRequest()->attributes->get('_route');
-                $link = $this->container->get('router')->generate($route, ['_locale' => $language]);
-
+                $staticRoute = Staticroute::getByName($route);
+                $params = [];
+                if (strpos($staticRoute->getVariables(), '_locale')) {
+                    $params = ['_locale' => $language];
+                }
+                $link = $this->container->get('router')->generate($route, $params);
             } else {
                 if ( isset($translations[$language]) ) {
                     $localizedDocument = Document::getById($translations[$language]);

--- a/src/CoreShop/Bundle/FrontendBundle/Twig/LocaleSwitcherExtension.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Twig/LocaleSwitcherExtension.php
@@ -28,6 +28,7 @@ use Pimcore\Tool;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\RouterInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -37,7 +38,7 @@ final class LocaleSwitcherExtension extends AbstractExtension
         private Document\Service $documentService,
         private ShopperContextInterface $shopperContext,
         private RequestStack $requestStack,
-        protected ContainerInterface $container,
+        private RouterInterface $router,
     ) {
     }
 
@@ -95,7 +96,7 @@ final class LocaleSwitcherExtension extends AbstractExtension
                 if ( str_contains($staticRoute->getVariables(), '_locale') ) {
                     $params = ['_locale' => $language];
                 }
-                $link = $this->container->get('router')->generate($route, $params);
+                $link = $this->router->generate($route, $params);
             } else {
                 if ( isset($translations[$language]) ) {
                     $localizedDocument = Document::getById($translations[$language]);

--- a/src/CoreShop/Bundle/FrontendBundle/Twig/LocaleSwitcherExtension.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Twig/LocaleSwitcherExtension.php
@@ -24,6 +24,7 @@ use Pimcore\Model\DataObject\Data\UrlSlug;
 use Pimcore\Model\Document;
 use Pimcore\Model\Site;
 use Pimcore\Tool;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Extension\AbstractExtension;
@@ -35,6 +36,7 @@ final class LocaleSwitcherExtension extends AbstractExtension
         private Document\Service $documentService,
         private ShopperContextInterface $shopperContext,
         private RequestStack $requestStack,
+        protected ContainerInterface $container,
     ) {
     }
 
@@ -84,16 +86,27 @@ final class LocaleSwitcherExtension extends AbstractExtension
                 continue;
             }
 
-            if (isset($translations[$language])) {
-                $localizedDocument = Document::getById($translations[$language]);
+            $link = '';
+            if ($this->getMainRequest()->attributes->get('pimcore_request_source') === 'staticroute') {
+                $route = $this->getMainRequest()->attributes->get('_route');
+                $link = $this->container->get('router')->generate($route, ['_locale' => $language]);
+
             } else {
-                $localizedDocument = Document::getByPath($target);
+                if ( isset($translations[$language]) ) {
+                    $localizedDocument = Document::getById($translations[$language]);
+                } else {
+                    $localizedDocument = Document::getByPath($target);
+                }
+
+                if ( $localizedDocument instanceof Document && $localizedDocument->getPublished() ) {
+                    $link = $localizedDocument->getFullPath();
+                }
             }
 
-            if ($localizedDocument instanceof Document && $localizedDocument->getPublished()) {
+            if (!empty($link)) {
                 $links[] = [
                     'language' => $language,
-                    'target' => $localizedDocument->getFullPath(),
+                    'target' => $link,
                     'displayLanguage' => \Locale::getDisplayLanguage($language, $language),
                 ];
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Existing locale switcher doesn't change locale for static route pages such as /shop/login, /shop/cart, /shop/customer/profile etc. This happens because `$document` in https://github.com/coreshop/CoreShop/blob/738d977fea986e9ab13145c53b25ee00ed84f454/src/CoreShop/Bundle/FrontendBundle/Twig/LocaleSwitcherExtension.php#L50 relates to the document whose leftmost path matches the current URL. When you only have `/shop` as document but the remaining CoreShop pages are handled via static routes, even a request for `/shop/login` will have `$document = /shop`. Of course this document may have translations and so the wrong links get created.

This PR checks if a static route has been used for current request. In this case links for this static route (but for other locale) will get created. This avoids having to add all internal shop pages as Pimcore Documents.
