### PR TITLE
Handle unknown class names in ClassUpdate

### DIFF
--- a/src/CoreShop/Component/Pimcore/DataObject/ClassUpdate.php
+++ b/src/CoreShop/Component/Pimcore/DataObject/ClassUpdate.php
@@ -23,7 +23,7 @@ use Pimcore\Model\DataObject;
 
 class ClassUpdate extends AbstractDefinitionUpdate
 {
-    private DataObject\ClassDefinition $classDefinition;
+    private ?DataObject\ClassDefinition $classDefinition;
 
     public function __construct(
         string $className,


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Adjust ClassUpdate to allow $this->classDefinition to be assigned with null. Otherwise the assignment with the result of 
`DataObject\ClassDefinition::getByName($className)` may fail and the prepared null-check will not be reached.