### PR TITLE
ReplyToSymfonyResponseConverter is moved into `PayumBundle` from `Payum\Core\Bridge`

### DIFF
--- a/src/CoreShop/Bundle/PayumBundle/Exception/ReplyToSymfonyResponseConverter.php
+++ b/src/CoreShop/Bundle/PayumBundle/Exception/ReplyToSymfonyResponseConverter.php
@@ -18,7 +18,7 @@ declare(strict_types=1);
 
 namespace CoreShop\Bundle\PayumBundle\Exception;
 
-use Payum\Core\Bridge\Symfony\ReplyToSymfonyResponseConverter as BaseReplyToSymfonyResponseConverter;
+use Payum\Bundle\PayumBundle\ReplyToSymfonyResponseConverter as BaseReplyToSymfonyResponseConverter;
 use Payum\Core\Reply\ReplyInterface;
 
 class ReplyToSymfonyResponseConverter extends BaseReplyToSymfonyResponseConverter


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This file is moved into the bundle with a new namespace which needed fixing:

https://github.com/Payum/PayumBundle/blob/master/ReplyToSymfonyResponseConverter.php
https://github.com/Payum/PayumBundle/commit/0180a1f888311172569d34c31997b32b803dae12

