### PR TITLE
[Messenger] Fix `MessageRepository` service registration

### DIFF
--- a/src/CoreShop/Bundle/MessengerBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/MessengerBundle/Resources/config/services.yml
@@ -38,6 +38,7 @@ services:
   CoreShop\Bundle\MessengerBundle\Messenger\MessageRepository:
     arguments:
       - '@CoreShop\Bundle\MessengerBundle\Messenger\ReceiversRepository'
+      - '@event_dispatcher'
 
   CoreShop\Bundle\MessengerBundle\Messenger\FailedMessageRetryerInterface: '@CoreShop\Bundle\MessengerBundle\Messenger\FailedMessageRetryer'
   CoreShop\Bundle\MessengerBundle\Messenger\FailedMessageRetryer:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #2854

Fixes the service configuration with the new parameter that got added in #2854.

It would be great if we could get a bug fix release for `3.x` soon, as the `MessengerBundle` is currently not really usable (you get an exception when opening it in the Pimcore backend). 

Note: this was already fixed for `4.x` in 918f626a2fcaa4a7738e5dc1093ba88fe8fd9f8e, so it doesn't need a new release.