### PR TITLE
[OrderBundle] remove web2print, not needed anymore

### DIFF
--- a/src/CoreShop/Bundle/OrderBundle/composer.json
+++ b/src/CoreShop/Bundle/OrderBundle/composer.json
@@ -35,8 +35,7 @@
     "coreshop/money-bundle": "^5.0",
     "coreshop/workflow-bundle": "^5.0",
     "coreshop/order": "^5.0",
-    "pimcore/pimcore": "^12.3",
-    "pimcore/web-to-print-bundle": "^2.0"
+    "pimcore/pimcore": "^12.3"
   },
   "require-dev": {
     "phpstan/phpstan": "^2.1",


### PR DESCRIPTION
OrderBundle required `pimcore/web-to-print-bundle ^2.0` but the package only has 1.x releases (and 1.4 pins to Pimcore ^11.2, incompatible with 5.0's Pimcore ^12.3). The bundle is not used anywhere in CoreShop code — PDF rendering goes through the internal `CoreShop\\Component\\Pimcore\\Print\\WkhtmltopdfProcessor`.

Fixes the failing `composer update --prefer-lowest` job.