### PR TITLE
Increase MessengerBundle Receivers combobox width

### DIFF
--- a/src/CoreShop/Bundle/MessengerBundle/Resources/public/pimcore/js/list.js
+++ b/src/CoreShop/Bundle/MessengerBundle/Resources/public/pimcore/js/list.js
@@ -136,6 +136,7 @@ coreshop.messenger.list = Class.create({
         var failureReceivers = Ext.create('Ext.form.ComboBox', {
             xtype: 'combo',
             fieldLabel: t('coreshop_messenger_failure_receivers'),
+            width: 400,
             mode: 'local',
             store: {
                 proxy: {
@@ -315,6 +316,7 @@ coreshop.messenger.list = Class.create({
         var receivers = Ext.create('Ext.form.ComboBox', {
             xtype: 'combo',
             fieldLabel: t('coreshop_messenger_receivers'),
+            width: 400,
             mode: 'local',
             store: {
                 proxy: {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | not really
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | none

This is just a visual change to increase the with of the box so that it contains longer message names such as `pimcore_search_backend_message`.

Before:
![image](https://github.com/coreshop/CoreShop/assets/279826/9d44235f-4073-407e-a864-c98b68cb4110)


After:
![image](https://github.com/coreshop/CoreShop/assets/279826/931c3282-dd0a-4135-bae0-e5544f287609)
