### PR TITLE
change $request->query->get() to ->all()

### DIFF
--- a/src/CoreShop/Bundle/ResourceBundle/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
@@ -65,7 +65,7 @@ final class HttpFoundationRequestHandler implements RequestHandlerInterface
                     return;
                 }
 
-                $data = $request->query->get($name);
+                $data = $request->query->all($name);
             }
         } else {
             // Mark the form with an error if the uploaded size was too large


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #2429

Symfony changed the $parameterBag->get() method to scalar return values only.
