### PR TITLE
fix PHP 8.4 Behat: force react/promise v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -124,7 +124,8 @@
     "pimcore/opensearch-client": "Allows to use OpenSearch as your index engine."
   },
   "conflict": {
-    "ezimuel/ringphp": "<1.4"
+    "ezimuel/ringphp": "<1.4",
+    "react/promise": "<3"
   },
   "require-dev": {
     "behat/behat": "^3.27",


### PR DESCRIPTION
## Summary
On PHP 8.4, `react/promise` v2.x emits an `implicit nullable` deprecation from `FulfilledPromise::then()` that Pimcore's error handler converts into a `SearchFailedException` inside `DataObjectIndexUpdateSubscriber`. This blows up 415 of 521 Behat scenarios on the `PHP 8.4, Deps highest` matrix entry (currently masked by `allow-failure: true`).

`react/promise` v3 fixes the signatures. Its only consumer in our tree is `ezimuel/ringphp`, which already accepts `^2.0 || ^3.0`.

## Change
Add `react/promise: <3` to the `conflict` block so composer resolves to v3 on every branch, independent of cache state.

## Test plan
- [ ] Behat `PHP 8.4, Deps highest` goes green on this PR
- [ ] Behat `PHP 8.3, Deps highest` stays green (v3 works on 8.3 too)
- [ ] Follow-up once confirmed: drop `allow-failure: true` from the PHP 8.4 matrix entry