### PR TITLE
update composer package dachcom-digital/emailizr to ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
   "require": {
     "php": "^8.0",
     "ext-json": "*",
-    "dachcom-digital/emailizr": "^2.0.0 || ^3.0.0",
+    "dachcom-digital/emailizr": "^2.0 || ^3.0",
     "doctrine/data-fixtures": "^1.5",
     "doctrine/doctrine-bundle": "^2.4",
     "doctrine/doctrine-fixtures-bundle": "^3.4",

--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
   "require": {
     "php": "^8.0",
     "ext-json": "*",
-    "dachcom-digital/emailizr": "^3.0.0",
+    "dachcom-digital/emailizr": "^2.0.0 || ^3.0.0",
     "doctrine/data-fixtures": "^1.5",
     "doctrine/doctrine-bundle": "^2.4",
     "doctrine/doctrine-fixtures-bundle": "^3.4",

--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
   "require": {
     "php": "^8.0",
     "ext-json": "*",
-    "dachcom-digital/emailizr": "^2.0.0",
+    "dachcom-digital/emailizr": "^3.0.0",
     "doctrine/data-fixtures": "^1.5",
     "doctrine/doctrine-bundle": "^2.4",
     "doctrine/doctrine-fixtures-bundle": "^3.4",


### PR DESCRIPTION
dachcom-digital/emailizr ^2.0 requires "pelago/emogrifier": "^4.0 | ^5.0 | ^6.0" which requires "php": "~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0" => PHP 8.2 missing

dachcom-digital/emailizr ^3.0 requires "pelago/emogrifier": "^7.0" which requires "php": "~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0" => supports PHP 8.2

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | yes/no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->
