### PR TITLE
make password reset notification store aware

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/EventListener/NotificationRules/CustomerListener.php
+++ b/src/CoreShop/Bundle/CoreBundle/EventListener/NotificationRules/CustomerListener.php
@@ -143,6 +143,7 @@ final class CustomerListener extends AbstractNotificationRuleListener
     {
         return [
             '_locale' => $this->shopperContext->getLocaleCode(),
+            'store_id' => $this->shopperContext->getStore()->getId(),
             'recipient' => $user->getCustomer()->getEmail(),
             'gender' => $user->getCustomer()->getGender(),
             'firstname' => $user->getCustomer()->getFirstname(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | none

There is an error if you use the password reset notification with store based emails.
`Message with ID "62164" of Class "CoreShop\Component\Notification\Messenger\NotificationMessage" failed. Redelivery tried at "2024-04-19 11:47:40". Error was: "StoreMailActionProcessor: Store is not set."`
=> That's because the Customer is not an instance of StoreAwareInterface.

With this PR the store_id is added to the rules parameters.