### PR TITLE
improve unlinking files in pdf generation

### DIFF
--- a/src/CoreShop/Bundle/OrderBundle/Renderer/Pdf/WkHtmlToPdf.php
+++ b/src/CoreShop/Bundle/OrderBundle/Renderer/Pdf/WkHtmlToPdf.php
@@ -192,9 +192,17 @@ final class WkHtmlToPdf implements PdfRendererInterface
         return $pdfContent;
     }
 
-    private function unlinkFile($file): void
+    private function unlinkFile(?string $file): void
     {
-        @unlink($file);
+        if ($file === null) {
+            return;
+        }
+
+        if (!file_exists($file)) {
+            return;
+        }
+
+        unlink($file);
     }
 
     private function getWkHtmlToPdfBinary(): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

1. `$file` can be null, it is not allowed to pass `null`in `unlink`
2. Use `file_exists` instead of `@unlink` (see https://php.watch/versions/8.0/fatal-error-suppression)
