### PR TITLE
Index error if product does not have a store

### DIFF
--- a/src/CoreShop/Component/Core/Index/Extensions/ProductClassExtension.php
+++ b/src/CoreShop/Component/Core/Index/Extensions/ProductClassExtension.php
@@ -75,7 +75,7 @@ final class ProductClassExtension implements IndexColumnsExtensionInterface
             /**
              * @psalm-suppress InvalidArgument
              */
-            $stores = @implode(',', $indexable->getStores());
+            $stores = @implode(',', $indexable->getStores() ?? []);
 
             return [
                 'categoryIds' => ',' . implode(',', $categoryIds) . ',',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #...   none

If there is a product without a store, the coreshop:index fail with:
`implode(): Argument #1 ($array) must be of type array, string given`

