### PR TITLE
Revert "Revert "[Twig] twig >= 3.14 is compatible again""

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -139,7 +139,7 @@
   },
   "conflict": {
     "jms/serializer-bundle": "4.1.0",
-    "twig/twig": "^3.9.0",
+    "twig/twig": ">=3.9.0 <3.14.0",
     "pimcore/pimcore": "11.3.1"
   },
   "suggest": {

--- a/src/CoreShop/Bundle/FrontendBundle/Resources/views/layout.html.twig
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/views/layout.html.twig
@@ -25,12 +25,12 @@
         {% do pimcore_head_title().setSeparator(' | ') %}
     {%- endapply -%}
 
-    {% block layout_head_meta deferred %}
+    {% block layout_head_meta %}
         {{ pimcore_head_title('CoreShop') }}
         {{ pimcore_head_meta() }}
     {% endblock %}
 
-    {% block head_stylesheets deferred %}
+    {% block head_stylesheets %}
         {{ pimcore_head_link() }}
     {% endblock %}
 </head>
@@ -53,7 +53,7 @@
     {% include '@CoreShopFrontend/_footer.html.twig' %}
 {% endblock %}
 
-{% block scripts deferred %}
+{% block scripts %}
     {{ pimcore_head_script() }}
 {% endblock %}
 </body>


### PR DESCRIPTION
A bit ridiculous, I know, but @fashxp pointed me to the Pimcore PR were they changed it.  https://github.com/pimcore/pimcore/pull/17593 ?