### PR TITLE
[Messenger] wrap failed message details info modal data in `<pre>` tags

### DIFF
--- a/src/CoreShop/Bundle/MessengerBundle/Messenger/FailedMessageRepository.php
+++ b/src/CoreShop/Bundle/MessengerBundle/Messenger/FailedMessageRepository.php
@@ -52,9 +52,9 @@ final class FailedMessageRepository implements FailedMessageRepositoryInterface
             $rows[] = new FailedMessageDetails(
                 $this->getMessageId($envelope),
                 $envelope->getMessage()::class,
-                null !== $lastRedeliveryStamp ? $lastRedeliveryStamp->getRedeliveredAt()->format('Y-m-d H:i:s') : '',
-                null !== $lastErrorDetailsStamp ? $lastErrorDetailsStamp->getExceptionMessage() : '',
-                print_r($envelope->getMessage(), true),
+                $lastRedeliveryStamp?->getRedeliveredAt()->format('Y-m-d H:i:s') ?? '',
+                $lastErrorDetailsStamp?->getExceptionMessage() ?? '',
+                '<pre>' . print_r($envelope->getMessage(), true) . '</pre>',
             );
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Same as #2855, but for failed messages (which I overlooked back then).
