### PR TITLE
[ProductBundle] default return empty array instead of null in preGetData

### DIFF
--- a/src/CoreShop/Bundle/ProductBundle/CoreExtension/ProductSpecificPriceRules.php
+++ b/src/CoreShop/Bundle/ProductBundle/CoreExtension/ProductSpecificPriceRules.php
@@ -107,7 +107,7 @@ class ProductSpecificPriceRules extends Data implements
             }
         }
 
-        return $data;
+        return $data ?? [];
     }
 
     public function createDataCopy(Concrete $object, mixed $data): mixed


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes/no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->
