### PR TITLE
changed jmsSerializer type from ArrayTransformerInterface to Serializ…

### DIFF
--- a/src/CoreShop/Bundle/OrderBundle/Controller/OrderController.php
+++ b/src/CoreShop/Bundle/OrderBundle/Controller/OrderController.php
@@ -56,6 +56,7 @@ use Pimcore\Model\User;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Workflow\StateMachine;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -67,7 +68,7 @@ class OrderController extends PimcoreController
 
     protected AddressFormatterInterface $addressFormatter;
 
-    protected ArrayTransformerInterface $jmsSerializer;
+    protected SerializerInterface $jmsSerializer;
 
     protected WorkflowStateInfoManagerInterface $workflowStateManager;
 
@@ -742,7 +743,7 @@ class OrderController extends PimcoreController
         $this->addressFormatter = $addressFormatter;
     }
 
-    public function setJmsSerializer(ArrayTransformerInterface $jmsSerializer): void
+    public function setJmsSerializer(SerializerInterface $jmsSerializer): void
     {
         $this->jmsSerializer = $jmsSerializer;
     }

--- a/src/CoreShop/Bundle/OrderBundle/Controller/OrderController.php
+++ b/src/CoreShop/Bundle/OrderBundle/Controller/OrderController.php
@@ -355,7 +355,7 @@ class OrderController extends PimcoreController
 
     protected function getDetails(OrderInterface $order): array
     {
-        $jsonSale = $this->jmsSerializer->toArray($order);
+        $jsonSale = json_decode($this->jmsSerializer->normalize($order, 'json'), true, 512, JSON_THROW_ON_ERROR);
 
         $jsonSale['o_id'] = $order->getId();
         $jsonSale['saleNumber'] = $order->getOrderNumber();
@@ -484,7 +484,7 @@ class OrderController extends PimcoreController
                 'cancel',
             ], false);
 
-            $data = $this->jmsSerializer->toArray($invoice);
+            $data = json_decode($this->jmsSerializer->normalize($invoice, 'json'), true, 512, JSON_THROW_ON_ERROR);
 
             $data['stateInfo'] = $this->workflowStateManager->getStateInfo('coreshop_invoice', $invoice->getState(), false);
             $data['transitions'] = $availableTransitions;
@@ -507,7 +507,7 @@ class OrderController extends PimcoreController
                 'cancel',
             ], false);
 
-            $data = $this->jmsSerializer->toArray($shipment);
+            $data = json_decode($this->jmsSerializer->normalize($shipment, 'json'), true, 512, JSON_THROW_ON_ERROR);
 
             $data['stateInfo'] = $this->workflowStateManager->getStateInfo('coreshop_shipment', $shipment->getState(), false);
             $data['transitions'] = $availableTransitions;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Adjusted OrderController according to JsonHelperTrait Pimcore using SerializerInterface instead of ArrayTransformerInterface
```
https://github.com/pimcore/pimcore/blob/81be9535e5b461fe045c0cce6cf3d94be92901bf/bundles/AdminBundle/Controller/AdminController.php#L34:36
```
```
abstract class AdminController extends UserAwareController implements AdminControllerInterface
{
    use JsonHelperTrait;
```
