### PR TITLE
Added action price casting to int

### DIFF
--- a/src/CoreShop/Component/Product/Rule/Action/PriceActionProcessor.php
+++ b/src/CoreShop/Component/Product/Rule/Action/PriceActionProcessor.php
@@ -55,7 +55,7 @@ class PriceActionProcessor implements ProductPriceActionProcessorInterface
          * @var CurrencyInterface $contextCurrency
          */
         $contextCurrency = $context['base_currency'];
-        $price = $configuration['price'];
+        $price = (int) $configuration['price'];
 
         /**
          * @var CurrencyInterface $currency


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | no

Added action price casting to int in PriceActionProcessor.php to ensure the price is correctly handled as an integer. This change addresses the issue discussed in [#2759](https://github.com/coreshop/CoreShop/discussions/2759).