### PR TITLE
[Messenger] dispatch `FailedMessageDetailsEvent` to allow customization of failed message details generation

### DIFF
--- a/src/CoreShop/Bundle/MessengerBundle/Event/FailedMessageDetailsEvent.php
+++ b/src/CoreShop/Bundle/MessengerBundle/Event/FailedMessageDetailsEvent.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace CoreShop\Bundle\MessengerBundle\Event;
+
+use CoreShop\Bundle\MessengerBundle\Messenger\FailedMessageDetails;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class FailedMessageDetailsEvent extends Event
+{
+    public function __construct(
+        private string $receiverName,
+        private Envelope $envelope,
+        private FailedMessageDetails $failedMessageDetails,
+    ) {
+    }
+
+    public function getReceiverName(): string
+    {
+        return $this->receiverName;
+    }
+
+    public function getEnvelope(): Envelope
+    {
+        return $this->envelope;
+    }
+
+    public function getFailedMessageDetails(): FailedMessageDetails
+    {
+        return $this->failedMessageDetails;
+    }
+}

--- a/src/CoreShop/Bundle/MessengerBundle/Messenger/FailedMessageDetails.php
+++ b/src/CoreShop/Bundle/MessengerBundle/Messenger/FailedMessageDetails.php
@@ -61,6 +61,11 @@ final class FailedMessageDetails implements \JsonSerializable
         return $this->serialized;
     }
 
+    public function setSerialized(string $serialized): void
+    {
+        $this->serialized = $serialized;
+    }
+
     public function jsonSerialize(): mixed
     {
         return [

--- a/src/CoreShop/Bundle/MessengerBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/MessengerBundle/Resources/config/services.yml
@@ -33,6 +33,7 @@ services:
   CoreShop\Bundle\MessengerBundle\Messenger\FailedMessageRepository:
     arguments:
       - '@CoreShop\Bundle\MessengerBundle\Messenger\FailureReceiversRepository'
+      - '@event_dispatcher'
 
   CoreShop\Bundle\MessengerBundle\Messenger\MessageRepositoryInterface: '@CoreShop\Bundle\MessengerBundle\Messenger\MessageRepository'
   CoreShop\Bundle\MessengerBundle\Messenger\MessageRepository:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

Same as #2854 & #2876, but for failed messages (which I overlooked back then).