### PR TITLE
[Docs] Replace configuration for Google Analytics Universal by Google Analytics 4

### DIFF
--- a/docs/03_Development/13_Ecommerce_Tracking/index.md
+++ b/docs/03_Development/13_Ecommerce_Tracking/index.md
@@ -23,7 +23,7 @@ core_shop_tracking:
    trackers:
       google-analytics-enhanced-ecommerce:
         enabled: false
-      google-analytics-universal-ecommerce:
+      google-analytics-4:
         enabled: false
       google-gtag-enhanced-ecommerce:
         enabled: false


### PR DESCRIPTION
Google Analytics Universal has been [shut down](https://support.google.com/analytics/answer/11583528?hl=de). 
Additionally, in #2303 GA4 support has been implemented but the docs currently do not mention how to use it.

This PR replaces the configuration for GA Univeral with GA4.