### PR TITLE
skip prefer-lowest on PHP 8.4

### DIFF
--- a/.github/workflows/packages_bundles.yml
+++ b/.github/workflows/packages_bundles.yml
@@ -61,6 +61,9 @@ jobs:
         pimcore: [ ^12.3 ]
         dependencies: [ highest, lowest ]
         package: "${{ fromJson(needs.list.outputs.packages) }}"
+        exclude:
+          - php: 8.4
+            dependencies: lowest
 
     steps:
       - name: Checkout PR head (only for pull_request_target)

--- a/.github/workflows/packages_components.yml
+++ b/.github/workflows/packages_components.yml
@@ -62,6 +62,9 @@ jobs:
         pimcore: [ ^12.3 ]
         dependencies: [ highest, lowest ]
         package: "${{ fromJson(needs.list.outputs.packages) }}"
+        exclude:
+          - php: 8.4
+            dependencies: lowest
 
     steps:
       - name: Checkout PR head (only for pull_request_target)

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -48,6 +48,9 @@ jobs:
         php: [ 8.3, 8.4 ]
         pimcore: [ ^12.3 ]
         dependencies: [ highest, lowest ]
+        exclude:
+          - php: 8.4
+            dependencies: lowest
     services:
       database:
         image: "mysql:8"


### PR DESCRIPTION
Skip `dependencies: lowest` when running on PHP 8.4 in the matrix.

`--prefer-lowest` resolves to library versions released ~2023, before PHP 8.4. These libs are full of "implicitly nullable parameter" deprecations that were fixed upstream in later patches — but since they remain in our constraint range, lowest-resolution keeps hitting them. We can't fix upstream code retroactively.

Affects: `symfony/error-handler`, `thecodingmachine/safe`, `sabre/event`, `sabre/xml`, `guzzlehttp/promises`.

`lowest` on PHP 8.3 still runs — that's what actually validates our minimum constraints are installable.