### PR TITLE
CI: drop 3.2/4.0 from upmerge chain, add 5.1 between 5.0 and 2026.x

### DIFF
--- a/.github/workflows/upmerge.yaml
+++ b/.github/workflows/upmerge.yaml
@@ -31,6 +31,9 @@ jobs:
             target_branch: "5.0"
           -
             base_branch: "5.0"
+            target_branch: "5.1"
+          -
+            base_branch: "5.1"
             target_branch: "2026.x"
 
     steps:


### PR DESCRIPTION
## Summary
- Drop `3.2 → 4.0` and `4.0 → 4.1` from the upmerge matrix (EOL branches)
- Add `5.0 → 5.1` and `5.1 → 2026.x` so 5.1 is no longer skipped

## New chain
```
4.1 → 5.0 → 5.1 → 2026.x
```