### PR TITLE
[Messenger] dispatch `MessageDetailsEvent` to allow customization of message details generation

### DIFF
--- a/src/CoreShop/Bundle/MessengerBundle/Event/MessageDetailsEvent.php
+++ b/src/CoreShop/Bundle/MessengerBundle/Event/MessageDetailsEvent.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace CoreShop\Bundle\MessengerBundle\Event;
+
+use CoreShop\Bundle\MessengerBundle\Messenger\MessageDetails;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class MessageDetailsEvent extends Event
+{
+    public function __construct(
+        private string $receiverName,
+        private Envelope $envelope,
+        private MessageDetails $messageDetails,
+    ) {
+    }
+
+    public function getReceiverName(): string
+    {
+        return $this->receiverName;
+    }
+
+    public function getEnvelope(): Envelope
+    {
+        return $this->envelope;
+    }
+
+    public function getMessageDetails(): MessageDetails
+    {
+        return $this->messageDetails;
+    }
+}

--- a/src/CoreShop/Bundle/MessengerBundle/Messenger/MessageDetails.php
+++ b/src/CoreShop/Bundle/MessengerBundle/Messenger/MessageDetails.php
@@ -41,4 +41,9 @@ final class MessageDetails
     {
         return $this->serialized;
     }
+
+    public function setSerialized(string $serialized): void
+    {
+        $this->serialized = $serialized;
+    }
 }

--- a/src/CoreShop/Bundle/MessengerBundle/Messenger/MessageRepository.php
+++ b/src/CoreShop/Bundle/MessengerBundle/Messenger/MessageRepository.php
@@ -18,7 +18,9 @@ declare(strict_types=1);
 
 namespace CoreShop\Bundle\MessengerBundle\Messenger;
 
+use CoreShop\Bundle\MessengerBundle\Event\MessageDetailsEvent;
 use CoreShop\Bundle\MessengerBundle\Exception\ReceiverNotListableException;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
 use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
@@ -27,6 +29,7 @@ final class MessageRepository implements MessageRepositoryInterface
 {
     public function __construct(
         private ReceiversRepositoryInterface $receivers,
+        private EventDispatcherInterface $eventDispatcher,
     ) {
     }
 
@@ -45,11 +48,19 @@ final class MessageRepository implements MessageRepositoryInterface
          * @var Envelope $envelope
          */
         foreach ($envelopes as $envelope) {
-            $rows[] = new MessageDetails(
+            $messageDetails = new MessageDetails(
                 $this->getMessageId($envelope),
                 $envelope->getMessage()::class,
                 print_r($envelope->getMessage(), true),
             );
+
+            /** @var MessageDetailsEvent $event */
+            $event = $this->eventDispatcher->dispatch(
+                new MessageDetailsEvent($receiverName, $envelope, $messageDetails),
+                'coreshop.messenger.message_details',
+            );
+
+            $rows[] = $event->getMessageDetails();
         }
 
         return $rows;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

Currently, the “Details” modal only contains a `print_r` of the message. Sometimes, however, it is desirable to present the content better. For this purpose, a `MessageDetailsEvent` has been introduced, which can be used to manipulate the displayed data. 

Here is an example for a message that contains XML:

```php
#[AsEventListener('coreshop.messenger.message_details')]
class MyMessageDetailsListener
{
    public function __invoke(MessageDetailsEvent $event): void
    {
        if ('my_receiver' === $event->getReceiverName()) {
            $xml = $event->getEnvelope()->getMessage()->xml;

            $event->getMessageDetails()->setSerialized('<pre>'.htmlentities($xml).'</pre>');
        }
    }
}
```