### PR TITLE
[4.1] replace outdated translation ts with t

### DIFF
--- a/src/CoreShop/Bundle/PimcoreBundle/Resources/public/pimcore/js/coreExtension/tags/coreShopDynamicDropdown.js
+++ b/src/CoreShop/Bundle/PimcoreBundle/Resources/public/pimcore/js/coreExtension/tags/coreShopDynamicDropdown.js
@@ -87,7 +87,7 @@ pimcore.object.tags.coreShopDynamicDropdown = Class.create(pimcore.object.tags.s
         }.bind(this, field.key);
 
         return {
-            header: ts(field.label), sortable: true, dataIndex: field.key, renderer: renderer,
+            header: t(field.label), sortable: true, dataIndex: field.key, renderer: renderer,
             editor: this.getGridColumnEditor(field)
         };
     },

--- a/src/CoreShop/Bundle/ProductBundle/Resources/public/pimcore/js/coreExtension/tags/coreShopProductSpecificPriceRules.js
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/public/pimcore/js/coreExtension/tags/coreShopProductSpecificPriceRules.js
@@ -143,7 +143,7 @@ pimcore.object.tags.coreShopProductSpecificPriceRules = Class.create(pimcore.obj
 
     getGridColumnConfig: function (field) {
         return {
-            header: ts(field.label), width: 150, sortable: false, dataIndex: field.key,
+            header: t(field.label), width: 150, sortable: false, dataIndex: field.key,
             renderer: function (key, value, metaData, record) {
                 this.applyPermissionStyle(key, value, metaData, record);
 

--- a/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/public/pimcore/js/coreExtension/tags/coreShopProductQuantityPriceRules.js
+++ b/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/public/pimcore/js/coreExtension/tags/coreShopProductQuantityPriceRules.js
@@ -140,7 +140,7 @@ pimcore.object.tags.coreShopProductQuantityPriceRules = Class.create(pimcore.obj
 
     getGridColumnConfig: function (field) {
         return {
-            header: ts(field.label), width: 150, sortable: false, dataIndex: field.key,
+            header: t(field.label), width: 150, sortable: false, dataIndex: field.key,
             renderer: function (key, value, metaData, record) {
                 this.applyPermissionStyle(key, value, metaData, record);
                 return t('not_supported');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes

<!--
In this ticket ts(field.label) which was found 3 times was replaced with t(field.label).
-->
