### PR TITLE
Do not load complete product again from database on pre_update

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/EventListener/ProductAvailabilityEventListener.php
+++ b/src/CoreShop/Bundle/CoreBundle/EventListener/ProductAvailabilityEventListener.php
@@ -50,27 +50,16 @@ final class ProductAvailabilityEventListener
             return;
         }
 
-        if (in_array($object->getId(), $this->productIdsToCheck, true)) {
-            return;
-        }
-
-        /** @psalm-suppress InternalMethod */
-        $originalItem = $this->pimcoreModelFactory->build($object::class);
-        $originalItem->getDao()->getById($object->getId());
-
-        if (!$originalItem instanceof PurchasableInterface) {
-            return;
-        }
-
         if (!$object instanceof Concrete) {
             return;
         }
 
-        if (!$originalItem instanceof Concrete) {
+        if (in_array($object->getId(), $this->productIdsToCheck, true)) {
             return;
         }
 
-        if ($object->getPublished() === $originalItem->isPublished()) {
+        $originalPublished = (bool)\Pimcore\Db::get()->fetchOne('SELECT published FROM objects WHERE id=?', [$object->getId()]);
+        if ($object->getPublished() === $originalPublished) {
             return;
         }
 

--- a/src/CoreShop/Bundle/CoreBundle/EventListener/ProductAvailabilityEventListener.php
+++ b/src/CoreShop/Bundle/CoreBundle/EventListener/ProductAvailabilityEventListener.php
@@ -27,7 +27,6 @@ use CoreShop\Component\Pimcore\DataObject\VersionHelper;
 use Doctrine\DBAL\Connection;
 use Pimcore\Event\Model\DataObjectEvent;
 use Pimcore\Model\DataObject\Concrete;
-use Pimcore\Model\FactoryInterface;
 
 final class ProductAvailabilityEventListener
 {

--- a/src/CoreShop/Bundle/CoreBundle/EventListener/ProductAvailabilityEventListener.php
+++ b/src/CoreShop/Bundle/CoreBundle/EventListener/ProductAvailabilityEventListener.php
@@ -24,6 +24,7 @@ use CoreShop\Component\Order\Model\PurchasableInterface;
 use CoreShop\Component\Order\OrderSaleStates;
 use CoreShop\Component\Order\Repository\OrderItemRepositoryInterface;
 use CoreShop\Component\Pimcore\DataObject\VersionHelper;
+use Doctrine\DBAL\Connection;
 use Pimcore\Event\Model\DataObjectEvent;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\FactoryInterface;
@@ -34,7 +35,7 @@ final class ProductAvailabilityEventListener
 
     public function __construct(
         private OrderItemRepositoryInterface $cartItemRepository,
-        private FactoryInterface $pimcoreModelFactory,
+        private Connection $db,
     ) {
     }
 
@@ -58,7 +59,7 @@ final class ProductAvailabilityEventListener
             return;
         }
 
-        $originalPublished = (bool)\Pimcore\Db::get()->fetchOne('SELECT published FROM objects WHERE id=?', [$object->getId()]);
+        $originalPublished = (bool)$this->db->fetchOne('SELECT published FROM objects WHERE id=?', [$object->getId()]);
         if ($object->getPublished() === $originalPublished) {
             return;
         }

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services/listeners.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services/listeners.yml
@@ -42,7 +42,7 @@ services:
     CoreShop\Bundle\CoreBundle\EventListener\ProductAvailabilityEventListener:
         arguments:
             - '@coreshop.repository.order_item'
-            - '@Pimcore\Model\Factory'
+            - '@doctrine.dbal.default_connection'
         tags:
             - { name: kernel.event_listener, event: pimcore.dataobject.preUpdate, method: preUpdateListener }
             - { name: kernel.event_listener, event: pimcore.dataobject.postUpdate, method: postUpdateListener }


### PR DESCRIPTION
When a product gets saved, currently during `pimcore.dataobject.preUpdate` event the whole object gets loaded again from database - only to find out if the `published` state got changed. This is quite expensive from performance perspective. This PR changes this with a direct SQL query. I am quite sure that you will not accept it because of the SQL inside an event listener but maybe we can find a clean solution... 