### PR TITLE
[Docs] Maintenance mode <-> Maintenance job

### DIFF
--- a/docs/03_Development/04_Cart/05_Commands.md
+++ b/docs/03_Development/04_Cart/05_Commands.md
@@ -13,9 +13,9 @@ $ bin/console coreshop:cart:expire --user
 $ bin/console coreshop:cart:expire --days=20
 ```
 
-## Expire Abandoned Carts via Maintenance Mode
+## Expire Abandoned Carts via maintenance job
 By default, this feature is disabled.
-If you want to swipe abandoned carts by default you need to define a expiration date:
+If you want to delete abandoned carts, you need to define an expiration date:
 
 ```yml
 core_shop_order:


### PR DESCRIPTION
The main point about this PR is the heading *Expire Abandoned Carts via Maintenance Mode* - I think here it is meant that the carts get removed as a [maintenance job task](https://pimcore.com/docs/platform/Pimcore/Extending_Pimcore/Maintenance_Tasks/). 
[Maintenance mode](https://pimcore.com/docs/platform/Pimcore/Extending_Pimcore/Maintenance_Mode/) is something different.