### PR TITLE
add 5.1 to branches triggers in CI workflows

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -1,7 +1,7 @@
 name: Behat
 on:
   push:
-    branches: [ '5.0', '2026.x' ]
+    branches: [ '5.0', '5.1', '2026.x' ]
     paths:
       - 'composer.json'
       - 'features/**'
@@ -10,7 +10,7 @@ on:
       - 'src/**'
       - '.github/workflows/behat.yml'
   pull_request_target:
-    branches: [ '5.0', '2026.x' ]
+    branches: [ '5.0', '5.1', '2026.x' ]
     paths:
       - 'composer.json'
       - 'features/**'

--- a/.github/workflows/behat_ui.yml
+++ b/.github/workflows/behat_ui.yml
@@ -1,7 +1,7 @@
 name: Behat UI
 on:
   push:
-    branches: [ '5.0', '2026.x' ]
+    branches: [ '5.0', '5.1', '2026.x' ]
     paths:
       - 'composer.json'
       - 'features/**'
@@ -10,7 +10,7 @@ on:
       - 'src/**'
       - '.github/workflows/behat_ui.yml'
   pull_request_target:
-    branches: [ '5.0', '2026.x' ]
+    branches: [ '5.0', '5.1', '2026.x' ]
     paths:
       - 'composer.json'
       - 'features/**'

--- a/.github/workflows/codestyles.yml
+++ b/.github/workflows/codestyles.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: [ '5.0', '2026.x' ]
+        branches: [ '5.0', '5.1', '2026.x' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -1,13 +1,13 @@
 name: License Check
 on:
   push:
-    branches: [ '5.0', '2026.x' ]
+    branches: [ '5.0', '5.1', '2026.x' ]
     paths:
       - 'composer.json'
       - '*/**/composer.json'
       - '.github/workflows/license-check.yaml'
   pull_request_target:
-    branches: [ '5.0', '2026.x' ]
+    branches: [ '5.0', '5.1', '2026.x' ]
     paths:
       - 'composer.json'
       - '*/**/composer.json'

--- a/.github/workflows/packages_bundles.yml
+++ b/.github/workflows/packages_bundles.yml
@@ -1,12 +1,12 @@
 name: Packages Bundles
 on:
   push:
-    branches: [ '5.0', '2026.x' ]
+    branches: [ '5.0', '5.1', '2026.x' ]
     paths:
       - 'src/CoreShop/Bundle/**'
       - '.github/workflows/packages_bundles.yml'
   pull_request_target:
-    branches: [ '5.0', '2026.x' ]
+    branches: [ '5.0', '5.1', '2026.x' ]
     paths:
       - 'src/CoreShop/Bundle/**'
       - '.github/workflows/packages_bundles.yml'

--- a/.github/workflows/packages_components.yml
+++ b/.github/workflows/packages_components.yml
@@ -1,12 +1,12 @@
 name: Packages Components
 on:
   push:
-    branches: [ '5.0', '2026.x' ]
+    branches: [ '5.0', '5.1', '2026.x' ]
     paths:
       - 'src/CoreShop/Component/**'
       - '.github/workflows/packages_components.yml'
   pull_request_target:
-    branches: [ '5.0', '2026.x' ]
+    branches: [ '5.0', '5.1', '2026.x' ]
     paths:
       - 'src/CoreShop/Component/**'
       - '.github/workflows/packages_components.yml'

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,7 +1,7 @@
 name: Static Tests (Lint, Stan)
 on:
   push:
-    branches: [ '5.0', '2026.x' ]
+    branches: [ '5.0', '5.1', '2026.x' ]
     paths:
       - 'features/**'
       - 'behat.yml.dist'
@@ -12,7 +12,7 @@ on:
       - 'composer.json'
       - '.github/workflows/static.yml'
   pull_request_target:
-    branches: [ '5.0', '2026.x' ]
+    branches: [ '5.0', '5.1', '2026.x' ]
     paths:
       - 'features/**'
       - 'behat.yml.dist'


### PR DESCRIPTION
## Summary
- Add `5.1` to the `branches` filter in all CI workflows on `2026.x` (default branch).
- Without `5.1` listed in the default-branch workflow files, PRs targeting `5.1` (e.g. #3004) never dispatch Static Tests, Behat, Behat UI, Packages Bundles/Components, License Check — only workflows without a `branches` filter (CLA, Frontend Build) ran.

Affected workflows: `static.yml`, `behat.yml`, `behat_ui.yml`, `packages_bundles.yml`, `packages_components.yml`, `license-check.yaml`, `codestyles.yml` (matrix).

## Test plan
- [ ] Merge, then re-push PR #3004 and verify all test workflows dispatch against `5.1`.