### PR TITLE
fix Index class dropdown to only show IndexableInterface classes

### DIFF
--- a/src/CoreShop/Bundle/IndexBundle/Controller/IndexController.php
+++ b/src/CoreShop/Bundle/IndexBundle/Controller/IndexController.php
@@ -22,7 +22,7 @@ use CoreShop\Bundle\ResourceBundle\Form\Registry\FormTypeRegistryInterface;
 use CoreShop\Bundle\StudioFormBundle\Form\Schema\RuleFormSchemaCollector;
 use CoreShop\Component\Index\Interpreter\LocalizedInterpreterInterface;
 use CoreShop\Component\Index\Interpreter\RelationInterpreterInterface;
-use CoreShop\Component\Index\Model\IndexableInterface;
+use CoreShop\Component\Index\Service\IndexableClassesProviderInterface;
 use CoreShop\Component\Registry\ServiceRegistryInterface;
 use Pimcore\Model\DataObject;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -49,6 +49,7 @@ class IndexController extends ResourceController
 
     public function getConfigAction(
         RuleFormSchemaCollector $schemaCollector,
+        IndexableClassesProviderInterface $indexableClassesProvider,
         #[Autowire(service: 'coreshop.form_registry.index.getter')]
         FormTypeRegistryInterface $getterFormTypeRegistry,
         #[Autowire(service: 'coreshop.form_registry.index.interpreter')]
@@ -118,22 +119,10 @@ class IndexController extends ResourceController
             }
         }
 
-        $classes = new DataObject\ClassDefinition\Listing();
-        $classes = $classes->load();
-        $availableClasses = [];
-
-        foreach ($classes as $class) {
-            if ($class instanceof DataObject\ClassDefinition) {
-                $pimcoreClass = 'Pimcore\Model\DataObject\\' . ucfirst($class->getName());
-                $implements = class_implements($pimcoreClass) ?: [];
-
-                if (in_array(IndexableInterface::class, $implements, true)) {
-                    $availableClasses[] = [
-                        'name' => $class->getName(),
-                    ];
-                }
-            }
-        }
+        $availableClasses = array_map(
+            static fn (string $name) => ['name' => $name],
+            $indexableClassesProvider->getIndexableClassNames(),
+        );
 
         $workersResult = [];
 

--- a/src/CoreShop/Bundle/IndexBundle/Form/Type/IndexType.php
+++ b/src/CoreShop/Bundle/IndexBundle/Form/Type/IndexType.php
@@ -19,7 +19,6 @@ namespace CoreShop\Bundle\IndexBundle\Form\Type;
 
 use CoreShop\Bundle\ResourceBundle\Form\Registry\FormTypeRegistryInterface;
 use CoreShop\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
-use CoreShop\Bundle\ResourceBundle\Form\Type\PimcoreClassChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -42,7 +41,7 @@ class IndexType extends AbstractResourceType
         $builder
             ->add('name', TextType::class)
             ->add('worker', IndexWorkerChoiceType::class)
-            ->add('class', PimcoreClassChoiceType::class)
+            ->add('class', IndexablePimcoreClassChoiceType::class)
             ->add('columns', IndexColumnCollectionType::class)
             ->add('indexLastVersion', CheckboxType::class)
         ;

--- a/src/CoreShop/Bundle/IndexBundle/Form/Type/IndexablePimcoreClassChoiceType.php
+++ b/src/CoreShop/Bundle/IndexBundle/Form/Type/IndexablePimcoreClassChoiceType.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CoreShop
+ *
+ * This source file is available under the terms of the
+ * CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    CoreShop Commercial License (CCL)
+ *
+ */
+
+namespace CoreShop\Bundle\IndexBundle\Form\Type;
+
+use CoreShop\Component\Index\Service\IndexableClassesProviderInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class IndexablePimcoreClassChoiceType extends AbstractType
+{
+    public function __construct(
+        private readonly IndexableClassesProviderInterface $indexableClassesProvider,
+    ) {
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $choices = [];
+
+        foreach ($this->indexableClassesProvider->getIndexableClassNames() as $name) {
+            $choices[$name] = $name;
+        }
+
+        $resolver->setDefaults([
+            'choices' => $choices,
+        ]);
+    }
+
+    public function getParent(): string
+    {
+        return ChoiceType::class;
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'coreshop_index_indexable_pimcore_class_choice';
+    }
+}

--- a/src/CoreShop/Bundle/IndexBundle/Form/Type/Worker/MysqlWorkerTableIndexType.php
+++ b/src/CoreShop/Bundle/IndexBundle/Form/Type/Worker/MysqlWorkerTableIndexType.php
@@ -21,8 +21,8 @@ use CoreShop\Bundle\IndexBundle\Worker\MysqlWorker\TableIndex;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class MysqlWorkerTableIndexType extends AbstractType
 {
@@ -37,18 +37,12 @@ final class MysqlWorkerTableIndexType extends AbstractType
                 'required' => false,
             ])
             ->add('columns', CollectionType::class, [
+                'entry_type' => TextType::class,
                 'allow_delete' => true,
                 'allow_add' => true,
                 'required' => false,
             ])
         ;
-    }
-
-    public function configureOptions(OptionsResolver $resolver): void
-    {
-        $resolver->setDefault('data_class', TableIndex::class);
-
-        parent::configureOptions($resolver);
     }
 
     public function getBlockPrefix(): string

--- a/src/CoreShop/Bundle/IndexBundle/Resources/assets/pimcore-studio/src/modules/indexes/components/ColumnsPanel.tsx
+++ b/src/CoreShop/Bundle/IndexBundle/Resources/assets/pimcore-studio/src/modules/indexes/components/ColumnsPanel.tsx
@@ -69,13 +69,16 @@ export const ColumnsPanel: React.FC<ColumnsPanelProps> = ({
       return
     }
 
-    // Create new column with defaults
-    const newColumn: IndexColumn = {
+    // `field.dataType` is the Pimcore ClassDefinition fieldtype (e.g. 'input', 'numeric'),
+    // not a valid index column type. Open the edit modal with the draft column and let the
+    // user pick a valid index column type (STRING, INTEGER, …). The column is only appended
+    // once the user clicks Apply (see handleSaveField with editingIndex === null).
+    const draftColumn: IndexColumn = {
       name: field.name || field.objectKey || '',
       objectKey: field.objectKey || '',
       objectType: field.objectType,
       dataType: field.dataType,
-      columnType: field.dataType || 'TEXT',
+      columnType: undefined,
       getter: field.getter,
       getterConfig: field.configuration,
       interpreter: field.interpreter,
@@ -83,10 +86,9 @@ export const ColumnsPanel: React.FC<ColumnsPanelProps> = ({
       configuration: field.configuration
     }
 
-    onChange({
-      ...index,
-      columns: [...columns, newColumn]
-    })
+    setEditingColumn(draftColumn)
+    setEditingIndex(null)
+    setDialogVisible(true)
   }
 
   const handleDrop = (info: DragAndDropInfo) => {
@@ -102,14 +104,21 @@ export const ColumnsPanel: React.FC<ColumnsPanelProps> = ({
   }
 
   const handleSaveField = (updatedColumn: IndexColumn) => {
-    if (editingIndex !== null) {
-      const newColumns = [...columns]
-      newColumns[editingIndex] = updatedColumn
+    if (editingIndex === null) {
+      // New field — append
       onChange({
         ...index,
-        columns: newColumns
+        columns: [...columns, updatedColumn]
       })
+      return
     }
+
+    const newColumns = [...columns]
+    newColumns[editingIndex] = updatedColumn
+    onChange({
+      ...index,
+      columns: newColumns
+    })
   }
 
   const handleCloseModal = () => {

--- a/src/CoreShop/Bundle/IndexBundle/Resources/assets/pimcore-studio/src/modules/indexes/components/FieldEditModal.tsx
+++ b/src/CoreShop/Bundle/IndexBundle/Resources/assets/pimcore-studio/src/modules/indexes/components/FieldEditModal.tsx
@@ -56,7 +56,7 @@ export const FieldEditModal: React.FC<FieldEditModalProps> = ({
         name: field.name || '',
         getter: field.getter || undefined,
         interpreter: field.interpreter || undefined,
-        columnType: field.columnType || 'INTEGER'
+        columnType: field.columnType || undefined
       })
       setSelectedGetter(field.getter)
       setSelectedInterpreter(field.interpreter)

--- a/src/CoreShop/Bundle/IndexBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/IndexBundle/Resources/config/services.yml
@@ -339,6 +339,10 @@ services:
             - '@coreshop.repository.index'
             - '@coreshop.registry.index.worker'
 
+    # Indexable Classes Provider
+    CoreShop\Component\Index\Service\IndexableClassesProviderInterface: '@CoreShop\Bundle\IndexBundle\Service\IndexableClassesProvider'
+    CoreShop\Bundle\IndexBundle\Service\IndexableClassesProvider: ~
+
     CoreShop\Component\Index\Extension\DecimalIndexColumnTypeConfigExtension:
         tags:
             - { name: coreshop.index.extension }

--- a/src/CoreShop/Bundle/IndexBundle/Resources/config/services/form.yml
+++ b/src/CoreShop/Bundle/IndexBundle/Resources/config/services/form.yml
@@ -38,6 +38,12 @@ services:
             - { name: form.type }
             - { name: coreshop.studio_form }
 
+    CoreShop\Bundle\IndexBundle\Form\Type\IndexablePimcoreClassChoiceType:
+        arguments:
+            - '@CoreShop\Component\Index\Service\IndexableClassesProviderInterface'
+        tags:
+            - { name: form.type }
+
     CoreShop\Bundle\IndexBundle\Form\Schema\IndexSchemaEnricher:
         tags:
             - { name: coreshop_studio_form.enricher }

--- a/src/CoreShop/Bundle/IndexBundle/Service/IndexableClassesProvider.php
+++ b/src/CoreShop/Bundle/IndexBundle/Service/IndexableClassesProvider.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CoreShop
+ *
+ * This source file is available under the terms of the
+ * CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    CoreShop Commercial License (CCL)
+ *
+ */
+
+namespace CoreShop\Bundle\IndexBundle\Service;
+
+use CoreShop\Component\Index\Model\IndexableInterface;
+use CoreShop\Component\Index\Service\IndexableClassesProviderInterface;
+use Pimcore\Model\DataObject\ClassDefinition;
+
+final class IndexableClassesProvider implements IndexableClassesProviderInterface
+{
+    public function getIndexableClassNames(): array
+    {
+        $listing = new ClassDefinition\Listing();
+        $result = [];
+
+        foreach ($listing->load() as $class) {
+            if (!$class instanceof ClassDefinition) {
+                continue;
+            }
+
+            $pimcoreClass = 'Pimcore\\Model\\DataObject\\' . ucfirst($class->getName());
+
+            if (!class_exists($pimcoreClass)) {
+                continue;
+            }
+
+            if (in_array(IndexableInterface::class, class_implements($pimcoreClass) ?: [], true)) {
+                $result[] = $class->getName();
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/CoreShop/Bundle/IndexBundle/Service/IndexableClassesProvider.php
+++ b/src/CoreShop/Bundle/IndexBundle/Service/IndexableClassesProvider.php
@@ -33,14 +33,20 @@ final class IndexableClassesProvider implements IndexableClassesProviderInterfac
                 continue;
             }
 
-            $pimcoreClass = 'Pimcore\\Model\\DataObject\\' . ucfirst($class->getName());
+            $name = $class->getName();
+
+            if (null === $name || '' === $name) {
+                continue;
+            }
+
+            $pimcoreClass = 'Pimcore\\Model\\DataObject\\' . ucfirst($name);
 
             if (!class_exists($pimcoreClass)) {
                 continue;
             }
 
             if (in_array(IndexableInterface::class, class_implements($pimcoreClass) ?: [], true)) {
-                $result[] = $class->getName();
+                $result[] = $name;
             }
         }
 

--- a/src/CoreShop/Bundle/IndexBundle/Worker/MysqlWorker.php
+++ b/src/CoreShop/Bundle/IndexBundle/Worker/MysqlWorker.php
@@ -207,14 +207,15 @@ class MysqlWorker extends AbstractWorker implements MysqlWorkerInterface, Worker
         }
 
         if (array_key_exists('indexes', $index->getConfiguration())) {
-            /**
-             * @var TableIndex $tableIndex
-             */
             foreach ($index->getConfiguration()['indexes'] as $tableIndex) {
-                if ($tableIndex->getType() === TableIndex::TABLE_INDEX_TYPE_UNIQUE) {
-                    $table->addUniqueIndex($tableIndex->getColumns());
+                if (!is_array($tableIndex) || empty($tableIndex['columns'])) {
+                    continue;
+                }
+
+                if (($tableIndex['type'] ?? null) === TableIndex::TABLE_INDEX_TYPE_UNIQUE) {
+                    $table->addUniqueIndex(array_values($tableIndex['columns']));
                 } else {
-                    $table->addIndex($tableIndex->getColumns());
+                    $table->addIndex(array_values($tableIndex['columns']));
                 }
             }
         }
@@ -269,14 +270,15 @@ class MysqlWorker extends AbstractWorker implements MysqlWorkerInterface, Worker
         }
 
         if (array_key_exists('localizedIndexes', $index->getConfiguration())) {
-            /**
-             * @var TableIndex $tableIndex
-             */
             foreach ($index->getConfiguration()['localizedIndexes'] as $tableIndex) {
-                if ($tableIndex->getType() === TableIndex::TABLE_INDEX_TYPE_UNIQUE) {
-                    $table->addUniqueIndex($tableIndex->getColumns());
+                if (!is_array($tableIndex) || empty($tableIndex['columns'])) {
+                    continue;
+                }
+
+                if (($tableIndex['type'] ?? null) === TableIndex::TABLE_INDEX_TYPE_UNIQUE) {
+                    $table->addUniqueIndex(array_values($tableIndex['columns']));
                 } else {
-                    $table->addIndex($tableIndex->getColumns());
+                    $table->addIndex(array_values($tableIndex['columns']));
                 }
             }
         }

--- a/src/CoreShop/Bundle/IndexBundle/Worker/MysqlWorker.php
+++ b/src/CoreShop/Bundle/IndexBundle/Worker/MysqlWorker.php
@@ -208,14 +208,16 @@ class MysqlWorker extends AbstractWorker implements MysqlWorkerInterface, Worker
 
         if (array_key_exists('indexes', $index->getConfiguration())) {
             foreach ($index->getConfiguration()['indexes'] as $tableIndex) {
-                if (!is_array($tableIndex) || empty($tableIndex['columns'])) {
+                $normalized = $this->normalizeTableIndex($tableIndex);
+
+                if (null === $normalized) {
                     continue;
                 }
 
-                if (($tableIndex['type'] ?? null) === TableIndex::TABLE_INDEX_TYPE_UNIQUE) {
-                    $table->addUniqueIndex(array_values($tableIndex['columns']));
+                if ($normalized['type'] === TableIndex::TABLE_INDEX_TYPE_UNIQUE) {
+                    $table->addUniqueIndex($normalized['columns']);
                 } else {
-                    $table->addIndex(array_values($tableIndex['columns']));
+                    $table->addIndex($normalized['columns']);
                 }
             }
         }
@@ -271,19 +273,52 @@ class MysqlWorker extends AbstractWorker implements MysqlWorkerInterface, Worker
 
         if (array_key_exists('localizedIndexes', $index->getConfiguration())) {
             foreach ($index->getConfiguration()['localizedIndexes'] as $tableIndex) {
-                if (!is_array($tableIndex) || empty($tableIndex['columns'])) {
+                $normalized = $this->normalizeTableIndex($tableIndex);
+
+                if (null === $normalized) {
                     continue;
                 }
 
-                if (($tableIndex['type'] ?? null) === TableIndex::TABLE_INDEX_TYPE_UNIQUE) {
-                    $table->addUniqueIndex(array_values($tableIndex['columns']));
+                if ($normalized['type'] === TableIndex::TABLE_INDEX_TYPE_UNIQUE) {
+                    $table->addUniqueIndex($normalized['columns']);
                 } else {
-                    $table->addIndex(array_values($tableIndex['columns']));
+                    $table->addIndex($normalized['columns']);
                 }
             }
         }
 
         return $tableSchema;
+    }
+
+    /**
+     * Accept both {@see TableIndex} objects (legacy programmatic setup) and plain arrays
+     * (the form + JSON-stored configuration format). Returns null for empty/invalid entries.
+     *
+     * @return array{type: string|null, columns: array<int, string>}|null
+     */
+    private function normalizeTableIndex(mixed $tableIndex): ?array
+    {
+        if ($tableIndex instanceof TableIndex) {
+            $columns = $tableIndex->getColumns();
+
+            if (empty($columns)) {
+                return null;
+            }
+
+            return [
+                'type' => $tableIndex->getType(),
+                'columns' => array_values($columns),
+            ];
+        }
+
+        if (is_array($tableIndex) && !empty($tableIndex['columns']) && is_array($tableIndex['columns'])) {
+            return [
+                'type' => $tableIndex['type'] ?? null,
+                'columns' => array_values($tableIndex['columns']),
+            ];
+        }
+
+        return null;
     }
 
     protected function createRelationalTableSchema(IndexInterface $index, Schema $tableSchema)

--- a/src/CoreShop/Component/Index/Service/IndexableClassesProviderInterface.php
+++ b/src/CoreShop/Component/Index/Service/IndexableClassesProviderInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CoreShop
+ *
+ * This source file is available under the terms of the
+ * CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    CoreShop Commercial License (CCL)
+ *
+ */
+
+namespace CoreShop\Component\Index\Service;
+
+interface IndexableClassesProviderInterface
+{
+    /**
+     * @return array<string> Pimcore DataObject class names whose generated model implements IndexableInterface
+     */
+    public function getIndexableClassNames(): array;
+}


### PR DESCRIPTION
## Summary

The `Class` dropdown in the Index configuration (Studio UI) currently shows **all** Pimcore DataObject classes, even though only classes whose generated model implements `IndexableInterface` can actually be indexed. The filter logic already existed inline inside `IndexController::getConfigAction`, but the form-schema endpoint used an unfiltered `PimcoreClassChoiceType`, so the Studio dropdown still exposed every class.

This PR introduces a single source of truth for "indexable Pimcore classes" and consumes it from both the Form Schema and the Controller.

## Change

- **New** `CoreShop\Component\Index\Service\IndexableClassesProviderInterface` with single method `getIndexableClassNames(): array<string>`.
- **New** `CoreShop\Bundle\IndexBundle\Service\IndexableClassesProvider` — walks `ClassDefinition\Listing` and filters by `IndexableInterface` (same logic that was inline in the controller).
- **New** `CoreShop\Bundle\IndexBundle\Form\Type\IndexablePimcoreClassChoiceType` — ChoiceType that consumes the provider. Used in `IndexType` instead of the generic `PimcoreClassChoiceType`.
- **Refactor** `IndexController::getConfigAction` — replaced the inline loop with a provider call.
- `PimcoreClassChoiceType` in ResourceBundle stays untouched (generic API for "pick any Pimcore class" remains available for other consumers).

## Test plan

- [ ] Index config dropdown shows only `IndexableInterface`-implementing classes (CoreShopProduct, CoreShopCategory, …) — not every DataObject in the system.
- [ ] `GET /pimcore-studio/api/coreshop/indexes/config` returns the same filtered list as before (no behavior change on the JSON response).
- [ ] Behat / static tests pass.