### PR TITLE
add missing cast to (int) for $page variable

### DIFF
--- a/src/CoreShop/Bundle/FrontendBundle/Controller/SearchController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/SearchController.php
@@ -46,7 +46,7 @@ class SearchController extends FrontendController
         if ($form->isSubmitted() && $form->isValid()) {
             $formData = $form->getData();
             $text = $formData['text'];
-            $page = $this->getParameterFromRequest($request, 'page', 1);
+            $page = (int) $this->getParameterFromRequest($request, 'page', 1);
             $itemsPerPage = 10;
 
             $query = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | didn't create a ticket

The paginator $page variable has to be an integer.
This should be the last fix for the SearchController, sorry about the fragmented PR's :)