### PR TITLE
Bugfix listing order by

### DIFF
--- a/src/CoreShop/Bundle/IndexBundle/Worker/MysqlWorker/Listing.php
+++ b/src/CoreShop/Bundle/IndexBundle/Worker/MysqlWorker/Listing.php
@@ -434,7 +434,7 @@ class Listing extends AbstractListing implements OrderAwareListingInterface, Ext
         }
 
         foreach ($this->orders as $order) {
-            $queryBuilder->add('orderBy', $this->getWorker()->renderOrder($order, 'q'));
+            $queryBuilder->add('orderBy', $this->getWorker()->renderOrder($order, 'q'), true);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no


Currently adding multiple "order by" expressions via `addOrder()` is not possible as they overwrite each other:
```php
/** @var \CoreShop\Bundle\IndexBundle\Worker\MysqlWorker\Listing $listing */
$filteredList->addOrder(new SimpleOrder('isTopProduct', 'desc'));
$filteredList->addOrder(new SimpleOrder($sortParsed['name'], $sortParsed['direction']));
```

With this PR the expressions get added correctly.