### PR TITLE
Fix store mail and store order mail collection entry type

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Form/Type/Notification/Action/StoreMailConfigurationType.php
+++ b/src/CoreShop/Bundle/CoreBundle/Form/Type/Notification/Action/StoreMailConfigurationType.php
@@ -21,7 +21,7 @@ namespace CoreShop\Bundle\CoreBundle\Form\Type\Notification\Action;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
-use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class StoreMailConfigurationType extends AbstractType
@@ -36,7 +36,7 @@ class StoreMailConfigurationType extends AbstractType
                 'entry_options' => [
                     'allow_add' => true,
                     'allow_delete' => true,
-                    'entry_type' => NumberType::class,
+                    'entry_type' => IntegerType::class,
                 ],
             ])
             ->add('doNotSendToDesignatedRecipient', CheckboxType::class)

--- a/src/CoreShop/Bundle/CoreBundle/Form/Type/Notification/Action/StoreOrderMailConfigurationType.php
+++ b/src/CoreShop/Bundle/CoreBundle/Form/Type/Notification/Action/StoreOrderMailConfigurationType.php
@@ -21,7 +21,7 @@ namespace CoreShop\Bundle\CoreBundle\Form\Type\Notification\Action;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
-use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class StoreOrderMailConfigurationType extends AbstractType
@@ -36,7 +36,7 @@ class StoreOrderMailConfigurationType extends AbstractType
                 'entry_options' => [
                     'allow_add' => true,
                     'allow_delete' => true,
-                    'entry_type' => NumberType::class,
+                    'entry_type' => IntegerType::class,
                 ],
             ])
             ->add('sendInvoices', CheckboxType::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | n/a

On PimCore 11.2 and PHP 8.2 I encountered this issue after trying to send a notification to the user.
```
13:20:18 WARNING   [messenger] Error thrown while handling message CoreShop\Component\Notification\Messenger\NotificationMessage. Sending for retry #2 using 600000 ms delay. Error: "Handling "CoreShop\Component\Notification\Messenger\NotificationMessage" failed: Pimcore\Model\Document::getById(): Argument #1 ($id) must be of type string|int, float given, called in /var/www/pimcore/vendor/coreshop/core-shop/src/CoreShop/Component/Notification/Rule/Action/MailActionProcessor.php on line 48" ["class" => "CoreShop\Component\Notification\Messenger\NotificationMessage","retryCount" => 2,"delay" => 600000,"error" => "Handling "CoreShop\Component\Notification\Messenger\NotificationMessage" failed: Pimcore\Model\Document::getById(): Argument #1 ($id) must be of type string|int, float given, called in /var/www/pimcore/vendor/coreshop/core-shop/src/CoreShop/Component/Notification/Rule/Action/MailActionProcessor.php on line 48","exception" => Symfony\Component\Messenger\Exception\HandlerFailedException { …}]
```
After my investigation, I found that serialized configuration data for documents in MySQL table is float instead of int.

