### PR TITLE
Fix branch alias for 4.0 branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -174,7 +174,7 @@
     "symfony-assets-install": "relative",
     "branch-alias": {
       "dev-next": "4.0-dev",
-      "dev-master": "4.0-dev"
+      "dev-4.0": "4.0-dev"
     }
   },
   "config": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Allows composer to install the new default branch `4.0` as `4.0.x-dev`
