### PR TITLE
Fix error in the filter functionality for multiselects

### DIFF
--- a/src/CoreShop/Component/Index/Filter/CategoryMultiSelectConditionProcessor.php
+++ b/src/CoreShop/Component/Index/Filter/CategoryMultiSelectConditionProcessor.php
@@ -90,7 +90,7 @@ class CategoryMultiSelectConditionProcessor implements FilterConditionProcessorI
             $field = 'parentCategoryIds';
         }
 
-        $values = $parameterBag->get($field);
+        $values = $parameterBag->all($field);
 
         if (empty($values)) {
             $values = $condition->getConfiguration()['preSelects'];

--- a/src/CoreShop/Component/Index/Filter/MultiselectFilterConditionFromMultiselectProcessor.php
+++ b/src/CoreShop/Component/Index/Filter/MultiselectFilterConditionFromMultiselectProcessor.php
@@ -71,7 +71,7 @@ class MultiselectFilterConditionFromMultiselectProcessor implements FilterCondit
     public function addCondition(FilterConditionInterface $condition, FilterInterface $filter, ListingInterface $list, array $currentFilter, ParameterBag $parameterBag, bool $isPrecondition = false): array
     {
         $field = $condition->getConfiguration()['field'];
-        $values = $parameterBag->get($field);
+        $values = $parameterBag->all($field);
 
         if (empty($values)) {
             $values = $condition->getConfiguration()['preSelects'];

--- a/src/CoreShop/Component/Index/Filter/MultiselectFilterConditionProcessor.php
+++ b/src/CoreShop/Component/Index/Filter/MultiselectFilterConditionProcessor.php
@@ -45,7 +45,7 @@ class MultiselectFilterConditionProcessor implements FilterConditionProcessorInt
     public function addCondition(FilterConditionInterface $condition, FilterInterface $filter, ListingInterface $list, array $currentFilter, ParameterBag $parameterBag, bool $isPrecondition = false): array
     {
         $field = $condition->getConfiguration()['field'];
-        $values = $parameterBag->get($field);
+        $values = $parameterBag->all($field);
 
         if (empty($values) && isset($condition->getConfiguration()['preSelects'])) {
             $values = $condition->getConfiguration()['preSelects'];

--- a/src/CoreShop/Component/Index/Filter/RelationalMultiselectConditionProcessor.php
+++ b/src/CoreShop/Component/Index/Filter/RelationalMultiselectConditionProcessor.php
@@ -57,7 +57,7 @@ class RelationalMultiselectConditionProcessor implements FilterConditionProcesso
     {
         $field = $condition->getConfiguration()['field'];
 
-        $values = $parameterBag->get($field);
+        $values = $parameterBag->all($field);
 
         if (empty($values) && isset($condition->getConfiguration()['preSelects'])) {
             $values = $condition->getConfiguration()['preSelects'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #2425

This PR fix an error in the filter functionality if you use any filter with multiple values (multiselects)

Since Symfony 6 we can't get a non scalar value form $parameterBag->get().
Symfony 5 triggered following deprecation note:

> Retrieving a non-scalar value from "$parameterBag->get()" is deprecated, and will throw a "%s" exception in Symfony 6.0, use "%s::all($key)" instead.

