### PR TITLE
CI: drop 3.2 and 4.0 from upmerge chain

### DIFF
--- a/.github/workflows/upmerge.yaml
+++ b/.github/workflows/upmerge.yaml
@@ -21,12 +21,6 @@ jobs:
       matrix:
         include:
           -
-            base_branch: "3.2"
-            target_branch: "4.0"
-          -
-            base_branch: "4.0"
-            target_branch: "4.1"
-          -
             base_branch: "4.1"
             target_branch: "5.0"
           -


### PR DESCRIPTION
## Summary
Remove `3.2 → 4.0` and `4.0 → 4.1` from the upmerge matrix. Those source branches are EOL — no more fixes flow out of them, so these matrix entries just burn CI minutes every night for no-op runs.

## Resulting chain
```
4.1 → 5.0 → 5.1 → 2026.x
```

Follow-up to #3013 (which added 5.1 to the chain but kept the EOL entries).