### PR TITLE
Update docs link (previous gave 404 error)

### DIFF
--- a/src/CoreShop/Bundle/AddressBundle/README.md
+++ b/src/CoreShop/Bundle/AddressBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/ClassDefinitionPatchBundle/README.md
+++ b/src/CoreShop/Bundle/ClassDefinitionPatchBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/ConfigurationBundle/README.md
+++ b/src/CoreShop/Bundle/ConfigurationBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/CoreBundle/README.md
+++ b/src/CoreShop/Bundle/CoreBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/CurrencyBundle/README.md
+++ b/src/CoreShop/Bundle/CurrencyBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/CustomerBundle/README.md
+++ b/src/CoreShop/Bundle/CustomerBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/FrontendBundle/README.md
+++ b/src/CoreShop/Bundle/FrontendBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/IndexBundle/README.md
+++ b/src/CoreShop/Bundle/IndexBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/InventoryBundle/README.md
+++ b/src/CoreShop/Bundle/InventoryBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/LocaleBundle/README.md
+++ b/src/CoreShop/Bundle/LocaleBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/MenuBundle/README.md
+++ b/src/CoreShop/Bundle/MenuBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/MessengerBundle/README.md
+++ b/src/CoreShop/Bundle/MessengerBundle/README.md
@@ -12,7 +12,7 @@ code. [Read more on coreshop.org](http://www.coreshop.org)
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/MoneyBundle/README.md
+++ b/src/CoreShop/Bundle/MoneyBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/NotificationBundle/README.md
+++ b/src/CoreShop/Bundle/NotificationBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/OptimisticEntityLockBundle/README.md
+++ b/src/CoreShop/Bundle/OptimisticEntityLockBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/OrderBundle/README.md
+++ b/src/CoreShop/Bundle/OrderBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/PaymentBundle/README.md
+++ b/src/CoreShop/Bundle/PaymentBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/PayumBundle/README.md
+++ b/src/CoreShop/Bundle/PayumBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/PayumPaymentBundle/README.md
+++ b/src/CoreShop/Bundle/PayumPaymentBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/PimcoreBundle/README.md
+++ b/src/CoreShop/Bundle/PimcoreBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/ProductBundle/README.md
+++ b/src/CoreShop/Bundle/ProductBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/README.md
+++ b/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/ResourceBundle/README.md
+++ b/src/CoreShop/Bundle/ResourceBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/RuleBundle/README.md
+++ b/src/CoreShop/Bundle/RuleBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/SEOBundle/README.md
+++ b/src/CoreShop/Bundle/SEOBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/SequenceBundle/README.md
+++ b/src/CoreShop/Bundle/SequenceBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/ShippingBundle/README.md
+++ b/src/CoreShop/Bundle/ShippingBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/StorageListBundle/README.md
+++ b/src/CoreShop/Bundle/StorageListBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/StoreBundle/README.md
+++ b/src/CoreShop/Bundle/StoreBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/TaxationBundle/README.md
+++ b/src/CoreShop/Bundle/TaxationBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/TestBundle/README.md
+++ b/src/CoreShop/Bundle/TestBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/ThemeBundle/README.md
+++ b/src/CoreShop/Bundle/ThemeBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/TrackingBundle/README.md
+++ b/src/CoreShop/Bundle/TrackingBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/UserBundle/README.md
+++ b/src/CoreShop/Bundle/UserBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/VariantBundle/README.md
+++ b/src/CoreShop/Bundle/VariantBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/WishlistBundle/README.md
+++ b/src/CoreShop/Bundle/WishlistBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Bundle/WorkflowBundle/README.md
+++ b/src/CoreShop/Bundle/WorkflowBundle/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/Address/README.md
+++ b/src/CoreShop/Component/Address/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/Configuration/README.md
+++ b/src/CoreShop/Component/Configuration/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/Core/README.md
+++ b/src/CoreShop/Component/Core/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/Currency/README.md
+++ b/src/CoreShop/Component/Currency/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/Customer/README.md
+++ b/src/CoreShop/Component/Customer/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/Index/README.md
+++ b/src/CoreShop/Component/Index/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/Inventory/README.md
+++ b/src/CoreShop/Component/Inventory/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/Locale/README.md
+++ b/src/CoreShop/Component/Locale/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/Notification/README.md
+++ b/src/CoreShop/Component/Notification/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/Order/README.md
+++ b/src/CoreShop/Component/Order/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/Payment/README.md
+++ b/src/CoreShop/Component/Payment/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/PayumPayment/README.md
+++ b/src/CoreShop/Component/PayumPayment/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/Pimcore/README.md
+++ b/src/CoreShop/Component/Pimcore/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/Product/README.md
+++ b/src/CoreShop/Component/Product/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/ProductQuantityPriceRules/README.md
+++ b/src/CoreShop/Component/ProductQuantityPriceRules/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/Registry/README.md
+++ b/src/CoreShop/Component/Registry/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/Resource/README.md
+++ b/src/CoreShop/Component/Resource/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/Rule/README.md
+++ b/src/CoreShop/Component/Rule/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/SEO/README.md
+++ b/src/CoreShop/Component/SEO/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/Sequence/README.md
+++ b/src/CoreShop/Component/Sequence/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/Shipping/README.md
+++ b/src/CoreShop/Component/Shipping/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/StorageList/README.md
+++ b/src/CoreShop/Component/StorageList/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/Store/README.md
+++ b/src/CoreShop/Component/Store/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/Taxation/README.md
+++ b/src/CoreShop/Component/Taxation/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/Tracking/README.md
+++ b/src/CoreShop/Component/Tracking/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/User/README.md
+++ b/src/CoreShop/Component/User/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/Variant/README.md
+++ b/src/CoreShop/Component/Variant/README.md
@@ -12,7 +12,7 @@ code. [Read more on coreshop.org](http://www.coreshop.org)
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------

--- a/src/CoreShop/Component/Wishlist/README.md
+++ b/src/CoreShop/Component/Wishlist/README.md
@@ -11,7 +11,7 @@ CoreShop is an eCommerce Solution for Pimcore. It is build from decoupled compon
 Documentation
 -------------
 
-Documentation is available on [**coreshop.org**](https://docs.coreshop.org/4.0.0).
+Documentation is available on [**coreshop.org**](https://docs.coreshop.org).
 
 Bug tracking
 ------------


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

The version number 4.0.0 tagged gave a 404 error and so did 4.1.0 so I assume there is no numbering any-more.