### PR TITLE
[Composer] conflict twig/twig: ^3.9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -131,7 +131,8 @@
   },
   "conflict": {
     "jms/serializer-bundle": "4.1.0",
-    "league/csv": ">= 9.11"
+    "league/csv": ">= 9.11",
+    "twig/twig": "^3.9.0"
   },
   "suggest": {
     "dpfaffenbauer/process-manager": "Allows to start Processes from within Pimcore UI and also tracks the status."


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no

related to https://github.com/pimcore/demo/pull/575

This shows even more that the FrontendBundle needs to be a separate Bundle, CoreShop should not be conflicted with any Twig Version.
