### PR TITLE
[Resource Bundle] Add specific settings for Multiselect Datatype

### DIFF
--- a/src/CoreShop/Bundle/ResourceBundle/Resources/public/pimcore/js/coreExtension/data/dataMultiselect.js
+++ b/src/CoreShop/Bundle/ResourceBundle/Resources/public/pimcore/js/coreExtension/data/dataMultiselect.js
@@ -33,7 +33,69 @@ coreshop.object.classes.data.dataMultiselect = Class.create(pimcore.object.class
         $super();
 
         this.specificPanel.removeAll();
+        const specificItems = this.getSpecificPanelItems(this.datax);
+        this.specificPanel.add(specificItems);
 
         return this.layout;
-    }
+    },
+
+    getSpecificPanelItems: function (datax) {
+        if (typeof datax.options != "object") {
+            datax.options = [];
+        }
+
+        const stylingItems = [
+            {
+                xtype: "textfield",
+                fieldLabel: t("width"),
+                name: "width",
+                value: datax.width,
+            },
+            {
+                xtype: "displayfield",
+                hideLabel: true,
+                value: t('width_explanation'),
+            },
+            {
+                xtype: "textfield",
+                fieldLabel: t("height"),
+                name: "height",
+                value: datax.height,
+            },
+            {
+                xtype: "displayfield",
+                hideLabel: true,
+                value: t('height_explanation'),
+            },
+        ];
+
+        if (this.isInCustomLayoutEditor()) {
+            return stylingItems;
+        }
+
+        return stylingItems.concat([
+            {
+                xtype: "numberfield",
+                fieldLabel: t("maximum_items"),
+                name: "maxItems",
+                value: datax.maxItems,
+                minValue: 0,
+            },
+            {
+                xtype: "combo",
+                fieldLabel: t("multiselect_render_type"),
+                name: "renderType",
+                itemId: "renderType",
+                mode: 'local',
+                store: [
+                    ['list', 'List'],
+                    ['tags', 'Tags'],
+                ],
+                value: datax["renderType"] ? datax["renderType"] : 'list',
+                triggerAction: "all",
+                editable: false,
+                forceSelection: true,
+            },
+        ]);
+    },
 });

--- a/src/CoreShop/Bundle/ResourceBundle/Resources/public/pimcore/js/coreExtension/tags/multiselect.js
+++ b/src/CoreShop/Bundle/ResourceBundle/Resources/public/pimcore/js/coreExtension/tags/multiselect.js
@@ -36,11 +36,26 @@ coreshop.object.tags.multiselect = Class.create(pimcore.object.tags.multiselect,
             queryMode: 'local',
             displayField: this.displayField,
             valueField: 'id',
+            labelWidth: this.fieldConfig.labelWidth || 100,
             listeners: {
                 beforerender: function () {
-                    if (!store.isLoaded() && !store.isLoading())
+                    if (!store.isLoaded() && !store.isLoading()) {
                         store.load();
-                }
+                    }
+                },
+                change: function (multiselect, newValue, oldValue) {
+                    if (this.fieldConfig.maxItems && multiselect.getValue().length > this.fieldConfig.maxItems) {
+                        // we need to set a timeout so setValue is applied when change event is totally finished
+                        // without this, multiselect won't be updated visually with oldValue (but internal value will be oldValue)
+                        setTimeout(function(multiselect, oldValue){
+                            multiselect.setValue(oldValue);
+                        }, 100, multiselect, oldValue);
+
+                        Ext.Msg.alert(t('error'), t('limit_reached'));
+                    }
+
+                    return true;
+                }.bind(this),
             }
         };
 
@@ -52,11 +67,28 @@ coreshop.object.tags.multiselect = Class.create(pimcore.object.tags.multiselect,
             options.height = this.fieldConfig.height;
         }
 
+        if (this.fieldConfig.labelAlign) {
+            options.labelAlign = this.fieldConfig.labelAlign;
+        }
+
+        if (!this.fieldConfig.labelAlign || 'left' === this.fieldConfig.labelAlign) {
+            options.width = this.sumWidths(options.width, options.labelWidth);
+        }
+
         if (typeof this.data == 'string' || typeof this.data == 'number') {
             options.value = this.data;
         }
 
-        this.component = new Ext.ux.form.MultiSelect(options);
+        if (this.fieldConfig.renderType === 'tags') {
+            options.queryMode = 'local';
+            options.editable = true;
+            options.anyMatch = true;
+            options.plugins = 'dragdroptag';
+
+            this.component = new Ext.form.field.Tag(options);
+        } else {
+            this.component = new Ext.ux.form.MultiSelect(options);
+        }
 
         return this.component;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

This PR introduces a couple of additional specific settings for the Multiselect Datatype and therefore all inheriting Datatypes (e.g. country multiselect, etc.)

It now lets you configure the `width`, the `height`, a `maxItems` count and the `renderType` (list or tags).