### PR TITLE
reimplement existing data check in ProductQuantityPriceRulesCloner

### DIFF
--- a/src/CoreShop/Component/Core/Product/Cloner/ProductQuantityPriceRulesCloner.php
+++ b/src/CoreShop/Component/Core/Product/Cloner/ProductQuantityPriceRulesCloner.php
@@ -47,7 +47,7 @@ class ProductQuantityPriceRulesCloner implements ProductClonerInterface
         }
 
         $quantityPriceRules = $referenceProduct->getQuantityPriceRules();
-        $hasQuantityPriceRules = is_array($product->getQuantityPriceRules()) && count($product->getQuantityPriceRules()) > 0;
+        $hasQuantityPriceRules = count($product->getQuantityPriceRules()) > 0;
 
         if ($hasQuantityPriceRules === true && $resetExistingData === false) {
             return;

--- a/src/CoreShop/Component/Core/Product/Cloner/ProductQuantityPriceRulesCloner.php
+++ b/src/CoreShop/Component/Core/Product/Cloner/ProductQuantityPriceRulesCloner.php
@@ -47,6 +47,11 @@ class ProductQuantityPriceRulesCloner implements ProductClonerInterface
         }
 
         $quantityPriceRules = $referenceProduct->getQuantityPriceRules();
+        $hasQuantityPriceRules = is_array($product->getQuantityPriceRules()) && count($product->getQuantityPriceRules()) > 0;
+
+        if ($hasQuantityPriceRules === true && $resetExistingData === false) {
+            return;
+        }
 
         /**
          * @var Concrete&ProductInterface $referenceProduct


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes/no
| Fixed tickets | --

> [!CAUTION]
> This also needs to be fixed in 4.0!

This PR fixes the existing data check in `ProductQuantityPriceRulesCloner` which has been removed in 3.x here:

https://github.com/coreshop/CoreShop/commit/b6398adba4e8ff3c5832254776882eb89aa08654#diff-e962d096cbcf710b879a82241a724d669b979581a20b9ed4d828823620fa09cfL41

Otherwise, all defined quantity price rules in variants will be overwritten after dispatching this action:

![image](https://github.com/coreshop/CoreShop/assets/700119/aae82984-d063-4a82-b01a-eba409d93bb8)

