### PR TITLE
[Messenger] wrap message details info modal data in `<pre>` tags

### DIFF
--- a/src/CoreShop/Bundle/MessengerBundle/Messenger/MessageRepository.php
+++ b/src/CoreShop/Bundle/MessengerBundle/Messenger/MessageRepository.php
@@ -48,7 +48,7 @@ final class MessageRepository implements MessageRepositoryInterface
             $rows[] = new MessageDetails(
                 $this->getMessageId($envelope),
                 $envelope->getMessage()::class,
-                print_r($envelope->getMessage(), true),
+                '<pre>' . print_r($envelope->getMessage(), true) . '</pre>',
             );
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

This improves the readability of the data.

Before:
![image](https://github.com/user-attachments/assets/45b60e49-7a58-40f1-b697-a51103db0541)

After:
![image](https://github.com/user-attachments/assets/b52a5b3b-5b13-4ad8-bb8f-5a9616bcda7a)
