### PR TITLE
[Order expiration] Use orderDate for confirmed orders, not o_creationDate

### DIFF
--- a/src/CoreShop/Bundle/OrderBundle/Pimcore/Repository/OrderRepository.php
+++ b/src/CoreShop/Bundle/OrderBundle/Pimcore/Repository/OrderRepository.php
@@ -186,7 +186,7 @@ class OrderRepository extends PimcoreRepository implements OrderRepositoryInterf
         $daysTimestamp = Carbon::now();
         $daysTimestamp->subDays($days);
 
-        $conditions = ['o_creationDate < ? AND saleState = ? AND orderState IN (?, ?, ?) AND paymentState <> ?'];
+        $conditions = ['IFNULL(orderDate,o_creationDate) < ? AND saleState = ? AND orderState IN (?, ?, ?) AND paymentState <> ?'];
         $params = [];
         $params[] = $daysTimestamp->getTimestamp();
         $params[] = OrderSaleStates::STATE_ORDER;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Carts and Orders use the same objects. The difference is only the value in the field `saleState`=`order`. When a user has a cart and then 2 weeks later comes back and checks out the cart (especially with an asynchronous payment method), the order will immediately get `cancelled` because 
https://github.com/BlackbitDevs/CoreShop/blob/4e954aea3ff037fcaaa029a3d42a3cbc71ae2558/src/CoreShop/Bundle/OrderBundle/Pimcore/Repository/OrderRepository.php#L189-L196
is based on `o_creationDate`.

With this PR, expiration gets based on `orderDate` if it is filled (so if the order is confirmed) and `o_creationDate` if it is a cart.