### PR TITLE
use getCount() instead of getTotalCount() for BatchListing

### DIFF
--- a/features/domain/pimcore/batch_list.feature
+++ b/features/domain/pimcore/batch_list.feature
@@ -1,0 +1,21 @@
+@domain @pimcore
+Feature: Using the CoreShop Batch List
+    In order to use the CoreShop Batch List
+    I want to create a new Pimcore Class and
+    iterate over all objects with the CoreShop Batch List
+
+  Background:
+    Given there is a pimcore class "Test"
+    And the definition has a checkbox field "enabled"
+    And the definition has a localized input field "name"
+    And the definitions parent class is set to "\CoreShop\Behat\Model\Index\TestEnableIndex"
+    And there are 20 instances of behat-class "Test" with key-prefix "test"
+
+  Scenario: Iterate the Class with Batch Listing
+    Then iterating the behat-class "Test" should return 20 objects
+
+  Scenario: Iterate the Class with Batch Listing with a offset
+    Then iterating the behat-class "Test" with a offset of 5 should return 15 objects
+
+  Scenario: Iterate the Class with Batch Listing with a offset and limit
+    Then iterating the behat-class "Test" with a offset of 5 and limit of 1 should return 1 objects

--- a/src/CoreShop/Behat/Context/Domain/PimcoreContext.php
+++ b/src/CoreShop/Behat/Context/Domain/PimcoreContext.php
@@ -19,6 +19,10 @@ declare(strict_types=1);
 namespace CoreShop\Behat\Context\Domain;
 
 use Behat\Behat\Context\Context;
+use CoreShop\Component\Pimcore\BatchProcessing\DataObjectBatchListing;
+use Pimcore\Model\DataObject\ClassDefinition;
+use Pimcore\Model\DataObject\Listing;
+
 use Webmozart\Assert\Assert;
 
 final class PimcoreContext implements Context
@@ -62,6 +66,72 @@ final class PimcoreContext implements Context
     public function allEditmodeCssResourceShouldExist(): void
     {
         $this->checkFilesExist($this->editmodeCss, 'Editmode CSS');
+    }
+
+    /**
+     * @Then /^iterating the (class|behat-class "[^"]+") should return (\d+) objects$/
+     */
+    public function iteratingTheClassShouldReturn(ClassDefinition $definition, int $count): void
+    {
+        $list = $this->getListingFromClassDefinition($definition);
+        $batchListing = new DataObjectBatchListing($list, 1);
+
+        Assert::eq($batchListing->count(), $count);
+        Assert::eq($this->countBatchListingObjects($batchListing), $count);
+    }
+
+    /**
+     * @Then /^iterating the (class|behat-class "[^"]+") with a offset of (\d+) should return (\d+) objects$/
+     */
+    public function iteratingTheClassWithAOffsetShouldReturn(ClassDefinition $definition, int $offset, int $count): void
+    {
+        $list = $this->getListingFromClassDefinition($definition);
+        $list->setOffset($offset);
+
+        $batchListing = new DataObjectBatchListing($list, 1);
+
+        Assert::eq($batchListing->count(), $count);
+        Assert::eq($this->countBatchListingObjects($batchListing), $count);
+    }
+
+    /**
+     * @Then /^iterating the (class|behat-class "[^"]+") with a offset of (\d+) and limit of (\d+) should return (\d+) objects$/
+     */
+    public function iteratingTheClassWithAOffsetAndLimitShouldReturn(ClassDefinition $definition, int $offset, int $limit, int $count): void
+    {
+        $list = $this->getListingFromClassDefinition($definition);
+        $list->setOffset($offset);
+        $list->setLimit($limit);
+
+        $batchListing = new DataObjectBatchListing($list, 1);
+
+        Assert::eq($batchListing->count(), $count);
+        Assert::eq($this->countBatchListingObjects($batchListing), $count);
+    }
+
+    private function countBatchListingObjects(DataObjectBatchListing $batchListing): int
+    {
+        $count = 0;
+
+        foreach ($batchListing as $object) {
+            ++$count;
+        }
+
+        return $count;
+    }
+
+    private function getListingFromClassDefinition(ClassDefinition $definition): Listing
+    {
+        $className = sprintf('Pimcore\\Model\\DataObject\\%s\\Listing', $definition->getName());
+
+        $list = new $className();
+
+        /**
+         * @Listing $list
+         */
+        Assert::isInstanceOf($list, Listing::class);
+
+        return $list;
     }
 
     private function checkFilesExist(array $files, string $type): void

--- a/src/CoreShop/Behat/Context/Setup/PimcoreClassContext.php
+++ b/src/CoreShop/Behat/Context/Setup/PimcoreClassContext.php
@@ -706,6 +706,27 @@ final class PimcoreClassContext implements Context
     }
 
     /**
+     * @Given /^there are (\d+) instances of (class|behat-class "[^"]+") with key-prefix "([^"]+)"$/
+     */
+    public function thereAreCountInstancesOfClassWithKey(int $count, ClassDefinition $definition, $key): void
+    {
+        /**
+         * @var class-string $className
+         */
+        $className = sprintf('Pimcore\\Model\\DataObject\\%s', $definition->getName());
+
+        for ($i = 0; $i < $count; $i++) {
+            /**
+             * @var Concrete $instance
+             */
+            $instance = new $className();
+            $instance->setKey(sprintf('%s-%s', $key, $i));
+            $instance->setParentId(1);
+            $instance->save();
+        }
+    }
+
+    /**
      * @Given /^I reload the (object-instance) into object-instance-2$/
      */
     public function iReloadTheObjectInstanceIntoObjectInstance2(Concrete $dataObject): void

--- a/src/CoreShop/Component/Pimcore/BatchProcessing/BatchListing.php
+++ b/src/CoreShop/Component/Pimcore/BatchProcessing/BatchListing.php
@@ -80,11 +80,11 @@ final class BatchListing implements Iterator, Countable
         if (!$this->total) {
             $dao = $this->list->getDao();
 
-            if (!method_exists($dao, 'getTotalCount')) {
+            if (!method_exists($dao, 'getCount')) {
                 throw new \InvalidArgumentException(sprintf('%s listing class does not support count.', $this->list::class));
             }
 
-            $this->total = $dao->getTotalCount();
+            $this->total = $dao->getCount();
         }
 
         return $this->total;

--- a/src/CoreShop/Component/Pimcore/BatchProcessing/DataObjectBatchListing.php
+++ b/src/CoreShop/Component/Pimcore/BatchProcessing/DataObjectBatchListing.php
@@ -83,7 +83,7 @@ final class DataObjectBatchListing implements Iterator, Countable
         if (!$this->total) {
             $dao = $this->list->getDao();
 
-            if (!method_exists($dao, 'getTotalCount')) {
+            if (!method_exists($dao, 'getCount')) {
                 throw new \InvalidArgumentException(sprintf(
                     '%s listing class does not support count.',
                     $this->list::class,
@@ -91,7 +91,7 @@ final class DataObjectBatchListing implements Iterator, Countable
             }
 
             /** @psalm-suppress InternalMethod */
-            $this->total = $dao->getTotalCount();
+            $this->total = $dao->getCount();
         }
 
         return $this->total;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no (maybe if BatchListing was used wrongly)
| Deprecations? | no
| Fixed tickets | #2714

use getCount() instead of getTotalCount() for BatchListing because getTotalCount ignores limit and offset.
