### PR TITLE
[SerializedData] show data as string  in version preview

### DIFF
--- a/src/CoreShop/Bundle/PimcoreBundle/CoreExtension/SerializedData.php
+++ b/src/CoreShop/Bundle/PimcoreBundle/CoreExtension/SerializedData.php
@@ -134,7 +134,9 @@ class SerializedData extends Model\DataObject\ClassDefinition\Data implements Mo
 
     public function getVersionPreview($data, $object = null, $params = [])
     {
-        return $this->getDataFromResource($data, $object, $params);
+        $data = $this->getDataFromResource($data, $object, $params);
+
+        return is_array($data) ? serialize($data) : '--';
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no


![image](https://github.com/coreshop/CoreShop/assets/700119/54d23dd1-9045-47d5-b59c-67398e1f8d25)

This one is quite old. Until now we always had to override the pimcore admin quicksearch object section, otherwise the exeption above will raise up when a cart (or now an order) object gets transformed for the version preview. However, besides us, it seems that no one else is using the pimcore quicksearch :)

This PR simply retturns again the serialized data:

![image](https://github.com/coreshop/CoreShop/assets/700119/c241d3e3-7c61-470e-be2e-42aba17404b6)

