### PR TITLE
[IndexBundle] OpenSearchWorker: Refactor delete methods for index operations

### DIFF
--- a/src/CoreShop/Bundle/IndexBundle/Worker/OpenSearchWorker.php
+++ b/src/CoreShop/Bundle/IndexBundle/Worker/OpenSearchWorker.php
@@ -162,12 +162,17 @@ class OpenSearchWorker extends AbstractWorker implements OpenSearchWorkerInterfa
      */
     public function deleteFromIndexById(IndexInterface $index, int $id): void
     {
-        $this->getClient($index)
-            ->delete([
-                'index' => $this->getIndexName($index->getName()),
-                'id' => (string) $id,
-            ])
-        ;
+        $client = $this->getClient($index);
+        $indexName = $this->getIndexName($index->getName());
+
+        if (!$client->exists(['index' => $indexName, 'id' => (string) $id])) {
+            return;
+        }
+
+        $client->delete([
+            'index' => $indexName,
+            'id' => (string) $id,
+        ]);
     }
 
     /**
@@ -175,12 +180,13 @@ class OpenSearchWorker extends AbstractWorker implements OpenSearchWorkerInterfa
      */
     public function deleteFromIndex(IndexInterface $index, IndexableInterface $object): void
     {
-        $this->getClient($index)
-            ->delete([
-                'index' => $this->getIndexName($index->getName()),
-                'id' => (string) $object->getId(),
-            ])
-        ;
+        $id = $object->getId();
+
+        if (!is_int($id)) {
+            return;
+        }
+
+        $this->deleteFromIndexById($index, $id);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

We experience a lot of failed `IndexDeleteMessages` with the following error:
```log
{"_index":"coreshop_index_os_INDEX_NAME","_id":"1234","_version":1,"result":"not_found","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":1234,"_primary_term":8}
```

Whenever the OpenSearch worker tries to delete a non-existent document in the index, the operation fails as well as the message handling process. This clogs the failed transport of `coreshop_index` and therefore we'd like to introduce this change.

With this PR, we first check if the ID exists in the index before attempting to remove that index document. If it doesn't exist, we abort the deletion process and all is good. 🙂