### PR TITLE
allow pending payments in checkout workflow

### DIFF
--- a/src/CoreShop/Bundle/OrderBundle/Resources/config/pimcore/workflow/coreshop_payment.yml
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/config/pimcore/workflow/coreshop_payment.yml
@@ -4,7 +4,7 @@ core_shop_workflow:
             callbacks:
                 after:
                   resolve_state:
-                      on: ['complete', 'refund', 'authorize']
+                      on: ['complete', 'process', 'refund', 'authorize']
                       do: ['@CoreShop\Bundle\OrderBundle\StateResolver\OrderPaymentStateResolver', 'resolve']
                       args: ['object.getOrder()']
                   add_to_history:

--- a/src/CoreShop/Bundle/OrderBundle/StateResolver/OrderPaymentStateResolver.php
+++ b/src/CoreShop/Bundle/OrderBundle/StateResolver/OrderPaymentStateResolver.php
@@ -100,6 +100,18 @@ final class OrderPaymentStateResolver implements StateResolverInterface
             return OrderPaymentTransitions::TRANSITION_PARTIALLY_AUTHORIZE;
         }
 
+        // Processing payments
+        $processingPaymentTotal = 0;
+        $processingPayments = $this->getPaymentsWithState($order, PaymentInterface::STATE_PROCESSING);
+
+        foreach ($processingPayments as $payment) {
+            $processingPaymentTotal += $payment->getTotalAmount();
+        }
+
+        if (count($processingPayments) > 0  && $processingPaymentTotal >= $order->getPaymentTotal()) {
+            return OrderPaymentTransitions::TRANSITION_REQUEST_PAYMENT;
+        }
+
         return null;
     }
 

--- a/src/CoreShop/Bundle/PayumBundle/Action/ConfirmOrderAction.php
+++ b/src/CoreShop/Bundle/PayumBundle/Action/ConfirmOrderAction.php
@@ -37,7 +37,8 @@ final class ConfirmOrderAction implements ActionInterface
         $payment = $request->getFirstModel();
         $order = $payment->getOrder();
         if ($payment->getState() === PaymentInterface::STATE_COMPLETED ||
-            $payment->getState() === PaymentInterface::STATE_AUTHORIZED
+            $payment->getState() === PaymentInterface::STATE_AUTHORIZED ||
+            $payment->getState() === PaymentInterface::STATE_PROCESSING
         ) {
             $this->stateMachineApplier->apply($order, OrderTransitions::IDENTIFIER, OrderTransitions::TRANSITION_CONFIRM);
 

--- a/src/CoreShop/Bundle/PayumBundle/Action/ResolveNextRouteAction.php
+++ b/src/CoreShop/Bundle/PayumBundle/Action/ResolveNextRouteAction.php
@@ -42,7 +42,8 @@ final class ResolveNextRouteAction implements ActionInterface
             ]);
 
             if ($payment->getState() === PaymentInterface::STATE_COMPLETED ||
-                $payment->getState() === PaymentInterface::STATE_AUTHORIZED
+                $payment->getState() === PaymentInterface::STATE_AUTHORIZED ||
+                $payment->getState() === PaymentInterface::STATE_PROCESSING
             ) {
                 $request->setRouteName('coreshop_checkout_thank_you');
                 $request->setRouteParameters([

--- a/src/CoreShop/Bundle/PayumBundle/Extension/UpdateOrderStateExtension.php
+++ b/src/CoreShop/Bundle/PayumBundle/Extension/UpdateOrderStateExtension.php
@@ -92,7 +92,8 @@ final class UpdateOrderStateExtension implements ExtensionInterface
         }
 
         if ($value === PaymentInterface::STATE_COMPLETED ||
-            $value === PaymentInterface::STATE_AUTHORIZED
+            $value === PaymentInterface::STATE_AUTHORIZED ||
+            $value === PaymentInterface::STATE_PROCESSING
         ) {
             $order = $payment->getOrder();
             $this->confirmOrderState($order);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | sort of
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #2478 

This PR allows pending payments (`PaymentInterface::STATE_PROCESSING`) in checkout:
- show thank-you page even if payment is in state "processing"
- respect process transition in OrderPaymentStateResolver
- allow state `PaymentInterface::STATE_PROCESSING` to dispatch order confirmation (from `new` to `confirmed`