### PR TITLE
[StorageListBundle] disable cache for StorageList and StorageListItem

### DIFF
--- a/src/CoreShop/Bundle/StorageListBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/StorageListBundle/DependencyInjection/Configuration.php
@@ -53,6 +53,7 @@ class Configuration implements ConfigurationInterface
                     ->useAttributeAsKey('name')
                     ->arrayPrototype()
                         ->children()
+                            ->booleanNode('disable_caching')->defaultFalse()->end()
                             ->arrayNode('context')
                                 ->addDefaultsIfNotSet()
                                 ->children()

--- a/src/CoreShop/Bundle/StorageListBundle/DependencyInjection/CoreShopStorageListExtension.php
+++ b/src/CoreShop/Bundle/StorageListBundle/DependencyInjection/CoreShopStorageListExtension.php
@@ -109,10 +109,13 @@ final class CoreShopStorageListExtension extends AbstractModelExtension
                 $container->setDefinition('coreshop.storage_list.session_subscriber.' . $name, $sessionSubscriber);
             }
 
-            $cacheSubscriber = new Definition(CacheListener::class, [
-                new Reference($list['resource']['repository']),
-                new Reference($list['resource']['item_repository'])
-            ]);
+            if ($list['disable_caching']) {
+                $cacheSubscriber = new Definition(CacheListener::class, [
+                    new Reference($list['resource']['repository']),
+                    new Reference($list['resource']['item_repository'])
+                ]);
+            }
+            
             $cacheSubscriber->addTag('kernel.event_subscriber');
 
             $container->setDefinition('coreshop.storage_list.cache_subscriber.' . $name, $cacheSubscriber);

--- a/src/CoreShop/Bundle/StorageListBundle/DependencyInjection/CoreShopStorageListExtension.php
+++ b/src/CoreShop/Bundle/StorageListBundle/DependencyInjection/CoreShopStorageListExtension.php
@@ -110,8 +110,8 @@ final class CoreShopStorageListExtension extends AbstractModelExtension
             }
 
             $cacheSubscriber = new Definition(CacheListener::class, [
-                new Reference(PimcoreContextResolver::class),
-                new Reference($contextCompositeServiceName),
+                new Reference($list['resource']['repository']),
+                new Reference($list['resource']['item_repository'])
             ]);
             $cacheSubscriber->addTag('kernel.event_subscriber');
 

--- a/src/CoreShop/Bundle/StorageListBundle/DependencyInjection/CoreShopStorageListExtension.php
+++ b/src/CoreShop/Bundle/StorageListBundle/DependencyInjection/CoreShopStorageListExtension.php
@@ -114,12 +114,11 @@ final class CoreShopStorageListExtension extends AbstractModelExtension
                     new Reference($list['resource']['repository']),
                     new Reference($list['resource']['item_repository'])
                 ]);
+
+                $cacheSubscriber->addTag('kernel.event_subscriber');
+                $container->setDefinition('coreshop.storage_list.cache_subscriber.' . $name, $cacheSubscriber);
             }
             
-            $cacheSubscriber->addTag('kernel.event_subscriber');
-
-            $container->setDefinition('coreshop.storage_list.cache_subscriber.' . $name, $cacheSubscriber);
-
             if ($list['controller']['enabled']) {
                 $class = $list['controller']['class'];
 

--- a/src/CoreShop/Bundle/StorageListBundle/EventListener/CacheListener.php
+++ b/src/CoreShop/Bundle/StorageListBundle/EventListener/CacheListener.php
@@ -41,7 +41,7 @@ final class CacheListener implements EventSubscriberInterface
 
     public function onKernelResponse(ResponseEvent $event): void
     {
-        Cache::addIgnoredTagOnSave(sprintf('object_%s', $this->storageListRepository->getClassId()));
-        Cache::addIgnoredTagOnSave(sprintf('object_%s', $this->storageListItemRepository->getClassId()));
+        Cache::addIgnoredTagOnSave(sprintf('class_%s', $this->storageListRepository->getClassId()));
+        Cache::addIgnoredTagOnSave(sprintf('class_%s', $this->storageListItemRepository->getClassId()));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? |no
| Fixed tickets | #2399

Problem is: In High Concurrency situtations, Pimcore loads the old cache entry since the new one isn't written yet. Completely disabling the cache for Order/OrderItem ist just a workaround...
