### PR TITLE
"apply CacheResourceMarshaller to doctrine_dbal adapter, add cache marshaller to MoneyCurrency

### DIFF
--- a/src/CoreShop/Bundle/ResourceBundle/DependencyInjection/Compiler/PimcoreCachePass.php
+++ b/src/CoreShop/Bundle/ResourceBundle/DependencyInjection/Compiler/PimcoreCachePass.php
@@ -30,6 +30,9 @@ final class PimcoreCachePass implements CompilerPassInterface
         $container->getDefinition('pimcore.cache.adapter.pdo')->setArgument(4, []);
         $container->getDefinition('pimcore.cache.adapter.pdo')->setArgument(5, new Reference(CacheResourceMarshaller::class));
 
+        $container->getDefinition('pimcore.cache.adapter.doctrine_dbal')->setArgument(4, []);
+        $container->getDefinition('pimcore.cache.adapter.doctrine_dbal')->setArgument(5, new Reference(CacheResourceMarshaller::class));
+
         $container->getDefinition('pimcore.cache.adapter.redis_tag_aware')->setArgument(4, new Reference(CacheResourceMarshaller::class));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | --

This PR fixes a quite huge memory issue, when it comes to cache marshalling of doctrine entities. Without it, out of memory exceptions will occur randomly while unserializing cache entries.

Background: In our case, we're dealing with large currency entities (lot of countries as relation for example), so we had cache entries up to 4-5mb each.

This PR fixes two things ( + performance bonus):
- Add CacheResourceMarshaller to `pimcore.cache.adapter.doctrine_dbal` Service
- Add marshalling to `MoneyCurrency`