### PR TITLE
[Security] fix pull_request_target workflow injection (pwn request)

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -9,7 +9,7 @@ on:
       - '*.php'
       - 'src/**'
       - '.github/workflows/behat.yml'
-  pull_request_target:
+  pull_request:
     branches: [ '5.0', 'next' ]
     paths:
       - 'composer.json'
@@ -84,16 +84,7 @@ jobs:
     name: "${{ matrix.pimcore }}, PHP ${{ matrix.php }}, Deps ${{ matrix.dependencies }}"
 
     steps:
-      - name: Checkout PR head (only for pull_request_target)
-        if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-
-      - name: Checkout PR head (for push or other events)
-        if: github.event_name != 'pull_request_target'
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/behat_ui.yml
+++ b/.github/workflows/behat_ui.yml
@@ -9,7 +9,7 @@ on:
       - '*.php'
       - 'src/**'
       - '.github/workflows/behat_ui.yml'
-  pull_request_target:
+  pull_request:
     branches: [ '5.0', 'next' ]
     paths:
       - 'composer.json'
@@ -85,16 +85,7 @@ jobs:
     name: "${{ matrix.pimcore }}, PHP ${{ matrix.php }}, Deps ${{ matrix.dependencies }}"
 
     steps:
-      - name: Checkout PR head (only for pull_request_target)
-        if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-
-      - name: Checkout PR head (for push or other events)
-        if: github.event_name != 'pull_request_target'
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - uses: browser-actions/setup-chrome@v1
         with:

--- a/.github/workflows/docs_next.yml
+++ b/.github/workflows/docs_next.yml
@@ -1,6 +1,6 @@
 name: "Documentation"
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - 'docs/**'
       - '.github/workflows/docs_next.yml'

--- a/.github/workflows/frontend-build.yaml
+++ b/.github/workflows/frontend-build.yaml
@@ -3,7 +3,7 @@ name: CoreShop Studio Frontend Build
 on:
   push:
     branches: [ '4.0', '4.1', '5.0', 'next', 'studiov2' ]
-  pull_request_target:
+  pull_request:
     branches: [ '4.0', '4.1', '5.0', 'next', 'studiov2' ]
 
 jobs:

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -6,7 +6,7 @@ on:
       - 'composer.json'
       - '*/**/composer.json'
       - '.github/workflows/license-check.yaml'
-  pull_request_target:
+  pull_request:
     branches: [ '5.0', 'next' ]
     paths:
       - 'composer.json'
@@ -50,16 +50,7 @@ jobs:
     name: "${{ matrix.pimcore }}, PHP ${{ matrix.php }}, Deps ${{ matrix.dependencies }}"
 
     steps:
-      - name: Checkout PR head (only for pull_request_target)
-        if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-
-      - name: Checkout PR head (for push or other events)
-        if: github.event_name != 'pull_request_target'
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/packages_bundles.yml
+++ b/.github/workflows/packages_bundles.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - 'src/CoreShop/Bundle/**'
       - '.github/workflows/packages_bundles.yml'
-  pull_request_target:
+  pull_request:
     branches: [ '5.0', 'next' ]
     paths:
       - 'src/CoreShop/Bundle/**'
@@ -32,16 +32,7 @@ jobs:
     name: "Create a list of packages"
 
     steps:
-      - name: Checkout PR head (only for pull_request_target)
-        if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-
-      - name: Checkout PR head (for push or other events)
-        if: github.event_name != 'pull_request_target'
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: "List Packages"
         id: create-list
@@ -63,16 +54,7 @@ jobs:
         package: "${{ fromJson(needs.list.outputs.packages) }}"
 
     steps:
-      - name: Checkout PR head (only for pull_request_target)
-        if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-
-      - name: Checkout PR head (for push or other events)
-        if: github.event_name != 'pull_request_target'
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/packages_components.yml
+++ b/.github/workflows/packages_components.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - 'src/CoreShop/Component/**'
       - '.github/workflows/packages_components.yml'
-  pull_request_target:
+  pull_request:
     branches: [ '5.0', 'next' ]
     paths:
       - 'src/CoreShop/Component/**'
@@ -32,16 +32,7 @@ jobs:
     name: "Create a list of packages"
 
     steps:
-      - name: Checkout PR head (only for pull_request_target)
-        if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-
-      - name: Checkout PR head (for push or other events)
-        if: github.event_name != 'pull_request_target'
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: "List Packages"
         id: create-list
@@ -64,16 +55,7 @@ jobs:
         package: "${{ fromJson(needs.list.outputs.packages) }}"
 
     steps:
-      - name: Checkout PR head (only for pull_request_target)
-        if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-
-      - name: Checkout PR head (for push or other events)
-        if: github.event_name != 'pull_request_target'
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -11,7 +11,7 @@ on:
       - '*.xml'
       - 'composer.json'
       - '.github/workflows/static.yml'
-  pull_request_target:
+  pull_request:
     branches: [ '5.0', 'next' ]
     paths:
       - 'features/**'
@@ -60,16 +60,7 @@ jobs:
     name: "${{ matrix.pimcore }}, PHP ${{ matrix.php }}, Deps ${{ matrix.dependencies }}"
 
     steps:
-      - name: Checkout PR head (only for pull_request_target)
-        if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-
-      - name: Checkout PR head (for push or other events)
-        if: github.event_name != 'pull_request_target'
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
## Summary

Fixes a workflow injection vulnerability (GitHub's ""pwn request"" pattern) in multiple CI workflows that used `pull_request_target` together with a checkout of the PR head. This gave untrusted fork PRs access to repository secrets (`PIMCORE_SECRET`, `PIMCORE_INSTANCE_IDENTIFIER`, `PIMCORE_PRODUCT_KEY`) and `GITHUB_TOKEN` write permissions — exploitable via modified `composer.json` scripts, PHP files loaded during `phpstan`/`psalm`, etc.

## Changes

- `static.yml`, `behat.yml`, `behat_ui.yml`, `license-check.yaml`, `packages_bundles.yml`, `packages_components.yml`: switched trigger from `pull_request_target` to `pull_request`, removed fork-checkout steps
- `docs_next.yml`: switched to `pull_request` for consistency
- `frontend-build.yaml`: switched to `pull_request` (also fixes a broken conditional `github.event_name == 'pull_request'` that never matched under `pull_request_target`)

`cla-check.yml` is intentionally kept on `pull_request_target` — it does not check out PR code, which is the safe usage pattern.

## Test plan

- [ ] Confirm CI runs for this PR (internal branch → secrets available, tests should pass)
- [ ] Reference: [GitHub Security Lab — Preventing Pwn Requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

## Note on external fork PRs

After this fix, external fork PRs will no longer receive secrets (which is the whole point of the fix). Fork PRs that need Pimcore licensing secrets will fail CI. A follow-up can add a label-gated `pull_request_target` flow for approved external contributors if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)