### PR TITLE
fix: CheckoutManager::getNextStep return type

### DIFF
--- a/src/CoreShop/Component/Order/Checkout/CheckoutManager.php
+++ b/src/CoreShop/Component/Order/Checkout/CheckoutManager.php
@@ -51,7 +51,7 @@ class CheckoutManager implements CheckoutManagerInterface
         return $step;
     }
 
-    public function getNextStep(string $identifier): CheckoutStepInterface
+    public function getNextStep(string $identifier): ?CheckoutStepInterface
     {
         return $this->serviceRegistry->getNextTo($identifier);
     }


### PR DESCRIPTION
Fixes error:
`CoreShop\Component\Order\Checkout\CheckoutManager::getNextStep(): Return value must be of type CoreShop\Component\Order\Checkout\CheckoutStepInterface, null returned`

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->
