### PR TITLE
[Twig] remove deferred blocks

### DIFF
--- a/src/CoreShop/Bundle/FrontendBundle/Resources/views/layout.html.twig
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/views/layout.html.twig
@@ -25,12 +25,12 @@
         {% do pimcore_head_title().setSeparator(' | ') %}
     {%- endapply -%}
 
-    {% block layout_head_meta deferred %}
+    {% block layout_head_meta %}
         {{ pimcore_head_title('CoreShop') }}
         {{ pimcore_head_meta() }}
     {% endblock %}
 
-    {% block head_stylesheets deferred %}
+    {% block head_stylesheets %}
         {{ pimcore_head_link() }}
     {% endblock %}
 </head>
@@ -53,7 +53,7 @@
     {% include '@CoreShopFrontend/_footer.html.twig' %}
 {% endblock %}
 
-{% block scripts deferred %}
+{% block scripts %}
     {{ pimcore_head_script() }}
 {% endblock %}
 </body>


### PR DESCRIPTION
Pimcore removed the deferred extension and added it to the demo again. I don't think we, at CoreShop, have any advantage with the deferred extension and therefore just remove it. https://github.com/pimcore/pimcore/pull/16966