### PR TITLE
[Index] CoreShop Index Command with Opensearch

### DIFF
--- a/src/CoreShop/Bundle/IndexBundle/Worker/OpenSearchWorker.php
+++ b/src/CoreShop/Bundle/IndexBundle/Worker/OpenSearchWorker.php
@@ -198,6 +198,17 @@ class OpenSearchWorker extends AbstractWorker implements OpenSearchWorkerInterfa
 
         // Delete the document from the index if it is not indexable
         if (!$object->getIndexable($index)) {
+            $documentExists = $client
+                ->exists([
+                    'index' => $indexName,
+                    'id' => $objectId,
+                ])
+            ;
+
+            if (! $documentExists) {
+                return;
+            }
+
             $client
                 ->delete([
                     'index' => $indexName,

--- a/src/CoreShop/Bundle/IndexBundle/Worker/OpenSearchWorker.php
+++ b/src/CoreShop/Bundle/IndexBundle/Worker/OpenSearchWorker.php
@@ -206,11 +206,11 @@ class OpenSearchWorker extends AbstractWorker implements OpenSearchWorkerInterfa
                         'id' => $objectId,
                     ])
                 ;
-            } catch (NotFoundHttpException) {
-                // If the document does not exist, we can ignore the exception
             } catch (\Exception $exception) {
-                // If any other exception occurs, we rethrow it
-                throw $exception;
+                // If the exception is not a "Not Found" HTTP exception, we rethrow it
+                if ($exception->getCode() !== 404) {
+                    throw $exception;
+                }
             }
 
             return;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

OpenSearch does not allow to delete documents that do not exist in the index. Therefore we need to check whether the document exists before trying to delete it.
