### PR TITLE
Backport Doctrine ORM 3 compatibility + docs/studio ignore to 5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ docs/.docusaurus
 node_modules
 cache/
 docker-compose.override.yaml
+
+# Studio frontend build artifacts — locally ignored, force-added in CI (see .github/workflows/shared-frontend-build.yaml)
+src/CoreShop/Bundle/*/Resources/public/studio/*/
+supervisord.pid

--- a/config/packages/doctrine_mapping_types.yaml
+++ b/config/packages/doctrine_mapping_types.yaml
@@ -1,0 +1,7 @@
+doctrine:
+    dbal:
+        connections:
+            default:
+                mapping_types:
+                    bit: boolean
+                    enum: string

--- a/docs/01_Getting_Started/00_Installation.md
+++ b/docs/01_Getting_Started/00_Installation.md
@@ -5,7 +5,7 @@ CoreShop:
 
 ## Initial Setup
 
-1. Install with composer: `composer require coreshop/core-shop ^4.0`
+1. Install with composer: `composer require coreshop/core-shop ^5.0`
 2. Enable the bundle in `config/bundles.php` and the `CoreShopCoreBundle` to the list of Bundles to load:
     ```php
     <?php

--- a/src/CoreShop/Bundle/AddressBundle/Resources/config/doctrine/model/AddressIdentifier.orm.xml
+++ b/src/CoreShop/Bundle/AddressBundle/Resources/config/doctrine/model/AddressIdentifier.orm.xml
@@ -9,7 +9,7 @@
         </id>
 
         <field name="active" column="active" type="boolean" />
-        <field name="name" column="name" type="string" />
+        <field name="name" column="name" type="string" length="255" />
         <field name="creationDate" type="datetime">
             <gedmo:timestampable on="create"/>
         </field>

--- a/src/CoreShop/Bundle/AddressBundle/Resources/config/doctrine/model/Country.orm.xml
+++ b/src/CoreShop/Bundle/AddressBundle/Resources/config/doctrine/model/Country.orm.xml
@@ -14,7 +14,7 @@
 
         <field name="isoCode" column="isoCode" type="string" length="2" nullable="true"/>
         <field name="active" column="active" type="boolean" />
-        <field name="addressFormat" column="addressFormat" type="string" />
+        <field name="addressFormat" column="addressFormat" type="string" length="255" />
         <field name="salutations" column="salutations" type="simple_array" nullable="true" />
         <field name="creationDate" type="datetime">
             <gedmo:timestampable on="create"/>

--- a/src/CoreShop/Bundle/AddressBundle/Resources/config/doctrine/model/CountryTranslation.orm.xml
+++ b/src/CoreShop/Bundle/AddressBundle/Resources/config/doctrine/model/CountryTranslation.orm.xml
@@ -8,7 +8,7 @@
             <generator strategy="AUTO" />
         </id>
 
-        <field name="name" column="name" nullable="true" />
+        <field name="name" column="name" nullable="true" type="string" length="255" />
         <field name="creationDate" type="datetime">
             <gedmo:timestampable on="create"/>
         </field>

--- a/src/CoreShop/Bundle/AddressBundle/Resources/config/doctrine/model/StateTranslation.orm.xml
+++ b/src/CoreShop/Bundle/AddressBundle/Resources/config/doctrine/model/StateTranslation.orm.xml
@@ -7,7 +7,7 @@
         <id name="id" column="id" type="integer">
             <generator strategy="AUTO" />
         </id>
-        <field name="name" column="name" nullable="true"/>
+        <field name="name" column="name" nullable="true" type="string" length="255"/>
         <field name="creationDate" type="datetime">
             <gedmo:timestampable on="create"/>
         </field>

--- a/src/CoreShop/Bundle/AddressBundle/Resources/config/doctrine/model/Zone.orm.xml
+++ b/src/CoreShop/Bundle/AddressBundle/Resources/config/doctrine/model/Zone.orm.xml
@@ -9,7 +9,7 @@
         </id>
 
         <field name="active" column="active" type="boolean" />
-        <field name="name" column="name" type="string" />
+        <field name="name" column="name" type="string" length="255" />
         <field name="creationDate" type="datetime">
             <gedmo:timestampable on="create"/>
         </field>


### PR DESCRIPTION
Backports doctrine-related fixes from `b1f1eab` (2026.x) to 5.0. Needed on 5.0 because it also uses `doctrine/orm: ^3.0`.

## Summary
- **[Docs]** correct composer require version `^4.0` → `^5.0`
- **[Doctrine]** add explicit `length="255"` (and `type="string"` where missing) to string fields in AddressBundle ORM mappings — required by Doctrine ORM 3, which no longer infers defaults silently. Affected: `AddressIdentifier`, `Country`, `CountryTranslation`, `StateTranslation`, `Zone`.
- **[Doctrine]** add `config/packages/doctrine_mapping_types.yaml` with DBAL mapping `bit → boolean`, `enum → string` to avoid schema-introspection errors.
- **[Studio]** ignore local Studio build artifacts (`src/CoreShop/Bundle/*/Resources/public/studio/*/`) + `supervisord.pid`. On 5.0 the Studio build CI doesn't exist yet, but the ignore prevents pollution when switching from newer branches.

## Test plan
- [ ] Schema validates with Doctrine ORM 3 (`bin/console doctrine:schema:validate --skip-sync`)
- [ ] Installation docs show correct composer version
- [ ] Upmerge 5.0 → 5.1 applies cleanly (only composer version needs manual `^5.0` → `^5.1`)