### PR TITLE
[Cart] fix using right context for performance increase

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services/context.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services/context.yml
@@ -36,7 +36,7 @@ services:
 
     # country store resolver
     CoreShop\Component\Core\Context\StoreBasedCartContext:
-        decorates: CoreShop\Component\Order\Context\CartContext
+        decorates: CoreShop\Component\Order\Context\CompositeCartContext
         arguments:
             - '@CoreShop\Component\Core\Context\StoreBasedCartContext.inner'
             - '@CoreShop\Component\Core\Context\ShopperContextInterface'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

`StoreBasedCartContext` is used to set the Current Store and also cache the current Order, if not used, all the Contexts get called every single time.
