### PR TITLE
[Messenger] fix menu in standalone mode

### DIFF
--- a/src/CoreShop/Bundle/MessengerBundle/Resources/public/pimcore/js/resource_standalone.js
+++ b/src/CoreShop/Bundle/MessengerBundle/Resources/public/pimcore/js/resource_standalone.js
@@ -28,7 +28,7 @@ if (coreshop.resource === undefined) {
                 var item = e.detail.item;
                 var type = e.detail.type;
 
-                if (type === 'coreshop.messenger' && item.attributes.function === 'list') {
+                if (type === 'coreshop.coreshop' && item.id === 'coreshop_messenger' && item.attributes.function === 'list') {
                     me.openList();
                 }
             });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | https://github.com/coreshop/CoreShop/pull/2344#issuecomment-1764427020

With #2344 the way menus are loaded was changed, but this part was forgotten to be adjusted.
