### PR TITLE
fix reserved key query

### DIFF
--- a/src/CoreShop/Bundle/ProductBundle/Pimcore/Repository/CategoryRepository.php
+++ b/src/CoreShop/Bundle/ProductBundle/Pimcore/Repository/CategoryRepository.php
@@ -39,7 +39,7 @@ class CategoryRepository extends PimcoreRepository implements CategoryRepository
 
         if (method_exists($category, 'getChildrenSortBy')) {
             $list->setOrderKey(
-                sprintf('%s ASC', $category->getChildrenSortBy()),
+                sprintf('`%s` ASC', $category->getChildrenSortBy()),
                 false,
             );
         } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | --

This fixes the case `getChildrenSortBy` returns `key` (previously `o_key` < p11) which is a reserved sql key.