### PR TITLE
Support "store" field type in grid

### DIFF
--- a/src/CoreShop/Bundle/StoreBundle/CoreExtension/Store.php
+++ b/src/CoreShop/Bundle/StoreBundle/CoreExtension/Store.php
@@ -35,7 +35,7 @@ class Store extends Select
      */
     public $fieldtype = 'coreShopStore';
 
-    /** @var array */
+    /** @var array|null */
     public $options = [];
 
     /** @var string */
@@ -63,7 +63,7 @@ class Store extends Select
 
     public function getOptionsProviderClass()
     {
-        return '@' . StoreOptionProvider::class;
+        return $this->optionsProviderClass;
     }
 
     public function getDataForGrid($data, $object = null, $params = [])

--- a/src/CoreShop/Bundle/StoreBundle/CoreExtension/Store.php
+++ b/src/CoreShop/Bundle/StoreBundle/CoreExtension/Store.php
@@ -20,6 +20,8 @@ namespace CoreShop\Bundle\StoreBundle\CoreExtension;
 
 use CoreShop\Bundle\ResourceBundle\CoreExtension\Select;
 use CoreShop\Component\Store\Model\StoreInterface;
+use InvalidArgumentException;
+use Pimcore\Model\DataObject\ClassDefinition\Helper\OptionsProviderResolver;
 
 /**
  * @psalm-suppress InvalidReturnType, InvalidReturnStatement
@@ -32,6 +34,12 @@ class Store extends Select
      * @var string
      */
     public $fieldtype = 'coreShopStore';
+
+    /** @var array */
+    public $options = [];
+
+    /** @var string */
+    public $optionsProviderClass = '@'.StoreOptionProvider::class;
 
     protected function getRepository()
     {
@@ -56,5 +64,67 @@ class Store extends Select
     public function getOptionsProviderClass()
     {
         return '@' . StoreOptionProvider::class;
+    }
+
+    public function getDataForGrid($data, $object = null, $params = [])
+    {
+        $optionsProvider = OptionsProviderResolver::resolveProvider(
+            $this->getOptionsProviderClass(),
+            OptionsProviderResolver::MODE_SELECT
+        );
+
+        if ($optionsProvider) {
+            $context = $params['context'] ?? [];
+            $context['object'] = $object;
+            if ($object) {
+                $context['class'] = $object->getClass();
+            }
+
+            $context['fieldname'] = $this->getName();
+            $options = $optionsProvider->{'getOptions'}($context, $this);
+            $this->setOptions($options);
+
+            if (isset($params['purpose']) && $params['purpose'] === 'editmode') {
+                $result = $data?->getId();
+            } else {
+                $result = ['value' => $data?->getId(), 'options' => $this->getOptions()];
+            }
+
+            return $result;
+        }
+
+        return $data?->getId();
+    }
+
+    /**
+     * @param array|null $options
+     *
+     * @return $this
+     */
+    public function setOptions(?array $options)
+    {
+        if (is_array($options)) {
+            $this->options = [];
+            foreach ($options as $option) {
+                $option = (array)$option;
+                if (!array_key_exists('key', $option) || !array_key_exists('value', $option)) {
+                    throw new InvalidArgumentException('Please provide select options as associative array with fields "key" and "value"');
+                }
+
+                $this->options[] = $option;
+            }
+        } else {
+            $this->options = null;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->options;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

If show a `coreShopStore` (store select) field in grid you'll get no data

<img width="941" alt="Снимок экрана 2023-04-27 в 17 02 21" src="https://user-images.githubusercontent.com/8749138/234887076-ec68d4ba-714e-4f48-a796-693c0f8e00b2.png">

This is because `CoreShop\Bundle\StoreBundle\CoreExtension\Store` class hasn't method `getDataForGrid`

This method with all dependent methods `setOptions` and `getOptions` was copied from https://github.com/pimcore/pimcore/blob/10.5/models/DataObject/ClassDefinition/Data/Select.php (because Coreshop does not extend Pimcore's Select field type)
Only return data was changed from `return $data;` to `return $data?->getId();` because the getter returns a `Store` object via https://github.com/coreshop/CoreShop/blob/bb483e7279ac28af236caf8e8ff96001661cf70f/src/CoreShop/Bundle/ResourceBundle/CoreExtension/Select.php#L186

The most important point why it did not work is that in
https://github.com/pimcore/pimcore/blob/a5b86f3f9a63ac76282acee00879fb52b416a4ce/bundles/AdminBundle/Resources/public/js/pimcore/object/tags/select.js#L99
`field.layout.optionsProviderClass` is checked. This refers to a public field `optionsProviderClass` in the Store PHP class which did not exist before (only the `getOptionsProviderClass()` existed) and caused a JS error because of accessing a non-existing object property.

With this PR it looks like this
<img width="469" alt="Снимок экрана 2023-04-27 в 17 04 10" src="https://user-images.githubusercontent.com/8749138/234889699-d495566c-5890-4038-aa5e-054f7d93c862.png">