### PR TITLE
[ResourceBundle] Fix EntityMerger and cascade-merging

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,7 @@ x-php: &php
     # step debugging with `trigger`.
     # To configure PhpStorm for step-debugging with xdebug see: https://www.jetbrains.com/help/phpstorm/2021.3/zero-configuration-debugging.html#start-debugging-session
     # See: https://xdebug.org/docs/all_settings#mode
-    XDEBUG_MODE: debug,develop
+    XDEBUG_MODE: debug
     # This forces xdebug to always connect to the debug client running on docker host (host.docker.internal).
     # It will work without further configuration with [Docker Desktop](https://www.docker.com/products/docker-desktop).
     # See: https://xdebug.org/docs/all_settings#client_host

--- a/src/CoreShop/Bundle/CoreBundle/CoreExtension/StoreValues.php
+++ b/src/CoreShop/Bundle/CoreBundle/CoreExtension/StoreValues.php
@@ -474,14 +474,14 @@ class StoreValues extends Model\DataObject\ClassDefinition\Data implements
         foreach ($availableStoreValues as $availableStoreValuesEntity) {
             if (!in_array($availableStoreValuesEntity->getId(), $validStoreValues, true)) {
                 $this->getEntityManager()->remove($availableStoreValuesEntity);
-                $this->getEntityManager()->flush($availableStoreValuesEntity);
             }
         }
 
         foreach ($allStoreValues as $storeEntity) {
             $this->getEntityManager()->persist($storeEntity);
-            $this->getEntityManager()->flush($storeEntity);
         }
+
+        $this->getEntityManager()->flush();
 
         //We have to set that here, values could change during persist due to copy or variant inheritance break
         $object->setObjectVar($this->getName(), $allStoreValues);

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/doctrine/model/Country.orm.xml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/doctrine/model/Country.orm.xml
@@ -6,6 +6,7 @@
             <join-column name="currencyId" referenced-column-name="id" nullable="true"/>
             <cascade>
                 <cascade-persist/>
+                <cascade-merge/>
             </cascade>
         </many-to-one>
 

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/doctrine/model/ProductStoreValues.orm.xml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/doctrine/model/ProductStoreValues.orm.xml
@@ -16,6 +16,9 @@
 
         <many-to-one field="store" target-entity="CoreShop\Component\Store\Model\StoreInterface">
             <join-column name="store" referenced-column-name="id" on-delete="CASCADE"/>
+            <cascade>
+                <cascade-merge/>
+            </cascade>
         </many-to-one>
 
         <one-to-many field="productUnitDefinitionPrices" target-entity="CoreShop\Component\Core\Model\ProductUnitDefinitionPriceInterface" mapped-by="productStoreValues" orphan-removal="true">

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/doctrine/model/ProductStoreValues.orm.xml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/doctrine/model/ProductStoreValues.orm.xml
@@ -16,9 +16,6 @@
 
         <many-to-one field="store" target-entity="CoreShop\Component\Store\Model\StoreInterface">
             <join-column name="store" referenced-column-name="id" on-delete="CASCADE"/>
-            <cascade>
-                <cascade-merge/>
-            </cascade>
         </many-to-one>
 
         <one-to-many field="productUnitDefinitionPrices" target-entity="CoreShop\Component\Core\Model\ProductUnitDefinitionPriceInterface" mapped-by="productStoreValues" orphan-removal="true">

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/doctrine/model/ProductUnitDefinitionPrice.orm.xml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/doctrine/model/ProductUnitDefinitionPrice.orm.xml
@@ -5,6 +5,9 @@
 
         <many-to-one field="productStoreValues" target-entity="CoreShop\Component\Core\Model\ProductStoreValuesInterface" inversed-by="productUnitDefinitionPrices">
             <join-column name="product_store_values" referenced-column-name="id" on-delete="CASCADE"/>
+            <cascade>
+
+            </cascade>
         </many-to-one>
 
     </mapped-superclass>

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/doctrine/model/ProductUnitDefinitionPrice.orm.xml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/doctrine/model/ProductUnitDefinitionPrice.orm.xml
@@ -5,9 +5,6 @@
 
         <many-to-one field="productStoreValues" target-entity="CoreShop\Component\Core\Model\ProductStoreValuesInterface" inversed-by="productUnitDefinitionPrices">
             <join-column name="product_store_values" referenced-column-name="id" on-delete="CASCADE"/>
-            <cascade>
-
-            </cascade>
         </many-to-one>
 
     </mapped-superclass>

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/doctrine/model/ProductUnitDefinitionPrice.orm.xml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/doctrine/model/ProductUnitDefinitionPrice.orm.xml
@@ -5,9 +5,6 @@
 
         <many-to-one field="productStoreValues" target-entity="CoreShop\Component\Core\Model\ProductStoreValuesInterface" inversed-by="productUnitDefinitionPrices">
             <join-column name="product_store_values" referenced-column-name="id" on-delete="CASCADE"/>
-            <cascade>
-                <cascade-merge/>
-            </cascade>
         </many-to-one>
 
     </mapped-superclass>

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/doctrine/model/Store.orm.xml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/doctrine/model/Store.orm.xml
@@ -16,6 +16,9 @@
         </one-to-many>
 
         <many-to-many field="countries" target-entity="CoreShop\Component\Address\Model\CountryInterface" inversed-by="stores">
+            <cascade>
+                <cascade-merge/>
+            </cascade>
             <join-table name="coreshop_store_countries">
                 <join-columns>
                     <join-column name="store_id" referenced-column-name="id" nullable="false"/>

--- a/src/CoreShop/Bundle/ProductBundle/CoreExtension/ProductUnitDefinitions.php
+++ b/src/CoreShop/Bundle/ProductBundle/CoreExtension/ProductUnitDefinitions.php
@@ -364,7 +364,7 @@ class ProductUnitDefinitions extends Data implements
             $productUnitDefinitions->setProduct($object);
 
             $this->getEntityManager()->persist($productUnitDefinitions);
-            $this->getEntityManager()->flush($productUnitDefinitions);
+            $this->getEntityManager()->flush();
         }
     }
 
@@ -455,9 +455,12 @@ class ProductUnitDefinitions extends Data implements
         $defaultUnit = $data->getDefaultUnitDefinition() instanceof ProductUnitDefinitionInterface && $data->getDefaultUnitDefinition()->getUnit() instanceof ProductUnitInterface ? $data->getDefaultUnitDefinition()->getUnit()->getName() : '--';
 
         return sprintf(
-            'Default Unit: %s, additional units: %d',
+            'Default Unit: %s, additional units: %d (%s)',
             $defaultUnit,
             $data->getAdditionalUnitDefinitions()->count(),
+            implode(', ', array_map(static function(ProductUnitDefinitionInterface $unitDefinition) {
+                return sprintf('%s: %s %s', $unitDefinition->getId(), $unitDefinition->getConversionRate(), $unitDefinition->getUnitName());
+            }, $data->getUnitDefinitions()->toArray()))
         );
     }
 

--- a/src/CoreShop/Bundle/ProductBundle/CoreExtension/ProductUnitDefinitions.php
+++ b/src/CoreShop/Bundle/ProductBundle/CoreExtension/ProductUnitDefinitions.php
@@ -358,6 +358,9 @@ class ProductUnitDefinitions extends Data implements
         $productUnitDefinitions = $object->getObjectVar($this->getName());
 
         if ($productUnitDefinitions instanceof ProductUnitDefinitionsInterface) {
+            $entityMerger = new EntityMerger($this->getEntityManager());
+            $entityMerger->merge($productUnitDefinitions);
+
             $productUnitDefinitions->setProduct($object);
 
             $this->getEntityManager()->persist($productUnitDefinitions);
@@ -404,7 +407,19 @@ class ProductUnitDefinitions extends Data implements
         }
 
         $errors = [];
-        $unitDefinitionsEntity = $this->getProductUnitDefinitionsRepository()->findOneForProduct($object);
+        $productUnitDefinitionsValues = null;
+
+        $unitDefinitionsEntity = null;
+        $unitDefinitionsId = isset($data['id']) && is_numeric($data['id']) ? $data['id'] : null;
+
+        $tempEntityManager = $this->createTempEntityManager($this->getEntityManager());
+        $tempStoreValuesRepository = $this->getProductUnitDefinitionsRepositoryFactory()->createNewRepository($tempEntityManager);
+
+        Assert::isInstanceOf($tempStoreValuesRepository, ProductUnitDefinitionsRepositoryInterface::class);
+
+        if ($unitDefinitionsId !== null) {
+            $unitDefinitionsEntity = $tempStoreValuesRepository->findOneForProduct($object);
+        }
 
         $form = $this->getFormFactory()->createNamed('', ProductUnitDefinitionsType::class, $unitDefinitionsEntity);
 

--- a/src/CoreShop/Bundle/ProductBundle/CoreExtension/ProductUnitDefinitions.php
+++ b/src/CoreShop/Bundle/ProductBundle/CoreExtension/ProductUnitDefinitions.php
@@ -358,9 +358,6 @@ class ProductUnitDefinitions extends Data implements
         $productUnitDefinitions = $object->getObjectVar($this->getName());
 
         if ($productUnitDefinitions instanceof ProductUnitDefinitionsInterface) {
-            $entityMerger = new EntityMerger($this->getEntityManager());
-            $entityMerger->merge($productUnitDefinitions);
-
             $productUnitDefinitions->setProduct($object);
 
             $this->getEntityManager()->persist($productUnitDefinitions);
@@ -407,19 +404,7 @@ class ProductUnitDefinitions extends Data implements
         }
 
         $errors = [];
-        $productUnitDefinitionsValues = null;
-
-        $unitDefinitionsEntity = null;
-        $unitDefinitionsId = isset($data['id']) && is_numeric($data['id']) ? $data['id'] : null;
-
-        $tempEntityManager = $this->createTempEntityManager($this->getEntityManager());
-        $tempStoreValuesRepository = $this->getProductUnitDefinitionsRepositoryFactory()->createNewRepository($tempEntityManager);
-
-        Assert::isInstanceOf($tempStoreValuesRepository, ProductUnitDefinitionsRepositoryInterface::class);
-
-        if ($unitDefinitionsId !== null) {
-            $unitDefinitionsEntity = $tempStoreValuesRepository->findOneForProduct($object);
-        }
+        $unitDefinitionsEntity = $this->getProductUnitDefinitionsRepository()->findOneForProduct($object);
 
         $form = $this->getFormFactory()->createNamed('', ProductUnitDefinitionsType::class, $unitDefinitionsEntity);
 

--- a/src/CoreShop/Bundle/ProductBundle/Resources/config/doctrine/model/ProductSpecificPriceRule.orm.xml
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/config/doctrine/model/ProductSpecificPriceRule.orm.xml
@@ -32,7 +32,7 @@
                 </inverse-join-columns>
             </join-table>
             <cascade>
-                <cascade-all/>
+                <cascade-persist/>
             </cascade>
             <order-by>
                 <order-by-field name="sort" direction="ASC"/>
@@ -49,7 +49,7 @@
                 </inverse-join-columns>
             </join-table>
             <cascade>
-                <cascade-all/>
+                <cascade-persist/>
             </cascade>
             <order-by>
                 <order-by-field name="sort" direction="ASC"/>

--- a/src/CoreShop/Bundle/ProductBundle/Resources/config/doctrine/model/ProductUnitDefinition.orm.xml
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/config/doctrine/model/ProductUnitDefinition.orm.xml
@@ -15,17 +15,10 @@
 
         <many-to-one field="unit" target-entity="CoreShop\Component\Product\Model\ProductUnitInterface" fetch="EAGER">
             <join-column name="unit" referenced-column-name="id"/>
-            <cascade>
-                <cascade-merge/>
-            </cascade>
         </many-to-one>
 
         <many-to-one field="productUnitDefinitions" target-entity="CoreShop\Component\Product\Model\ProductUnitDefinitions" inversed-by="unitDefinitions">
             <join-column name="product_unit_definitions" referenced-column-name="id" on-delete="CASCADE"/>
-            <cascade>
-                <cascade-merge/>
-                <cascade-persist/>
-            </cascade>
         </many-to-one>
     </mapped-superclass>
 </doctrine-mapping>

--- a/src/CoreShop/Bundle/ProductBundle/Resources/config/doctrine/model/ProductUnitDefinitionPrice.orm.xml
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/config/doctrine/model/ProductUnitDefinitionPrice.orm.xml
@@ -12,7 +12,6 @@
         <many-to-one field="unitDefinition" target-entity="CoreShop\Component\Product\Model\ProductUnitDefinitionInterface">
             <join-column name="unit_definition" referenced-column-name="id" on-delete="CASCADE"/>
             <cascade>
-                <cascade-merge/>
                 <cascade-persist/>
             </cascade>
         </many-to-one>

--- a/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/config/doctrine/model/ProductQuantityPriceRule.orm.xml
+++ b/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/config/doctrine/model/ProductQuantityPriceRule.orm.xml
@@ -42,8 +42,7 @@
                      target-entity="CoreShop\Component\ProductQuantityPriceRules\Model\QuantityRangeInterface"
                      mapped-by="rule" orphan-removal="true" fetch="LAZY">
             <cascade>
-                <cascade-persist/>
-                <cascade-remove/>
+                <cascade-all/>
             </cascade>
             <order-by>
                 <order-by-field name="rangeStartingFrom" direction="ASC" />

--- a/src/CoreShop/Bundle/ResourceBundle/Doctrine/ORM/EntityMerger.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Doctrine/ORM/EntityMerger.php
@@ -330,6 +330,11 @@ class EntityMerger
                 $id = $relatedEntityClass->getIdentifierValues($relatedEntities);
                 $uwEntity = $this->em->getUnitOfWork()->tryGetById($id, $relatedEntityClass->getName());
 
+                //Entity might not be loaded and managed yet, try to load it
+                if (!$uwEntity) {
+                    $uwEntity = $this->em->find($relatedEntityClass->getName(), $id);
+                }
+
                 if ($uwEntity) {
                     $class->reflFields[$assoc['fieldName']]->setValue($entity, $uwEntity);
                 }

--- a/src/CoreShop/Bundle/ResourceBundle/Doctrine/ORM/EntityMerger.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Doctrine/ORM/EntityMerger.php
@@ -330,7 +330,9 @@ class EntityMerger
                 $id = $relatedEntityClass->getIdentifierValues($relatedEntities);
                 $uwEntity = $this->em->getUnitOfWork()->tryGetById($id, $relatedEntityClass->getName());
 
-                $class->reflFields[$assoc['fieldName']]->setValue($entity, $uwEntity);
+                if ($uwEntity) {
+                    $class->reflFields[$assoc['fieldName']]->setValue($entity, $uwEntity);
+                }
             }
         }
 

--- a/src/CoreShop/Bundle/ResourceBundle/Doctrine/ORM/EntityMerger.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Doctrine/ORM/EntityMerger.php
@@ -313,6 +313,10 @@ class EntityMerger
         foreach ($noMergeAssociationMappings as $assoc) {
             $relatedEntities = $class->reflFields[$assoc['fieldName']]->getValue($entity);
 
+            if (!$relatedEntities) {
+                continue;
+            }
+
             if ($relatedEntities instanceof Collection) {
                 //Reset Collection
                 $pColl = new PersistentCollection($this->em, $assoc['targetEntity'], new ArrayCollection());
@@ -320,7 +324,7 @@ class EntityMerger
                 $pColl->setInitialized(false);
 
                 $class->reflFields[$assoc['fieldName']]->setValue($entity, $pColl);
-            } elseif ($relatedEntities !== null) {
+            } else {
                 //Reset "tmp" entity with managed entity
                 $relatedEntityClass = $this->em->getClassMetadata($assoc['targetEntity']);
                 $id = $relatedEntityClass->getIdentifierValues($relatedEntities);

--- a/src/CoreShop/Bundle/ResourceBundle/Doctrine/ORM/EntityMerger.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Doctrine/ORM/EntityMerger.php
@@ -60,12 +60,21 @@ class EntityMerger
         }
 
         $visited[$oid] = $entity; // mark visited
+        $class = $this->em->getClassMetadata($entity::class);
 
         if ($entity instanceof Proxy && !$entity->__isInitialized()) {
-            $entity->__load();
+            $id = $class->getIdentifierValues($entity);
+
+            $uwEntity = $this->em->getUnitOfWork()->tryGetById($id, $class->getName());
+
+            if ($uwEntity) {
+                $entity = $uwEntity;
+            }
+            else {
+                $entity->__load();
+            }
         }
 
-        $class = $this->em->getClassMetadata($entity::class);
 
         if ($this->em->getUnitOfWork()->getEntityState($entity, UnitOfWork::STATE_DETACHED) !== UnitOfWork::STATE_MANAGED) {
             $id = $class->getIdentifierValues($entity);

--- a/src/CoreShop/Bundle/ResourceBundle/Doctrine/ORM/EntityMerger.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Doctrine/ORM/EntityMerger.php
@@ -63,16 +63,7 @@ class EntityMerger
         $class = $this->em->getClassMetadata($entity::class);
 
         if ($entity instanceof Proxy && !$entity->__isInitialized()) {
-            $id = $class->getIdentifierValues($entity);
-
-            $uwEntity = $this->em->getUnitOfWork()->tryGetById($id, $class->getName());
-
-            if ($uwEntity) {
-                $entity = $uwEntity;
-            }
-            else {
-                $entity->__load();
-            }
+            $entity->__load();
         }
 
 

--- a/src/CoreShop/Bundle/ResourceBundle/Doctrine/ORM/EntityMerger.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Doctrine/ORM/EntityMerger.php
@@ -328,6 +328,11 @@ class EntityMerger
                 //Reset "tmp" entity with managed entity
                 $relatedEntityClass = $this->em->getClassMetadata($assoc['targetEntity']);
                 $id = $relatedEntityClass->getIdentifierValues($relatedEntities);
+
+                if (!$id) {
+                    continue;
+                }
+
                 $uwEntity = $this->em->getUnitOfWork()->tryGetById($id, $relatedEntityClass->getName());
 
                 //Entity might not be loaded and managed yet, try to load it


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? |no
| Fixed tickets | #2621

@solverat Please check if this works.

We need to refactor these things completely. It is so hard to debug and understand. I remember why we have the EntityMerger, but I am certain there are easier ways. 

Main reason for the Entity Merger is:

 - In preparation of the unsaved data-object, we don't use the EntityManager to load the data.
 - Reason is: If you do changes and decide to not persist them, EntityManager holds the wrong state. Any flush on it, will cause the "temporary" changes to be flushed to the DB.
 - This is one big disadvantages of Entity Management. Every state change that gets persisted, gets flushed.
 - Since we don't know if a change gets persisted or not, we can't even use `refresh` to get the "original" data.
 - So the merger gets the data from the actual Entity Manager, and merges them with our changes.
 

One workaround might be to use DTOs. So we don't actually work with real entities in combination with Pimcore DataObjects, but with DTOs that get converted to Entity on persisting. Not sure about it though.