### PR TITLE
[PayumBundle] remove payment_state processing to confirm orders

### DIFF
--- a/src/CoreShop/Bundle/PayumBundle/Action/ConfirmOrderAction.php
+++ b/src/CoreShop/Bundle/PayumBundle/Action/ConfirmOrderAction.php
@@ -37,8 +37,7 @@ final class ConfirmOrderAction implements ActionInterface
         $payment = $request->getFirstModel();
         $order = $payment->getOrder();
         if ($payment->getState() === PaymentInterface::STATE_COMPLETED ||
-            $payment->getState() === PaymentInterface::STATE_AUTHORIZED ||
-            $payment->getState() === PaymentInterface::STATE_PROCESSING
+            $payment->getState() === PaymentInterface::STATE_AUTHORIZED
         ) {
             $this->stateMachineApplier->apply($order, OrderTransitions::IDENTIFIER, OrderTransitions::TRANSITION_CONFIRM);
 

--- a/src/CoreShop/Bundle/PayumBundle/Extension/UpdateOrderStateExtension.php
+++ b/src/CoreShop/Bundle/PayumBundle/Extension/UpdateOrderStateExtension.php
@@ -92,8 +92,7 @@ final class UpdateOrderStateExtension implements ExtensionInterface
         }
 
         if ($value === PaymentInterface::STATE_COMPLETED ||
-            $value === PaymentInterface::STATE_AUTHORIZED ||
-            $value === PaymentInterface::STATE_PROCESSING
+            $value === PaymentInterface::STATE_AUTHORIZED
         ) {
             $order = $payment->getOrder();
             $this->confirmOrderState($order);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | #2740

This can be considered a BC depending on Payment Provider being used.