### PR TITLE
use null coalescing operator against maxUsagePerUser

### DIFF
--- a/src/CoreShop/Component/Order/Cart/Rule/Condition/VoucherConditionChecker.php
+++ b/src/CoreShop/Component/Order/Cart/Rule/Condition/VoucherConditionChecker.php
@@ -45,7 +45,7 @@ class VoucherConditionChecker extends AbstractConditionChecker
         }
 
         $maxUsagePerCode = $configuration['maxUsagePerCode'];
-        $maxUsagePerUser = $configuration['maxUsagePerUser'] ?: null;
+        $maxUsagePerUser = $configuration['maxUsagePerUser'] ?? null;
         $onlyOnePerCart = $configuration['onlyOnePerCart'];
 
         $storedCode = $this->voucherCodeRepository->findByCode($voucher->getCode());

--- a/src/CoreShop/Component/Order/Modifier/VoucherModifier.php
+++ b/src/CoreShop/Component/Order/Modifier/VoucherModifier.php
@@ -74,7 +74,7 @@ class VoucherModifier implements VoucherModifierInterface
 
             foreach ($item->getCartPriceRule()?->getConditions() ?: [] as $conditions) {
                 if ($conditions->getType() === 'voucher') {
-                    $maxUsagePerCustomer = $conditions->getConfiguration()['maxUsagePerUser'];
+                    $maxUsagePerCustomer = $conditions->getConfiguration()['maxUsagePerUser'] ?? null;
 
                     if ($maxUsagePerCustomer !== null) {
                         $perCustomerEntry = $this->codePerUserRepository->findUsesByCustomer($customer, $voucherCode);
@@ -136,7 +136,7 @@ class VoucherModifier implements VoucherModifierInterface
 
             foreach ($item->getCartPriceRule()?->getConditions() ?: [] as $conditions) {
                 if ($conditions->getType() === 'voucher') {
-                    $maxUsagePerCustomer = $conditions->getConfiguration()['maxUsagePerUser'];
+                    $maxUsagePerCustomer = $conditions->getConfiguration()['maxUsagePerUser'] ?? null;
 
                     if ($maxUsagePerCustomer !== null) {
                         $perCustomerEntry = $this->codePerUserRepository->findUsesByCustomer($customer, $voucherCode);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | --


- Use null coalescing operator against `maxUsagePerUser` which is not available after updating coreshop on existing rules
- Do not use elvis operator since it's not safe against availability