### PR TITLE
Backport selected fixes from 2026.x to 5.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1387,10 +1387,6 @@
       "resolved": "src/CoreShop/Bundle/ResourceBundle/Resources/assets/pimcore-studio",
       "link": true
     },
-    "node_modules/@coreshop/resource-studio-plugin": {
-      "resolved": "src/CoreShop/Bundle/ResourceBundle/Resources/assets/pimcore-studio",
-      "link": true
-    },
     "node_modules/@coreshop/rule": {
       "resolved": "src/CoreShop/Bundle/RuleBundle/Resources/assets/pimcore-studio",
       "link": true
@@ -1721,6 +1717,262 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/netbsd-arm64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
@@ -1736,6 +1988,22 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
@@ -1755,6 +2023,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/openharmony-arm64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
@@ -1770,6 +2054,70 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2109,10 +2457,34 @@
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
     },
+    "node_modules/@modern-js/node-bundle-require": {
+      "version": "2.65.1",
+      "resolved": "https://registry.npmjs.org/@modern-js/node-bundle-require/-/node-bundle-require-2.65.1.tgz",
+      "integrity": "sha512-XpEkciVEfDbkkLUI662ZFlI9tXsUQtLXk4NRJDBGosNnk9uL2XszmC8sKsdCSLK8AYuPW2w6MTVWuJsOR0EU8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@modern-js/utils": "2.65.1",
+        "@swc/helpers": "0.5.13",
+        "esbuild": "0.17.19"
+      }
+    },
+    "node_modules/@modern-js/utils": {
+      "version": "2.65.1",
+      "resolved": "https://registry.npmjs.org/@modern-js/utils/-/utils-2.65.1.tgz",
+      "integrity": "sha512-HrChf19F+6nALo5XPra8ycjhXGQfGi23+S7Y2FLfTKe8vaNnky8duT/XvRWpbS4pp3SQj8ryO8m/qWSsJ1Rogw==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "0.5.13",
+        "caniuse-lite": "^1.0.30001520",
+        "lodash": "^4.17.21",
+        "rslog": "^1.1.0"
+      }
+    },
     "node_modules/@module-federation/bridge-react-webpack-plugin": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-2.4.0.tgz",
       "integrity": "sha512-yxDv/FJoLiKo2eqIcEWvSnSpJgyYkCzJvNaFsQ2QE3rNv68IeAarlSzCo+d0QyQoPJnTETyHsOh1SSBazIzecw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/sdk": "2.4.0",
@@ -2124,6 +2496,7 @@
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2136,6 +2509,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-2.4.0.tgz",
       "integrity": "sha512-c46g9srroc2hDfrlHyd4Y404SLnw3v9t7Kqij+yK01Hx8C2FyZpyanTGUHVyrmzqp/0y3lPrWURUHkHfk/cJQA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/dts-plugin": "2.4.0",
@@ -2154,6 +2528,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
       "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -2163,6 +2538,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.4.0.tgz",
       "integrity": "sha512-sa6v5ByyqMRHzpwDu0zc7s5mZ39EFIkG0jkRfZU09pzkrJEIy4uZ1Kt9SLysFB8RBMIAvAakAfqDlVWvf1lndg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/error-codes": "2.4.0",
@@ -2190,6 +2566,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.4.0.tgz",
       "integrity": "sha512-NiccK03x7V6bK2LvJNuW520kT+Onx+LJe8lyPsENjXctECCIFJdJOmYr8ABif/kLayWKrrYCzCGVNNiQXANEGQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/bridge-react-webpack-plugin": "2.4.0",
@@ -2231,6 +2608,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2247,6 +2625,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
@@ -2259,12 +2638,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@module-federation/enhanced/node_modules/schema-utils": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
       "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
@@ -2284,12 +2665,14 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.4.0.tgz",
       "integrity": "sha512-ktCZtwOoiKR1URJyBt223OsOFAUvc13rICYif55mt7+DomtELlh5FicnEz6mPLBUwmNM9vyBMvkxOdp+fQ5oUg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@module-federation/inject-external-runtime-core-plugin": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.4.0.tgz",
       "integrity": "sha512-GucUMQmQXcnJC/OnJGvMz3Qy7ap8nAffhQPwDpOSi0Qwm+Iq/ppzG8N3tlLBDmv/O8hiF8HHlg789XK2kcCQtg==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@module-federation/runtime-tools": "2.4.0"
@@ -2299,6 +2682,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.4.0.tgz",
       "integrity": "sha512-Z8j6aog44G1gt4yIAaeDowwZ7xg0aAxTA1Hq69euJK9cR9MDEaLbLUk57jDoiRj6xLwlCiw7ozY+U15BQATk6Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/sdk": "2.4.0",
@@ -2309,6 +2693,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-2.4.0.tgz",
       "integrity": "sha512-ZL+W5rbtgRf9TWRP7Dupt/Svia4bJEOS6gWSj9jzemiLPRPkMO5hjWZKVHIc8oG+Vb25yzozFMmQ+luGi695wg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/dts-plugin": "2.4.0",
@@ -2367,6 +2752,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-2.4.0.tgz",
       "integrity": "sha512-NWH5Vaj/fA9R7PfbwTuE1Ty/pfiAt12On0E3FzoeVPCyb5MxO1i0z+xxRHbPhF4ZOrAPGEMaMQ8Z9vH94EiElw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/bridge-react-webpack-plugin": "2.4.0",
@@ -2395,6 +2781,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.4.0.tgz",
       "integrity": "sha512-IrLAMwUuteRgFlEkg9jrn4bk8uC897FnXvfNmkKD8/qIoNtSd+32e5ouQn+PEYbX/RjRUB1TYveY6rYHpTPkyg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/error-codes": "2.4.0",
@@ -2406,6 +2793,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.4.0.tgz",
       "integrity": "sha512-0S8fDw28DXDW17lTQwq5vfJWe2lG0Lw3+w4vk3DVVImLwXXay+OGxLDxzWUfypWcMznfpnoAnFUMO3PtuXziuA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/error-codes": "2.4.0",
@@ -2416,6 +2804,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.4.0.tgz",
       "integrity": "sha512-BWQsGT4EWscV9bx3bVHEwp6lERBsiYm7rnPiDpwd2fx+hGEpz1IM9Pz35VryHNDXYxw7MzaAuwTMM+L7uN8OYQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/runtime": "2.4.0",
@@ -2426,6 +2815,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.4.0.tgz",
       "integrity": "sha512-eZDdF5B69W9npuka0VL24FY7XDM+YAwwfkscSeWOSqv4/8Hm0xmcmSurlP6NIOrwbeogerRCtEcnx/TFXYjoow==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "node-fetch": "^2.7.0 || ^3.3.2"
@@ -2440,6 +2830,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.4.0.tgz",
       "integrity": "sha512-4v24t6L3dET/6abMOM2fiM3roT0c8mi21/i+uDc6WG7U0i+Xp2SojBppTs6gnT0lkwMTe+u6xIpNQakdUftHsg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "find-pkg": "2.0.0",
@@ -2450,6 +2841,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.4.0.tgz",
       "integrity": "sha512-Ntx0+QsgcwtXlpGjL/Vf2PMdPjUHl07b3yM4kBc1kbRogW3Ee84QneBRi/X3w4/jlz4JKbHjD+CMXaqi2W6hgw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/error-codes": "2.4.0",
@@ -2570,6 +2962,251 @@
         "reflect-metadata": "0.2.x",
         "ts-patch": "^3.3.0",
         "uuid": "^10.0.0"
+      }
+    },
+    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/bridge-react-webpack-plugin": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-0.13.1.tgz",
+      "integrity": "sha512-3RgGd8KcRw5vibnxWa1NUWwfb0tKwn8OvHeQ4GFKzMvDLm+QpCgQd9LeTEBP38wZgGXVtIJR3y5FPnufWswFKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/sdk": "0.13.1",
+        "@types/semver": "7.5.8",
+        "semver": "7.6.3"
+      }
+    },
+    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/cli": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-0.13.1.tgz",
+      "integrity": "sha512-ej7eZTVUiRMor37pkl2y3hbXwcaNvPgbZJVO+hb2c7cKBjWto7AndgR5qcKpcXXXlhbGwtnI+VrgldruKC+AqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@modern-js/node-bundle-require": "2.65.1",
+        "@module-federation/dts-plugin": "0.13.1",
+        "@module-federation/sdk": "0.13.1",
+        "chalk": "3.0.0",
+        "commander": "11.1.0"
+      },
+      "bin": {
+        "mf": "bin/mf.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/dts-plugin": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-0.13.1.tgz",
+      "integrity": "sha512-PQMs57h9s5pCkLWZ0IyDGCcac4VZ+GgJE40pAWrOQ+/AgTC+WFyAT16M7PsRENS57Qed4wWQwgfOjS9zmfxKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.13.1",
+        "@module-federation/managers": "0.13.1",
+        "@module-federation/sdk": "0.13.1",
+        "@module-federation/third-party-dts-extractor": "0.13.1",
+        "adm-zip": "^0.5.10",
+        "ansi-colors": "^4.1.3",
+        "axios": "^1.8.2",
+        "chalk": "3.0.0",
+        "fs-extra": "9.1.0",
+        "isomorphic-ws": "5.0.0",
+        "koa": "2.16.1",
+        "lodash.clonedeepwith": "4.5.0",
+        "log4js": "6.9.1",
+        "node-schedule": "2.1.1",
+        "rambda": "^9.1.0",
+        "ws": "8.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^4.9.0 || ^5.0.0",
+        "vue-tsc": ">=1.0.24"
+      },
+      "peerDependenciesMeta": {
+        "vue-tsc": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/enhanced": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-0.13.1.tgz",
+      "integrity": "sha512-jbbk68RnvNmusGGcXNXVDJAzJOFB/hV+RVV2wWNWmBOVkDZPiWj7aFb0cJAwc9EYZbPel3QzRitZJ73+SaH1IA==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/bridge-react-webpack-plugin": "0.13.1",
+        "@module-federation/cli": "0.13.1",
+        "@module-federation/data-prefetch": "0.13.1",
+        "@module-federation/dts-plugin": "0.13.1",
+        "@module-federation/error-codes": "0.13.1",
+        "@module-federation/inject-external-runtime-core-plugin": "0.13.1",
+        "@module-federation/managers": "0.13.1",
+        "@module-federation/manifest": "0.13.1",
+        "@module-federation/rspack": "0.13.1",
+        "@module-federation/runtime-tools": "0.13.1",
+        "@module-federation/sdk": "0.13.1",
+        "btoa": "^1.2.1",
+        "schema-utils": "^4.3.0",
+        "upath": "2.0.1"
+      },
+      "bin": {
+        "mf": "bin/mf.js"
+      },
+      "peerDependencies": {
+        "typescript": "^4.9.0 || ^5.0.0",
+        "vue-tsc": ">=1.0.24",
+        "webpack": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "vue-tsc": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/enhanced/node_modules/@module-federation/data-prefetch": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/data-prefetch/-/data-prefetch-0.13.1.tgz",
+      "integrity": "sha512-hj3R72rRyune4fb4V4OFmo1Rfa9T9u0so2Q4vt69frPc2NV2FPPJkIvHGs/geGTLOgt4nn7OH1/ukmR3wWvSuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "0.13.1",
+        "@module-federation/sdk": "0.13.1",
+        "fs-extra": "9.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/error-codes": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.13.1.tgz",
+      "integrity": "sha512-azgGDBnFRfqlivHOl96ZjlFUFlukESz2Rnnz/pINiSqoBBNjUE0fcAZP4X6jgrVITuEg90YkruZa7pW9I3m7Uw==",
+      "license": "MIT"
+    },
+    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/inject-external-runtime-core-plugin": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-0.13.1.tgz",
+      "integrity": "sha512-K+ltl2AqVqlsvEds1PffCMLDMlC5lvdkyMXOfcZO6u0O4dZlaTtZbT32NchY7kIEvEsj0wyYhX1i2DnsbHpUBw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@module-federation/runtime-tools": "0.13.1"
+      }
+    },
+    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/managers": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-0.13.1.tgz",
+      "integrity": "sha512-vQMrqSFQxjSuGgByC2wcY7zUTmVfhzCyDpnCCq0PtaozK8DcgwsEMzrAT3dbg8ifGUmse/xiRIbTmS5leKK+UQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/sdk": "0.13.1",
+        "find-pkg": "2.0.0",
+        "fs-extra": "9.1.0"
+      }
+    },
+    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/manifest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-0.13.1.tgz",
+      "integrity": "sha512-XcuFtLycoR0jQj8op+w20V5n459blNBvGXe//AwkEppQERk8SM5kQgIPvOVbZ8zGx7tl/F2HGTDVZlhDiKzIew==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/dts-plugin": "0.13.1",
+        "@module-federation/managers": "0.13.1",
+        "@module-federation/sdk": "0.13.1",
+        "chalk": "3.0.0",
+        "find-pkg": "2.0.0"
+      }
+    },
+    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/rspack": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-0.13.1.tgz",
+      "integrity": "sha512-+qz8sW99SYDULajjjn4rSNaI4rogEPVOZsBvT6y0PdfpMD/wZxvh5HlV0u7+5DgWEjgrdm0cJHBHChlIbV/CMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/bridge-react-webpack-plugin": "0.13.1",
+        "@module-federation/dts-plugin": "0.13.1",
+        "@module-federation/inject-external-runtime-core-plugin": "0.13.1",
+        "@module-federation/managers": "0.13.1",
+        "@module-federation/manifest": "0.13.1",
+        "@module-federation/runtime-tools": "0.13.1",
+        "@module-federation/sdk": "0.13.1",
+        "btoa": "1.2.1"
+      },
+      "peerDependencies": {
+        "@rspack/core": ">=0.7",
+        "typescript": "^4.9.0 || ^5.0.0",
+        "vue-tsc": ">=1.0.24"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "vue-tsc": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/runtime": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.13.1.tgz",
+      "integrity": "sha512-ZHnYvBquDm49LiHfv6fgagMo/cVJneijNJzfPh6S0CJrPS2Tay1bnTXzy8VA5sdIrESagYPaskKMGIj7YfnPug==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.13.1",
+        "@module-federation/runtime-core": "0.13.1",
+        "@module-federation/sdk": "0.13.1"
+      }
+    },
+    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/runtime-core": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.13.1.tgz",
+      "integrity": "sha512-TfyKfkSAentKeuvSsAItk8s5tqQSMfIRTPN2e1aoaq/kFhE+7blps719csyWSX5Lg5Es7WXKMsXHy40UgtBtuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.13.1",
+        "@module-federation/sdk": "0.13.1"
+      }
+    },
+    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/runtime-tools": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.13.1.tgz",
+      "integrity": "sha512-GEF1pxqLc80osIMZmE8j9UKZSaTm2hX2lql8tgIH/O9yK4wnF06k6LL5Ah+wJt+oJv6Dj55ri/MoxMP4SXoPNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "0.13.1",
+        "@module-federation/webpack-bundler-runtime": "0.13.1"
+      }
+    },
+    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/sdk": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.13.1.tgz",
+      "integrity": "sha512-bmf2FGQ0ymZuxYnw9bIUfhV3y6zDhaqgydEjbl4msObKMLGXZqhse2pTIIxBFpIxR1oONKX/y2FAolDCTlWKiw==",
+      "license": "MIT"
+    },
+    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/third-party-dts-extractor": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-0.13.1.tgz",
+      "integrity": "sha512-0kWSupoC0aTxFjJZE5TVPNsoZ9kBsZhkvRxFnUW2vDYLgtvgs2dIrDlNlIXYiS/MaQCNHGyvdNepbchKQiwFaw==",
+      "license": "MIT",
+      "dependencies": {
+        "find-pkg": "2.0.0",
+        "fs-extra": "9.1.0",
+        "resolve": "1.22.8"
+      }
+    },
+    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/webpack-bundler-runtime": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.13.1.tgz",
+      "integrity": "sha512-QSuSIGa09S8mthbB1L6xERqrz+AzPlHR6D7RwAzssAc+IHf40U6NiTLPzUqp9mmKDhC5Tm0EISU0ZHNeJpnpBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "0.13.1",
+        "@module-federation/sdk": "0.13.1"
       }
     },
     "node_modules/@pimcore/studio-ui-bundle/node_modules/antd": {
@@ -2967,6 +3604,18 @@
       "peerDependencies": {
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@pimcore/studio-ui-bundle/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@rc-component/async-validator": {
@@ -3786,6 +4435,15 @@
       },
       "peerDependencies": {
         "@svgr/core": "*"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.13.tgz",
+      "integrity": "sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@tanstack/react-table": {
@@ -4636,6 +5294,19 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -4678,6 +5349,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
@@ -5091,6 +5774,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -5115,6 +5813,18 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -5424,6 +6134,18 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/bubblesets-js": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/bubblesets-js/-/bubblesets-js-2.3.4.tgz",
@@ -5510,6 +6232,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cache-content-type": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-content-type/-/cache-content-type-1.0.1.tgz",
+      "integrity": "sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^2.1.18",
+        "ylru": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/call-bind": {
@@ -5611,6 +6346,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
@@ -5666,6 +6414,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
     "node_modules/codemirror": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
@@ -5707,6 +6465,18 @@
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/comlink": {
@@ -5824,12 +6594,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookies": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/copy-to-clipboard": {
       "version": "3.3.3",
@@ -6493,6 +7297,15 @@
         "url": "https://opencollective.com/date-fns"
       }
     },
+    "node_modules/date-format": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
+      "integrity": "sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.19",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
@@ -6515,6 +7328,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -6569,6 +7388,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT"
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/des.js": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
@@ -6578,6 +7421,16 @@
       "dependencies": {
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/diffie-hellman": {
@@ -6731,6 +7584,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.256",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.256.tgz",
@@ -6777,11 +7636,20 @@
         "node": ">= 4"
       }
     },
+    "node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/encoding": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -7012,6 +7880,43 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
+      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.17.19",
+        "@esbuild/android-arm64": "0.17.19",
+        "@esbuild/android-x64": "0.17.19",
+        "@esbuild/darwin-arm64": "0.17.19",
+        "@esbuild/darwin-x64": "0.17.19",
+        "@esbuild/freebsd-arm64": "0.17.19",
+        "@esbuild/freebsd-x64": "0.17.19",
+        "@esbuild/linux-arm": "0.17.19",
+        "@esbuild/linux-arm64": "0.17.19",
+        "@esbuild/linux-ia32": "0.17.19",
+        "@esbuild/linux-loong64": "0.17.19",
+        "@esbuild/linux-mips64el": "0.17.19",
+        "@esbuild/linux-ppc64": "0.17.19",
+        "@esbuild/linux-riscv64": "0.17.19",
+        "@esbuild/linux-s390x": "0.17.19",
+        "@esbuild/linux-x64": "0.17.19",
+        "@esbuild/netbsd-x64": "0.17.19",
+        "@esbuild/openbsd-x64": "0.17.19",
+        "@esbuild/sunos-x64": "0.17.19",
+        "@esbuild/win32-arm64": "0.17.19",
+        "@esbuild/win32-ia32": "0.17.19",
+        "@esbuild/win32-x64": "0.17.19"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -7020,6 +7925,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -7922,6 +8833,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -7936,6 +8867,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/framer-motion": {
@@ -7963,6 +8910,30 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/fs.realpath": {
@@ -8308,8 +9279,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -8500,12 +9470,63 @@
         "void-elements": "3.1.0"
       }
     },
+    "node_modules/http-assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
+      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
+      "license": "MIT",
+      "dependencies": {
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.8.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-errors/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/https-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/i18next": {
       "version": "23.16.8",
@@ -9310,6 +10331,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -9324,6 +10357,18 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tsscmp": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/keyv": {
@@ -9343,6 +10388,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/koa": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.1.tgz",
+      "integrity": "sha512-umfX9d3iuSxTQP4pnzLOz0HKnPg0FaUUIKcye2lOiz3KPu1Y3M3xlz76dISdFPQs37P9eJz1wUpcTS6KDPn9fA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^1.3.5",
+        "cache-content-type": "^1.0.0",
+        "content-disposition": "~0.5.2",
+        "content-type": "^1.0.4",
+        "cookies": "~0.9.0",
+        "debug": "^4.3.2",
+        "delegates": "^1.0.0",
+        "depd": "^2.0.0",
+        "destroy": "^1.0.4",
+        "encodeurl": "^1.0.2",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.3.0",
+        "http-errors": "^1.6.3",
+        "is-generator-function": "^1.0.7",
+        "koa-compose": "^4.1.0",
+        "koa-convert": "^2.0.0",
+        "on-finished": "^2.3.0",
+        "only": "~0.0.2",
+        "parseurl": "^1.3.2",
+        "statuses": "^1.5.0",
+        "type-is": "^1.6.16",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": "^4.8.4 || ^6.10.1 || ^7.10.1 || >= 8.1.4"
+      }
+    },
+    "node_modules/koa-compose": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
+      "license": "MIT"
+    },
+    "node_modules/koa-convert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-2.0.0.tgz",
+      "integrity": "sha512-asOvN6bFlSnxewce2e/DK3p4tltyfC4VM7ZwuTuepI7dEQVcvpyFuBcEARu1+Hxg8DIwytce2n7jrZtRlPrARA==",
+      "license": "MIT",
+      "dependencies": {
+        "co": "^4.6.0",
+        "koa-compose": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -9443,12 +10541,34 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/lodash.clonedeepwith": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeepwith/-/lodash.clonedeepwith-4.5.0.tgz",
+      "integrity": "sha512-QRBRSxhbtsX1nc0baxSkkK5WlVTTm/s48DSukcGcWZwIyI8Zz+lB+kFiELJXtzfH4Aj6kMWQ1VWW4U5uUDgZMA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log4js": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.9.1.tgz",
+      "integrity": "sha512-1somDdy9sChrr9/f4UlzhdaGfDR2c/SaD2a4T7qEkG4jTS57/B3qmnjLYePwQ8cqWnUHZI0iAKxMBpCZICiZ2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "date-format": "^4.0.14",
+        "debug": "^4.3.4",
+        "flatted": "^3.2.7",
+        "rfdc": "^1.3.0",
+        "streamroller": "^3.1.5"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
     },
     "node_modules/long-timeout": {
       "version": "0.1.1",
@@ -9525,6 +10645,15 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -9582,7 +10711,6 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -9592,7 +10720,6 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -9724,6 +10851,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -9746,7 +10882,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -9935,6 +11071,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -9944,6 +11092,11 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/only": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
+      "integrity": "sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ=="
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -10081,6 +11234,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/path-browserify": {
@@ -10260,6 +11422,15 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
@@ -10343,6 +11514,12 @@
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
       "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
       "license": "ISC"
+    },
+    "node_modules/rambda": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/rambda/-/rambda-9.4.2.tgz",
+      "integrity": "sha512-++euMfxnl7OgaEKwXh9QqThOjMeta2HH001N1v4mYQzBjJBnmXBh2BCK6dZAbICFVXOFUVD3xFG0R3ZPU0mxXw==",
+      "license": "MIT"
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -11323,6 +12500,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -11415,6 +12598,12 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rslog": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/rslog/-/rslog-1.3.2.tgz",
+      "integrity": "sha512-1YyYXBvN0a2b1MSIDLwDTqqgjDzRKxUg/S/+KO6EAgbtZW1B3fdLHAMhEEtvk1patJYMqcRvlp3HQwnxj7AdGQ==",
       "license": "MIT"
     },
     "node_modules/run-parallel": {
@@ -11551,7 +12740,6 @@
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -11571,7 +12759,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -11588,7 +12775,6 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -11600,8 +12786,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/scroll-into-view-if-needed": {
       "version": "3.1.0",
@@ -11687,6 +12872,12 @@
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/sha.js": {
       "version": "2.4.12",
@@ -11920,6 +13111,15 @@
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
       "license": "MIT"
     },
+    "node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -11986,6 +13186,52 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/streamroller": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.1.5.tgz",
+      "integrity": "sha512-KFxaM7XT+irxvdqSP1LGLgNWbYN7ay5owZ3r/8t77p+EtSUAfUgtl7be3xtqtOmGUl9K9YPO2ca8133RlTjvKw==",
+      "license": "MIT",
+      "dependencies": {
+        "date-format": "^4.0.14",
+        "debug": "^4.3.4",
+        "fs-extra": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/streamroller/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/streamroller/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/streamroller/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/string_decoder": {
@@ -12316,7 +13562,6 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
       "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       },
@@ -12449,11 +13694,20 @@
       "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
       "license": "MIT"
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tree-kill": {
@@ -12603,6 +13857,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
     },
     "node_modules/tsx": {
       "version": "4.20.6",
@@ -13073,6 +14336,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -13183,11 +14459,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/upath": {
       "version": "2.0.1",
@@ -13312,6 +14607,15 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/vm-browserify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
@@ -13352,7 +14656,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
@@ -13442,7 +14746,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -13707,6 +15011,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/ylru": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.4.0.tgz",
+      "integrity": "sha512-2OQsPNEmBCvXuFlIni/a+Rn+R2pHW9INm0BxXJ4hVDA8TirqMj+J/Rp9ItLatT/5pZqWwefVrTQcHpixsxnVlA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -13754,7 +15067,7 @@
       "version": "1.0.0",
       "license": "CCL",
       "dependencies": {
-        "@coreshop/resource": "*",
+        "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
         "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
         "@reduxjs/toolkit": "^2.0.1",
@@ -13774,14 +15087,15 @@
         "@coreshop/address": "file:../../../../AddressBundle/Resources/assets/pimcore-studio",
         "@coreshop/currency": "file:../../../../CurrencyBundle/Resources/assets/pimcore-studio",
         "@coreshop/menu": "file:../../../../MenuBundle/Resources/assets/pimcore-studio",
-        "@coreshop/notification": "file:../../../../NotificationBundle/Resources/assets/pimcore-studio",
         "@coreshop/order": "file:../../../../OrderBundle/Resources/assets/pimcore-studio",
         "@coreshop/payment": "file:../../../../PaymentBundle/Resources/assets/pimcore-studio",
+        "@coreshop/pimcore": "file:../../../../PimcoreBundle/Resources/assets/pimcore-studio",
         "@coreshop/product": "file:../../../../ProductBundle/Resources/assets/pimcore-studio",
         "@coreshop/productquantitypricerules": "file:../../../../ProductQuantityPriceRulesBundle/Resources/assets/pimcore-studio",
         "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
         "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
         "@coreshop/shipping": "file:../../../../ShippingBundle/Resources/assets/pimcore-studio",
+        "@coreshop/store": "file:../../../../StoreBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
         "@coreshop/taxation": "file:../../../../TaxationBundle/Resources/assets/pimcore-studio",
         "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
@@ -13799,7 +15113,7 @@
       "version": "1.0.0",
       "license": "CCL",
       "dependencies": {
-        "@coreshop/resource-studio-plugin": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
+        "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
         "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
         "@reduxjs/toolkit": "^2.0.1",
@@ -13816,6 +15130,7 @@
       "version": "1.0.0",
       "license": "CCL",
       "dependencies": {
+        "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
         "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
@@ -13831,6 +15146,8 @@
       "version": "1.0.0",
       "license": "CCL",
       "dependencies": {
+        "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
+        "@coreshop/studio-form": "*",
         "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
@@ -13891,6 +15208,10 @@
       "version": "1.0.0",
       "license": "CCL",
       "dependencies": {
+        "@coreshop/pimcore": "file:../../../../PimcoreBundle/Resources/assets/pimcore-studio",
+        "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
+        "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
+        "@coreshop/store": "file:../../../../StoreBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
         "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
         "@reduxjs/toolkit": "^2.0.1",
@@ -13907,6 +15228,10 @@
       "version": "1.0.0",
       "license": "CCL",
       "dependencies": {
+        "@coreshop/payment": "file:../../../../PaymentBundle/Resources/assets/pimcore-studio",
+        "@coreshop/pimcore": "file:../../../../PimcoreBundle/Resources/assets/pimcore-studio",
+        "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
+        "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
         "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
         "@reduxjs/toolkit": "^2.0.1",
@@ -13923,6 +15248,8 @@
       "version": "1.0.0",
       "license": "CCL",
       "dependencies": {
+        "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
+        "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
         "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
         "@reduxjs/toolkit": "^2.0.1",
@@ -13939,6 +15266,7 @@
       "version": "1.0.0",
       "license": "CCL",
       "dependencies": {
+        "@coreshop/studio-form": "*",
         "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
@@ -13954,6 +15282,9 @@
       "version": "1.0.0",
       "license": "CCL",
       "dependencies": {
+        "@coreshop/pimcore": "file:../../../../PimcoreBundle/Resources/assets/pimcore-studio",
+        "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
+        "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
         "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
         "@reduxjs/toolkit": "^2.0.1",
@@ -13970,6 +15301,8 @@
       "version": "1.0.0",
       "license": "CCL",
       "dependencies": {
+        "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
+        "@coreshop/studio-form": "*",
         "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
@@ -13985,6 +15318,7 @@
       "version": "1.0.0",
       "license": "CCL",
       "dependencies": {
+        "@coreshop/pimcore": "file:../../../../PimcoreBundle/Resources/assets/pimcore-studio",
         "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
@@ -14001,6 +15335,7 @@
       "license": "CCL",
       "dependencies": {
         "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
+        "@coreshop/studio-form": "*",
         "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
@@ -14016,6 +15351,8 @@
       "version": "1.0.0",
       "license": "CCL",
       "dependencies": {
+        "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
+        "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
         "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
         "@reduxjs/toolkit": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "coreshop-studio-plugins",
       "version": "1.0.0",
       "dependencies": {
-        "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+        "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -1717,262 +1717,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
-      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
-      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
-      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
-      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
-      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
-      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
-      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
-      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
-      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
-      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
-      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
-      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
-      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
-      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
-      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
-      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@esbuild/netbsd-arm64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
@@ -1988,22 +1732,6 @@
       ],
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
-      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
@@ -2023,22 +1751,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
-      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@esbuild/openharmony-arm64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
@@ -2054,70 +1766,6 @@
       ],
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
-      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
-      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
-      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
-      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2457,34 +2105,10 @@
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
     },
-    "node_modules/@modern-js/node-bundle-require": {
-      "version": "2.65.1",
-      "resolved": "https://registry.npmjs.org/@modern-js/node-bundle-require/-/node-bundle-require-2.65.1.tgz",
-      "integrity": "sha512-XpEkciVEfDbkkLUI662ZFlI9tXsUQtLXk4NRJDBGosNnk9uL2XszmC8sKsdCSLK8AYuPW2w6MTVWuJsOR0EU8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@modern-js/utils": "2.65.1",
-        "@swc/helpers": "0.5.13",
-        "esbuild": "0.17.19"
-      }
-    },
-    "node_modules/@modern-js/utils": {
-      "version": "2.65.1",
-      "resolved": "https://registry.npmjs.org/@modern-js/utils/-/utils-2.65.1.tgz",
-      "integrity": "sha512-HrChf19F+6nALo5XPra8ycjhXGQfGi23+S7Y2FLfTKe8vaNnky8duT/XvRWpbS4pp3SQj8ryO8m/qWSsJ1Rogw==",
-      "license": "MIT",
-      "dependencies": {
-        "@swc/helpers": "0.5.13",
-        "caniuse-lite": "^1.0.30001520",
-        "lodash": "^4.17.21",
-        "rslog": "^1.1.0"
-      }
-    },
     "node_modules/@module-federation/bridge-react-webpack-plugin": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-2.4.0.tgz",
       "integrity": "sha512-yxDv/FJoLiKo2eqIcEWvSnSpJgyYkCzJvNaFsQ2QE3rNv68IeAarlSzCo+d0QyQoPJnTETyHsOh1SSBazIzecw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/sdk": "2.4.0",
@@ -2496,7 +2120,6 @@
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2509,7 +2132,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-2.4.0.tgz",
       "integrity": "sha512-c46g9srroc2hDfrlHyd4Y404SLnw3v9t7Kqij+yK01Hx8C2FyZpyanTGUHVyrmzqp/0y3lPrWURUHkHfk/cJQA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/dts-plugin": "2.4.0",
@@ -2528,7 +2150,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
       "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -2538,7 +2159,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.4.0.tgz",
       "integrity": "sha512-sa6v5ByyqMRHzpwDu0zc7s5mZ39EFIkG0jkRfZU09pzkrJEIy4uZ1Kt9SLysFB8RBMIAvAakAfqDlVWvf1lndg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/error-codes": "2.4.0",
@@ -2566,7 +2186,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.4.0.tgz",
       "integrity": "sha512-NiccK03x7V6bK2LvJNuW520kT+Onx+LJe8lyPsENjXctECCIFJdJOmYr8ABif/kLayWKrrYCzCGVNNiQXANEGQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/bridge-react-webpack-plugin": "2.4.0",
@@ -2608,7 +2227,6 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2625,7 +2243,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
@@ -2638,14 +2255,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@module-federation/enhanced/node_modules/schema-utils": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
       "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
@@ -2665,14 +2280,12 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.4.0.tgz",
       "integrity": "sha512-ktCZtwOoiKR1URJyBt223OsOFAUvc13rICYif55mt7+DomtELlh5FicnEz6mPLBUwmNM9vyBMvkxOdp+fQ5oUg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@module-federation/inject-external-runtime-core-plugin": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.4.0.tgz",
       "integrity": "sha512-GucUMQmQXcnJC/OnJGvMz3Qy7ap8nAffhQPwDpOSi0Qwm+Iq/ppzG8N3tlLBDmv/O8hiF8HHlg789XK2kcCQtg==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@module-federation/runtime-tools": "2.4.0"
@@ -2682,7 +2295,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.4.0.tgz",
       "integrity": "sha512-Z8j6aog44G1gt4yIAaeDowwZ7xg0aAxTA1Hq69euJK9cR9MDEaLbLUk57jDoiRj6xLwlCiw7ozY+U15BQATk6Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/sdk": "2.4.0",
@@ -2693,7 +2305,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-2.4.0.tgz",
       "integrity": "sha512-ZL+W5rbtgRf9TWRP7Dupt/Svia4bJEOS6gWSj9jzemiLPRPkMO5hjWZKVHIc8oG+Vb25yzozFMmQ+luGi695wg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/dts-plugin": "2.4.0",
@@ -2752,7 +2363,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-2.4.0.tgz",
       "integrity": "sha512-NWH5Vaj/fA9R7PfbwTuE1Ty/pfiAt12On0E3FzoeVPCyb5MxO1i0z+xxRHbPhF4ZOrAPGEMaMQ8Z9vH94EiElw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/bridge-react-webpack-plugin": "2.4.0",
@@ -2781,7 +2391,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.4.0.tgz",
       "integrity": "sha512-IrLAMwUuteRgFlEkg9jrn4bk8uC897FnXvfNmkKD8/qIoNtSd+32e5ouQn+PEYbX/RjRUB1TYveY6rYHpTPkyg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/error-codes": "2.4.0",
@@ -2793,7 +2402,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.4.0.tgz",
       "integrity": "sha512-0S8fDw28DXDW17lTQwq5vfJWe2lG0Lw3+w4vk3DVVImLwXXay+OGxLDxzWUfypWcMznfpnoAnFUMO3PtuXziuA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/error-codes": "2.4.0",
@@ -2804,7 +2412,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.4.0.tgz",
       "integrity": "sha512-BWQsGT4EWscV9bx3bVHEwp6lERBsiYm7rnPiDpwd2fx+hGEpz1IM9Pz35VryHNDXYxw7MzaAuwTMM+L7uN8OYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/runtime": "2.4.0",
@@ -2815,7 +2422,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.4.0.tgz",
       "integrity": "sha512-eZDdF5B69W9npuka0VL24FY7XDM+YAwwfkscSeWOSqv4/8Hm0xmcmSurlP6NIOrwbeogerRCtEcnx/TFXYjoow==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "node-fetch": "^2.7.0 || ^3.3.2"
@@ -2830,7 +2436,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.4.0.tgz",
       "integrity": "sha512-4v24t6L3dET/6abMOM2fiM3roT0c8mi21/i+uDc6WG7U0i+Xp2SojBppTs6gnT0lkwMTe+u6xIpNQakdUftHsg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "find-pkg": "2.0.0",
@@ -2841,7 +2446,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.4.0.tgz",
       "integrity": "sha512-Ntx0+QsgcwtXlpGjL/Vf2PMdPjUHl07b3yM4kBc1kbRogW3Ee84QneBRi/X3w4/jlz4JKbHjD+CMXaqi2W6hgw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/error-codes": "2.4.0",
@@ -2909,9 +2513,9 @@
       }
     },
     "node_modules/@pimcore/studio-ui-bundle": {
-      "version": "1.0.0-canary.20251119-143005-1b35b01",
-      "resolved": "https://registry.npmjs.org/@pimcore/studio-ui-bundle/-/studio-ui-bundle-1.0.0-canary.20251119-143005-1b35b01.tgz",
-      "integrity": "sha512-QF4ziZ3pDKmSnPfKJVzT9kRZY/rXsoHuDKndqw8q9M6rHMNNTh/rbgCncVS4TqPxn5xtJaQho8aZ9Hp91h4TDA==",
+      "version": "2025.4.3",
+      "resolved": "https://registry.npmjs.org/@pimcore/studio-ui-bundle/-/studio-ui-bundle-2025.4.3.tgz",
+      "integrity": "sha512-35ZnmYLHZGTTwLd1xkJ66KOfrv9qKw+3ZZTZU+1kw0SLrZGrEeqEM0TE4KF4pZrOu8L+WwdqCa6v+QqibE00GA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@ant-design/charts": "^2.4.0",
@@ -2927,7 +2531,7 @@
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/modifiers": "^7.0.0",
         "@dnd-kit/sortable": "^8.0.0",
-        "@module-federation/enhanced": "^0.13.1",
+        "@module-federation/enhanced": "^2.2.3",
         "@reduxjs/toolkit": "^2.3.0",
         "@rspack/plugin-react-refresh": "^1.5.1",
         "@tanstack/react-table": "^8.20.5",
@@ -2948,6 +2552,7 @@
         "i18next": "^23.16.8",
         "immer": "^10.1.1",
         "inversify": "6.1.x",
+        "js-yaml": "^4.1.1",
         "leaflet": "^1.9.4",
         "leaflet-draw": "^1.0.4",
         "lodash": "^4.17.21",
@@ -2962,251 +2567,6 @@
         "reflect-metadata": "0.2.x",
         "ts-patch": "^3.3.0",
         "uuid": "^10.0.0"
-      }
-    },
-    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/bridge-react-webpack-plugin": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-0.13.1.tgz",
-      "integrity": "sha512-3RgGd8KcRw5vibnxWa1NUWwfb0tKwn8OvHeQ4GFKzMvDLm+QpCgQd9LeTEBP38wZgGXVtIJR3y5FPnufWswFKw==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/sdk": "0.13.1",
-        "@types/semver": "7.5.8",
-        "semver": "7.6.3"
-      }
-    },
-    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/cli": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-0.13.1.tgz",
-      "integrity": "sha512-ej7eZTVUiRMor37pkl2y3hbXwcaNvPgbZJVO+hb2c7cKBjWto7AndgR5qcKpcXXXlhbGwtnI+VrgldruKC+AqQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@modern-js/node-bundle-require": "2.65.1",
-        "@module-federation/dts-plugin": "0.13.1",
-        "@module-federation/sdk": "0.13.1",
-        "chalk": "3.0.0",
-        "commander": "11.1.0"
-      },
-      "bin": {
-        "mf": "bin/mf.js"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/dts-plugin": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-0.13.1.tgz",
-      "integrity": "sha512-PQMs57h9s5pCkLWZ0IyDGCcac4VZ+GgJE40pAWrOQ+/AgTC+WFyAT16M7PsRENS57Qed4wWQwgfOjS9zmfxKJA==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/error-codes": "0.13.1",
-        "@module-federation/managers": "0.13.1",
-        "@module-federation/sdk": "0.13.1",
-        "@module-federation/third-party-dts-extractor": "0.13.1",
-        "adm-zip": "^0.5.10",
-        "ansi-colors": "^4.1.3",
-        "axios": "^1.8.2",
-        "chalk": "3.0.0",
-        "fs-extra": "9.1.0",
-        "isomorphic-ws": "5.0.0",
-        "koa": "2.16.1",
-        "lodash.clonedeepwith": "4.5.0",
-        "log4js": "6.9.1",
-        "node-schedule": "2.1.1",
-        "rambda": "^9.1.0",
-        "ws": "8.18.0"
-      },
-      "peerDependencies": {
-        "typescript": "^4.9.0 || ^5.0.0",
-        "vue-tsc": ">=1.0.24"
-      },
-      "peerDependenciesMeta": {
-        "vue-tsc": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/enhanced": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-0.13.1.tgz",
-      "integrity": "sha512-jbbk68RnvNmusGGcXNXVDJAzJOFB/hV+RVV2wWNWmBOVkDZPiWj7aFb0cJAwc9EYZbPel3QzRitZJ73+SaH1IA==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "0.13.1",
-        "@module-federation/cli": "0.13.1",
-        "@module-federation/data-prefetch": "0.13.1",
-        "@module-federation/dts-plugin": "0.13.1",
-        "@module-federation/error-codes": "0.13.1",
-        "@module-federation/inject-external-runtime-core-plugin": "0.13.1",
-        "@module-federation/managers": "0.13.1",
-        "@module-federation/manifest": "0.13.1",
-        "@module-federation/rspack": "0.13.1",
-        "@module-federation/runtime-tools": "0.13.1",
-        "@module-federation/sdk": "0.13.1",
-        "btoa": "^1.2.1",
-        "schema-utils": "^4.3.0",
-        "upath": "2.0.1"
-      },
-      "bin": {
-        "mf": "bin/mf.js"
-      },
-      "peerDependencies": {
-        "typescript": "^4.9.0 || ^5.0.0",
-        "vue-tsc": ">=1.0.24",
-        "webpack": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        },
-        "vue-tsc": {
-          "optional": true
-        },
-        "webpack": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/enhanced/node_modules/@module-federation/data-prefetch": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/data-prefetch/-/data-prefetch-0.13.1.tgz",
-      "integrity": "sha512-hj3R72rRyune4fb4V4OFmo1Rfa9T9u0so2Q4vt69frPc2NV2FPPJkIvHGs/geGTLOgt4nn7OH1/ukmR3wWvSuA==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/runtime": "0.13.1",
-        "@module-federation/sdk": "0.13.1",
-        "fs-extra": "9.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/error-codes": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.13.1.tgz",
-      "integrity": "sha512-azgGDBnFRfqlivHOl96ZjlFUFlukESz2Rnnz/pINiSqoBBNjUE0fcAZP4X6jgrVITuEg90YkruZa7pW9I3m7Uw==",
-      "license": "MIT"
-    },
-    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/inject-external-runtime-core-plugin": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-0.13.1.tgz",
-      "integrity": "sha512-K+ltl2AqVqlsvEds1PffCMLDMlC5lvdkyMXOfcZO6u0O4dZlaTtZbT32NchY7kIEvEsj0wyYhX1i2DnsbHpUBw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@module-federation/runtime-tools": "0.13.1"
-      }
-    },
-    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/managers": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-0.13.1.tgz",
-      "integrity": "sha512-vQMrqSFQxjSuGgByC2wcY7zUTmVfhzCyDpnCCq0PtaozK8DcgwsEMzrAT3dbg8ifGUmse/xiRIbTmS5leKK+UQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/sdk": "0.13.1",
-        "find-pkg": "2.0.0",
-        "fs-extra": "9.1.0"
-      }
-    },
-    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/manifest": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-0.13.1.tgz",
-      "integrity": "sha512-XcuFtLycoR0jQj8op+w20V5n459blNBvGXe//AwkEppQERk8SM5kQgIPvOVbZ8zGx7tl/F2HGTDVZlhDiKzIew==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/dts-plugin": "0.13.1",
-        "@module-federation/managers": "0.13.1",
-        "@module-federation/sdk": "0.13.1",
-        "chalk": "3.0.0",
-        "find-pkg": "2.0.0"
-      }
-    },
-    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/rspack": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-0.13.1.tgz",
-      "integrity": "sha512-+qz8sW99SYDULajjjn4rSNaI4rogEPVOZsBvT6y0PdfpMD/wZxvh5HlV0u7+5DgWEjgrdm0cJHBHChlIbV/CMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "0.13.1",
-        "@module-federation/dts-plugin": "0.13.1",
-        "@module-federation/inject-external-runtime-core-plugin": "0.13.1",
-        "@module-federation/managers": "0.13.1",
-        "@module-federation/manifest": "0.13.1",
-        "@module-federation/runtime-tools": "0.13.1",
-        "@module-federation/sdk": "0.13.1",
-        "btoa": "1.2.1"
-      },
-      "peerDependencies": {
-        "@rspack/core": ">=0.7",
-        "typescript": "^4.9.0 || ^5.0.0",
-        "vue-tsc": ">=1.0.24"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        },
-        "vue-tsc": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/runtime": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.13.1.tgz",
-      "integrity": "sha512-ZHnYvBquDm49LiHfv6fgagMo/cVJneijNJzfPh6S0CJrPS2Tay1bnTXzy8VA5sdIrESagYPaskKMGIj7YfnPug==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/error-codes": "0.13.1",
-        "@module-federation/runtime-core": "0.13.1",
-        "@module-federation/sdk": "0.13.1"
-      }
-    },
-    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/runtime-core": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.13.1.tgz",
-      "integrity": "sha512-TfyKfkSAentKeuvSsAItk8s5tqQSMfIRTPN2e1aoaq/kFhE+7blps719csyWSX5Lg5Es7WXKMsXHy40UgtBtuw==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/error-codes": "0.13.1",
-        "@module-federation/sdk": "0.13.1"
-      }
-    },
-    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/runtime-tools": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.13.1.tgz",
-      "integrity": "sha512-GEF1pxqLc80osIMZmE8j9UKZSaTm2hX2lql8tgIH/O9yK4wnF06k6LL5Ah+wJt+oJv6Dj55ri/MoxMP4SXoPNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/runtime": "0.13.1",
-        "@module-federation/webpack-bundler-runtime": "0.13.1"
-      }
-    },
-    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/sdk": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.13.1.tgz",
-      "integrity": "sha512-bmf2FGQ0ymZuxYnw9bIUfhV3y6zDhaqgydEjbl4msObKMLGXZqhse2pTIIxBFpIxR1oONKX/y2FAolDCTlWKiw==",
-      "license": "MIT"
-    },
-    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/third-party-dts-extractor": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-0.13.1.tgz",
-      "integrity": "sha512-0kWSupoC0aTxFjJZE5TVPNsoZ9kBsZhkvRxFnUW2vDYLgtvgs2dIrDlNlIXYiS/MaQCNHGyvdNepbchKQiwFaw==",
-      "license": "MIT",
-      "dependencies": {
-        "find-pkg": "2.0.0",
-        "fs-extra": "9.1.0",
-        "resolve": "1.22.8"
-      }
-    },
-    "node_modules/@pimcore/studio-ui-bundle/node_modules/@module-federation/webpack-bundler-runtime": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.13.1.tgz",
-      "integrity": "sha512-QSuSIGa09S8mthbB1L6xERqrz+AzPlHR6D7RwAzssAc+IHf40U6NiTLPzUqp9mmKDhC5Tm0EISU0ZHNeJpnpBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/runtime": "0.13.1",
-        "@module-federation/sdk": "0.13.1"
       }
     },
     "node_modules/@pimcore/studio-ui-bundle/node_modules/antd": {
@@ -3604,18 +2964,6 @@
       "peerDependencies": {
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/@pimcore/studio-ui-bundle/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@rc-component/async-validator": {
@@ -4442,6 +3790,8 @@
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.13.tgz",
       "integrity": "sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -5294,19 +4644,6 @@
         "node": ">=6.5"
       }
     },
-    "node_modules/accepts": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -5349,18 +4686,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0"
-      }
-    },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
@@ -5541,7 +4866,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
@@ -5774,21 +5098,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -5813,18 +5122,6 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
-        "https-proxy-agent": "^5.0.1",
-        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -6134,18 +5431,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/btoa": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
-      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
-      "license": "(MIT OR Apache-2.0)",
-      "bin": {
-        "btoa": "bin/btoa.js"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/bubblesets-js": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/bubblesets-js/-/bubblesets-js-2.3.4.tgz",
@@ -6234,19 +5519,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/cache-content-type": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cache-content-type/-/cache-content-type-1.0.1.tgz",
-      "integrity": "sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "^2.1.18",
-        "ylru": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -6270,6 +5542,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6283,6 +5556,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -6346,19 +5620,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
@@ -6414,16 +5675,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
-      "license": "MIT",
-      "engines": {
-        "iojs": ">= 1.0.0",
-        "node": ">= 0.12.0"
-      }
-    },
     "node_modules/codemirror": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
@@ -6465,18 +5716,6 @@
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
-      }
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/comlink": {
@@ -6594,46 +5833,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cookies": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
-      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "keygrip": "~1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/copy-to-clipboard": {
       "version": "3.3.3",
@@ -7297,15 +6502,6 @@
         "url": "https://opencollective.com/date-fns"
       }
     },
-    "node_modules/date-format": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
-      "integrity": "sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/dayjs": {
       "version": "1.11.19",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
@@ -7328,12 +6524,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
-      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -7388,30 +6578,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "license": "MIT"
-    },
-    "node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/des.js": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
@@ -7421,16 +6587,6 @@
       "dependencies": {
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
-      }
-    },
-    "node_modules/destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/diffie-hellman": {
@@ -7574,6 +6730,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -7583,12 +6740,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.256",
@@ -7636,20 +6787,11 @@
         "node": ">= 4"
       }
     },
-    "node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/encoding": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -7773,6 +6915,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7782,6 +6925,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7826,6 +6970,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -7838,6 +6983,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7880,43 +7026,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/esbuild": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
-      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/android-arm": "0.17.19",
-        "@esbuild/android-arm64": "0.17.19",
-        "@esbuild/android-x64": "0.17.19",
-        "@esbuild/darwin-arm64": "0.17.19",
-        "@esbuild/darwin-x64": "0.17.19",
-        "@esbuild/freebsd-arm64": "0.17.19",
-        "@esbuild/freebsd-x64": "0.17.19",
-        "@esbuild/linux-arm": "0.17.19",
-        "@esbuild/linux-arm64": "0.17.19",
-        "@esbuild/linux-ia32": "0.17.19",
-        "@esbuild/linux-loong64": "0.17.19",
-        "@esbuild/linux-mips64el": "0.17.19",
-        "@esbuild/linux-ppc64": "0.17.19",
-        "@esbuild/linux-riscv64": "0.17.19",
-        "@esbuild/linux-s390x": "0.17.19",
-        "@esbuild/linux-x64": "0.17.19",
-        "@esbuild/netbsd-x64": "0.17.19",
-        "@esbuild/openbsd-x64": "0.17.19",
-        "@esbuild/sunos-x64": "0.17.19",
-        "@esbuild/win32-arm64": "0.17.19",
-        "@esbuild/win32-ia32": "0.17.19",
-        "@esbuild/win32-x64": "0.17.19"
-      }
-    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -7925,12 +7034,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -8812,6 +7915,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/flexlayout-react": {
@@ -8833,26 +7937,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -8867,22 +7951,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/framer-motion": {
@@ -8910,30 +7978,6 @@
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/fs.realpath": {
@@ -9002,6 +8046,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
       "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9031,6 +8076,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -9055,6 +8101,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -9267,6 +8314,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9279,7 +8327,8 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -9352,6 +8401,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9364,6 +8414,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -9470,63 +8521,12 @@
         "void-elements": "3.1.0"
       }
     },
-    "node_modules/http-assert": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
-      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
-      "license": "MIT",
-      "dependencies": {
-        "deep-equal": "~1.0.1",
-        "http-errors": "~1.8.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/http-errors/node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/https-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/i18next": {
       "version": "23.16.8",
@@ -9646,6 +8646,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -9910,6 +8911,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
       "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.4",
@@ -10022,6 +9024,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -10262,7 +9265,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -10331,18 +9333,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -10357,18 +9347,6 @@
       },
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/keygrip": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
-      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tsscmp": "1.0.6"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/keyv": {
@@ -10388,59 +9366,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/koa": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.1.tgz",
-      "integrity": "sha512-umfX9d3iuSxTQP4pnzLOz0HKnPg0FaUUIKcye2lOiz3KPu1Y3M3xlz76dISdFPQs37P9eJz1wUpcTS6KDPn9fA==",
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "^1.3.5",
-        "cache-content-type": "^1.0.0",
-        "content-disposition": "~0.5.2",
-        "content-type": "^1.0.4",
-        "cookies": "~0.9.0",
-        "debug": "^4.3.2",
-        "delegates": "^1.0.0",
-        "depd": "^2.0.0",
-        "destroy": "^1.0.4",
-        "encodeurl": "^1.0.2",
-        "escape-html": "^1.0.3",
-        "fresh": "~0.5.2",
-        "http-assert": "^1.3.0",
-        "http-errors": "^1.6.3",
-        "is-generator-function": "^1.0.7",
-        "koa-compose": "^4.1.0",
-        "koa-convert": "^2.0.0",
-        "on-finished": "^2.3.0",
-        "only": "~0.0.2",
-        "parseurl": "^1.3.2",
-        "statuses": "^1.5.0",
-        "type-is": "^1.6.16",
-        "vary": "^1.1.2"
-      },
-      "engines": {
-        "node": "^4.8.4 || ^6.10.1 || ^7.10.1 || >= 8.1.4"
-      }
-    },
-    "node_modules/koa-compose": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
-      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
-      "license": "MIT"
-    },
-    "node_modules/koa-convert": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-2.0.0.tgz",
-      "integrity": "sha512-asOvN6bFlSnxewce2e/DK3p4tltyfC4VM7ZwuTuepI7dEQVcvpyFuBcEARu1+Hxg8DIwytce2n7jrZtRlPrARA==",
-      "license": "MIT",
-      "dependencies": {
-        "co": "^4.6.0",
-        "koa-compose": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -10541,34 +9466,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
-    "node_modules/lodash.clonedeepwith": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeepwith/-/lodash.clonedeepwith-4.5.0.tgz",
-      "integrity": "sha512-QRBRSxhbtsX1nc0baxSkkK5WlVTTm/s48DSukcGcWZwIyI8Zz+lB+kFiELJXtzfH4Aj6kMWQ1VWW4U5uUDgZMA==",
-      "license": "MIT"
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/log4js": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.9.1.tgz",
-      "integrity": "sha512-1somDdy9sChrr9/f4UlzhdaGfDR2c/SaD2a4T7qEkG4jTS57/B3qmnjLYePwQ8cqWnUHZI0iAKxMBpCZICiZ2g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "date-format": "^4.0.14",
-        "debug": "^4.3.4",
-        "flatted": "^3.2.7",
-        "rfdc": "^1.3.0",
-        "streamroller": "^3.1.5"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
     },
     "node_modules/long-timeout": {
       "version": "0.1.1",
@@ -10621,6 +9524,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10644,15 +9548,6 @@
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
       "dev": true,
       "license": "CC0-1.0"
-    },
-    "node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -10711,6 +9606,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -10720,6 +9616,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -10851,15 +9748,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -10882,7 +9770,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -11071,18 +9959,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/on-finished": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -11092,11 +9968,6 @@
       "dependencies": {
         "wrappy": "1"
       }
-    },
-    "node_modules/only": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
-      "integrity": "sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ=="
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -11234,15 +10105,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/parseurl": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/path-browserify": {
@@ -11422,15 +10284,6 @@
         "react-is": "^16.13.1"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
@@ -11514,12 +10367,6 @@
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
       "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
       "license": "ISC"
-    },
-    "node_modules/rambda": {
-      "version": "9.4.2",
-      "resolved": "https://registry.npmjs.org/rambda/-/rambda-9.4.2.tgz",
-      "integrity": "sha512-++euMfxnl7OgaEKwXh9QqThOjMeta2HH001N1v4mYQzBjJBnmXBh2BCK6dZAbICFVXOFUVD3xFG0R3ZPU0mxXw==",
-      "license": "MIT"
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -12500,12 +11347,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rfdc": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
-      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-      "license": "MIT"
-    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -12598,12 +11439,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/rslog": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/rslog/-/rslog-1.3.2.tgz",
-      "integrity": "sha512-1YyYXBvN0a2b1MSIDLwDTqqgjDzRKxUg/S/+KO6EAgbtZW1B3fdLHAMhEEtvk1patJYMqcRvlp3HQwnxj7AdGQ==",
       "license": "MIT"
     },
     "node_modules/run-parallel": {
@@ -12707,6 +11542,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -12740,6 +11576,7 @@
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -12759,6 +11596,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -12775,6 +11613,7 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -12786,7 +11625,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/scroll-into-view-if-needed": {
       "version": "3.1.0",
@@ -12872,12 +11712,6 @@
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/setprototypeof": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC"
     },
     "node_modules/sha.js": {
       "version": "2.4.12",
@@ -13111,15 +11945,6 @@
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
       "license": "MIT"
     },
-    "node_modules/statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -13186,52 +12011,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/streamroller": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.1.5.tgz",
-      "integrity": "sha512-KFxaM7XT+irxvdqSP1LGLgNWbYN7ay5owZ3r/8t77p+EtSUAfUgtl7be3xtqtOmGUl9K9YPO2ca8133RlTjvKw==",
-      "license": "MIT",
-      "dependencies": {
-        "date-format": "^4.0.14",
-        "debug": "^4.3.4",
-        "fs-extra": "^8.1.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/streamroller/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/streamroller/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/streamroller/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/string_decoder": {
@@ -13694,20 +12473,11 @@
       "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
       "license": "MIT"
     },
-    "node_modules/toidentifier": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tree-kill": {
@@ -13857,15 +12627,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/tsscmp": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
-      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.x"
-      }
     },
     "node_modules/tsx": {
       "version": "4.20.6",
@@ -14336,19 +13097,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "license": "MIT",
-      "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -14463,7 +13211,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
       "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -14474,15 +13221,6 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
-    },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
     },
     "node_modules/upath": {
       "version": "2.0.1",
@@ -14607,15 +13345,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/vm-browserify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
@@ -14656,7 +13385,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
@@ -14746,7 +13475,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -15011,15 +13740,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/ylru": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.4.0.tgz",
-      "integrity": "sha512-2OQsPNEmBCvXuFlIni/a+Rn+R2pHW9INm0BxXJ4hVDA8TirqMj+J/Rp9ItLatT/5pZqWwefVrTQcHpixsxnVlA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -15069,7 +13789,7 @@
       "dependencies": {
         "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
-        "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+        "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -15098,7 +13818,7 @@
         "@coreshop/store": "file:../../../../StoreBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
         "@coreshop/taxation": "file:../../../../TaxationBundle/Resources/assets/pimcore-studio",
-        "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+        "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -15115,7 +13835,7 @@
       "dependencies": {
         "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
-        "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+        "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -15131,7 +13851,7 @@
       "license": "CCL",
       "dependencies": {
         "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
-        "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+        "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -15148,7 +13868,7 @@
       "dependencies": {
         "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
-        "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+        "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -15163,7 +13883,7 @@
       "version": "1.0.0",
       "license": "CCL",
       "dependencies": {
-        "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+        "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -15178,7 +13898,7 @@
       "version": "1.0.0",
       "license": "CCL",
       "dependencies": {
-        "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+        "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -15193,7 +13913,7 @@
       "version": "1.0.0",
       "license": "CCL",
       "dependencies": {
-        "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+        "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -15213,7 +13933,7 @@
         "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
         "@coreshop/store": "file:../../../../StoreBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
-        "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+        "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -15233,7 +13953,7 @@
         "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
         "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
-        "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+        "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -15251,7 +13971,7 @@
         "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
         "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
-        "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+        "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -15267,7 +13987,7 @@
       "license": "CCL",
       "dependencies": {
         "@coreshop/studio-form": "*",
-        "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+        "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -15286,7 +14006,7 @@
         "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
         "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
-        "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+        "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -15303,7 +14023,7 @@
       "dependencies": {
         "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
-        "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+        "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -15319,7 +14039,7 @@
       "license": "CCL",
       "dependencies": {
         "@coreshop/pimcore": "file:../../../../PimcoreBundle/Resources/assets/pimcore-studio",
-        "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+        "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -15336,7 +14056,7 @@
       "dependencies": {
         "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
-        "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+        "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -15354,7 +14074,7 @@
         "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
         "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
-        "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+        "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -15372,7 +14092,7 @@
         "@coreshop/currency": "file:../../../../CurrencyBundle/Resources/assets/pimcore-studio",
         "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
-        "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+        "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -15387,7 +14107,7 @@
       "version": "1.0.0",
       "license": "CCL",
       "dependencies": {
-        "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+        "@pimcore/studio-ui-bundle": "2025.4.3",
         "antd": "^5.12.0",
         "react": "18.3.x",
         "react-dom": "18.3.x"
@@ -15400,7 +14120,7 @@
       "dependencies": {
         "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
-        "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+        "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -15415,7 +14135,7 @@
       "version": "1.0.0",
       "license": "CCL",
       "dependencies": {
-        "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+        "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -15431,7 +14151,7 @@
       "license": "CCL",
       "dependencies": {
         "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
-        "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+        "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@babel/preset-react": "^7.23.3",
-        "@module-federation/rsbuild-plugin": "^0.13.1",
+        "@module-federation/rsbuild-plugin": "^2.4.0",
         "@rsbuild/core": "^1.3.16",
         "@rsbuild/plugin-node-polyfill": "^1.4.1",
         "@rsbuild/plugin-react": "^1.3.1",
@@ -1721,262 +1721,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
-      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
-      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
-      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
-      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
-      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
-      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
-      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
-      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
-      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
-      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
-      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
-      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
-      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
-      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
-      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
-      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@esbuild/netbsd-arm64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
@@ -1992,22 +1736,6 @@
       ],
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
-      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
@@ -2027,22 +1755,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
-      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@esbuild/openharmony-arm64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
@@ -2058,70 +1770,6 @@
       ],
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
-      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
-      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
-      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
-      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2461,36 +2109,13 @@
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
     },
-    "node_modules/@modern-js/node-bundle-require": {
-      "version": "2.65.1",
-      "resolved": "https://registry.npmjs.org/@modern-js/node-bundle-require/-/node-bundle-require-2.65.1.tgz",
-      "integrity": "sha512-XpEkciVEfDbkkLUI662ZFlI9tXsUQtLXk4NRJDBGosNnk9uL2XszmC8sKsdCSLK8AYuPW2w6MTVWuJsOR0EU8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@modern-js/utils": "2.65.1",
-        "@swc/helpers": "0.5.13",
-        "esbuild": "0.17.19"
-      }
-    },
-    "node_modules/@modern-js/utils": {
-      "version": "2.65.1",
-      "resolved": "https://registry.npmjs.org/@modern-js/utils/-/utils-2.65.1.tgz",
-      "integrity": "sha512-HrChf19F+6nALo5XPra8ycjhXGQfGi23+S7Y2FLfTKe8vaNnky8duT/XvRWpbS4pp3SQj8ryO8m/qWSsJ1Rogw==",
-      "license": "MIT",
-      "dependencies": {
-        "@swc/helpers": "0.5.13",
-        "caniuse-lite": "^1.0.30001520",
-        "lodash": "^4.17.21",
-        "rslog": "^1.1.0"
-      }
-    },
     "node_modules/@module-federation/bridge-react-webpack-plugin": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-0.13.1.tgz",
-      "integrity": "sha512-3RgGd8KcRw5vibnxWa1NUWwfb0tKwn8OvHeQ4GFKzMvDLm+QpCgQd9LeTEBP38wZgGXVtIJR3y5FPnufWswFKw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-2.4.0.tgz",
+      "integrity": "sha512-yxDv/FJoLiKo2eqIcEWvSnSpJgyYkCzJvNaFsQ2QE3rNv68IeAarlSzCo+d0QyQoPJnTETyHsOh1SSBazIzecw==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/sdk": "0.13.1",
+        "@module-federation/sdk": "2.4.0",
         "@types/semver": "7.5.8",
         "semver": "7.6.3"
       }
@@ -2508,16 +2133,15 @@
       }
     },
     "node_modules/@module-federation/cli": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-0.13.1.tgz",
-      "integrity": "sha512-ej7eZTVUiRMor37pkl2y3hbXwcaNvPgbZJVO+hb2c7cKBjWto7AndgR5qcKpcXXXlhbGwtnI+VrgldruKC+AqQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-2.4.0.tgz",
+      "integrity": "sha512-c46g9srroc2hDfrlHyd4Y404SLnw3v9t7Kqij+yK01Hx8C2FyZpyanTGUHVyrmzqp/0y3lPrWURUHkHfk/cJQA==",
       "license": "MIT",
       "dependencies": {
-        "@modern-js/node-bundle-require": "2.65.1",
-        "@module-federation/dts-plugin": "0.13.1",
-        "@module-federation/sdk": "0.13.1",
-        "chalk": "3.0.0",
-        "commander": "11.1.0"
+        "@module-federation/dts-plugin": "2.4.0",
+        "@module-federation/sdk": "2.4.0",
+        "commander": "11.1.0",
+        "jiti": "2.4.2"
       },
       "bin": {
         "mf": "bin/mf.js"
@@ -2526,42 +2150,30 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@module-federation/data-prefetch": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/data-prefetch/-/data-prefetch-0.13.1.tgz",
-      "integrity": "sha512-hj3R72rRyune4fb4V4OFmo1Rfa9T9u0so2Q4vt69frPc2NV2FPPJkIvHGs/geGTLOgt4nn7OH1/ukmR3wWvSuA==",
+    "node_modules/@module-federation/cli/node_modules/jiti": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
       "license": "MIT",
-      "dependencies": {
-        "@module-federation/runtime": "0.13.1",
-        "@module-federation/sdk": "0.13.1",
-        "fs-extra": "9.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/@module-federation/dts-plugin": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-0.13.1.tgz",
-      "integrity": "sha512-PQMs57h9s5pCkLWZ0IyDGCcac4VZ+GgJE40pAWrOQ+/AgTC+WFyAT16M7PsRENS57Qed4wWQwgfOjS9zmfxKJA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.4.0.tgz",
+      "integrity": "sha512-sa6v5ByyqMRHzpwDu0zc7s5mZ39EFIkG0jkRfZU09pzkrJEIy4uZ1Kt9SLysFB8RBMIAvAakAfqDlVWvf1lndg==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "0.13.1",
-        "@module-federation/managers": "0.13.1",
-        "@module-federation/sdk": "0.13.1",
-        "@module-federation/third-party-dts-extractor": "0.13.1",
-        "adm-zip": "^0.5.10",
-        "ansi-colors": "^4.1.3",
-        "axios": "^1.8.2",
-        "chalk": "3.0.0",
-        "fs-extra": "9.1.0",
+        "@module-federation/error-codes": "2.4.0",
+        "@module-federation/managers": "2.4.0",
+        "@module-federation/sdk": "2.4.0",
+        "@module-federation/third-party-dts-extractor": "2.4.0",
+        "adm-zip": "0.5.10",
+        "ansi-colors": "4.1.3",
         "isomorphic-ws": "5.0.0",
-        "koa": "2.16.1",
-        "lodash.clonedeepwith": "4.5.0",
-        "log4js": "6.9.1",
         "node-schedule": "2.1.1",
-        "rambda": "^9.1.0",
+        "undici": "7.24.7",
         "ws": "8.18.0"
       },
       "peerDependencies": {
@@ -2575,24 +2187,24 @@
       }
     },
     "node_modules/@module-federation/enhanced": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-0.13.1.tgz",
-      "integrity": "sha512-jbbk68RnvNmusGGcXNXVDJAzJOFB/hV+RVV2wWNWmBOVkDZPiWj7aFb0cJAwc9EYZbPel3QzRitZJ73+SaH1IA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.4.0.tgz",
+      "integrity": "sha512-NiccK03x7V6bK2LvJNuW520kT+Onx+LJe8lyPsENjXctECCIFJdJOmYr8ABif/kLayWKrrYCzCGVNNiQXANEGQ==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "0.13.1",
-        "@module-federation/cli": "0.13.1",
-        "@module-federation/data-prefetch": "0.13.1",
-        "@module-federation/dts-plugin": "0.13.1",
-        "@module-federation/error-codes": "0.13.1",
-        "@module-federation/inject-external-runtime-core-plugin": "0.13.1",
-        "@module-federation/managers": "0.13.1",
-        "@module-federation/manifest": "0.13.1",
-        "@module-federation/rspack": "0.13.1",
-        "@module-federation/runtime-tools": "0.13.1",
-        "@module-federation/sdk": "0.13.1",
-        "btoa": "^1.2.1",
-        "schema-utils": "^4.3.0",
+        "@module-federation/bridge-react-webpack-plugin": "2.4.0",
+        "@module-federation/cli": "2.4.0",
+        "@module-federation/dts-plugin": "2.4.0",
+        "@module-federation/error-codes": "2.4.0",
+        "@module-federation/inject-external-runtime-core-plugin": "2.4.0",
+        "@module-federation/managers": "2.4.0",
+        "@module-federation/manifest": "2.4.0",
+        "@module-federation/rspack": "2.4.0",
+        "@module-federation/runtime-tools": "2.4.0",
+        "@module-federation/sdk": "2.4.0",
+        "@module-federation/webpack-bundler-runtime": "2.4.0",
+        "schema-utils": "4.3.0",
+        "tapable": "2.3.0",
         "upath": "2.0.1"
       },
       "bin": {
@@ -2615,60 +2227,135 @@
         }
       }
     },
+    "node_modules/@module-federation/enhanced/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@module-federation/enhanced/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/@module-federation/enhanced/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/enhanced/node_modules/schema-utils": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
+      "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/@module-federation/error-codes": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.13.1.tgz",
-      "integrity": "sha512-azgGDBnFRfqlivHOl96ZjlFUFlukESz2Rnnz/pINiSqoBBNjUE0fcAZP4X6jgrVITuEg90YkruZa7pW9I3m7Uw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.4.0.tgz",
+      "integrity": "sha512-ktCZtwOoiKR1URJyBt223OsOFAUvc13rICYif55mt7+DomtELlh5FicnEz6mPLBUwmNM9vyBMvkxOdp+fQ5oUg==",
       "license": "MIT"
     },
     "node_modules/@module-federation/inject-external-runtime-core-plugin": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-0.13.1.tgz",
-      "integrity": "sha512-K+ltl2AqVqlsvEds1PffCMLDMlC5lvdkyMXOfcZO6u0O4dZlaTtZbT32NchY7kIEvEsj0wyYhX1i2DnsbHpUBw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.4.0.tgz",
+      "integrity": "sha512-GucUMQmQXcnJC/OnJGvMz3Qy7ap8nAffhQPwDpOSi0Qwm+Iq/ppzG8N3tlLBDmv/O8hiF8HHlg789XK2kcCQtg==",
       "license": "MIT",
       "peerDependencies": {
-        "@module-federation/runtime-tools": "0.13.1"
+        "@module-federation/runtime-tools": "2.4.0"
       }
     },
     "node_modules/@module-federation/managers": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-0.13.1.tgz",
-      "integrity": "sha512-vQMrqSFQxjSuGgByC2wcY7zUTmVfhzCyDpnCCq0PtaozK8DcgwsEMzrAT3dbg8ifGUmse/xiRIbTmS5leKK+UQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.4.0.tgz",
+      "integrity": "sha512-Z8j6aog44G1gt4yIAaeDowwZ7xg0aAxTA1Hq69euJK9cR9MDEaLbLUk57jDoiRj6xLwlCiw7ozY+U15BQATk6Q==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/sdk": "0.13.1",
-        "find-pkg": "2.0.0",
-        "fs-extra": "9.1.0"
-      }
-    },
-    "node_modules/@module-federation/manifest": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-0.13.1.tgz",
-      "integrity": "sha512-XcuFtLycoR0jQj8op+w20V5n459blNBvGXe//AwkEppQERk8SM5kQgIPvOVbZ8zGx7tl/F2HGTDVZlhDiKzIew==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/dts-plugin": "0.13.1",
-        "@module-federation/managers": "0.13.1",
-        "@module-federation/sdk": "0.13.1",
-        "chalk": "3.0.0",
+        "@module-federation/sdk": "2.4.0",
         "find-pkg": "2.0.0"
       }
     },
-    "node_modules/@module-federation/rsbuild-plugin": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/rsbuild-plugin/-/rsbuild-plugin-0.13.1.tgz",
-      "integrity": "sha512-O+FQSN77l64FMiF9TwNVMaxkwqjxIHjwohn9gnNA2bxLPA/wCeXEroLfl+4+8N4avOEIyQ1t6z3d5ituHbPl5A==",
+    "node_modules/@module-federation/manifest": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-2.4.0.tgz",
+      "integrity": "sha512-ZL+W5rbtgRf9TWRP7Dupt/Svia4bJEOS6gWSj9jzemiLPRPkMO5hjWZKVHIc8oG+Vb25yzozFMmQ+luGi695wg==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/dts-plugin": "2.4.0",
+        "@module-federation/managers": "2.4.0",
+        "@module-federation/sdk": "2.4.0",
+        "find-pkg": "2.0.0"
+      }
+    },
+    "node_modules/@module-federation/node": {
+      "version": "2.7.42",
+      "resolved": "https://registry.npmjs.org/@module-federation/node/-/node-2.7.42.tgz",
+      "integrity": "sha512-aX/T4L9bPbOgNLIW+30k/dA2Iohoy9/jf4yG1ka6Hkuo5h7iEBeZiQkwIqC06cnCbtKL1HnAiYlXHmrDPW5xvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/enhanced": "0.13.1",
-        "@module-federation/sdk": "0.13.1"
+        "@module-federation/enhanced": "2.4.0",
+        "@module-federation/runtime": "2.4.0",
+        "@module-federation/sdk": "2.4.0",
+        "encoding": "0.1.13",
+        "node-fetch": "2.7.0",
+        "tapable": "2.3.0"
+      },
+      "peerDependencies": {
+        "webpack": "^5.40.0"
+      },
+      "peerDependenciesMeta": {
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@module-federation/rsbuild-plugin": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/rsbuild-plugin/-/rsbuild-plugin-2.4.0.tgz",
+      "integrity": "sha512-1hl9xoYG/oWkO4olUWV912j3zwePvINm+2DUCaCPYUHH8qq1Gf1qDI3uD4S7vZmS9O1OVbvxjAni4tfTDxlwJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/enhanced": "2.4.0",
+        "@module-federation/node": "2.7.42",
+        "@module-federation/sdk": "2.4.0"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@rsbuild/core": "1.x"
+        "@rsbuild/core": "^1.3.21 || ^2.0.0-0"
       },
       "peerDependenciesMeta": {
         "@rsbuild/core": {
@@ -2677,22 +2364,21 @@
       }
     },
     "node_modules/@module-federation/rspack": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-0.13.1.tgz",
-      "integrity": "sha512-+qz8sW99SYDULajjjn4rSNaI4rogEPVOZsBvT6y0PdfpMD/wZxvh5HlV0u7+5DgWEjgrdm0cJHBHChlIbV/CMQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-2.4.0.tgz",
+      "integrity": "sha512-NWH5Vaj/fA9R7PfbwTuE1Ty/pfiAt12On0E3FzoeVPCyb5MxO1i0z+xxRHbPhF4ZOrAPGEMaMQ8Z9vH94EiElw==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "0.13.1",
-        "@module-federation/dts-plugin": "0.13.1",
-        "@module-federation/inject-external-runtime-core-plugin": "0.13.1",
-        "@module-federation/managers": "0.13.1",
-        "@module-federation/manifest": "0.13.1",
-        "@module-federation/runtime-tools": "0.13.1",
-        "@module-federation/sdk": "0.13.1",
-        "btoa": "1.2.1"
+        "@module-federation/bridge-react-webpack-plugin": "2.4.0",
+        "@module-federation/dts-plugin": "2.4.0",
+        "@module-federation/inject-external-runtime-core-plugin": "2.4.0",
+        "@module-federation/managers": "2.4.0",
+        "@module-federation/manifest": "2.4.0",
+        "@module-federation/runtime-tools": "2.4.0",
+        "@module-federation/sdk": "2.4.0"
       },
       "peerDependencies": {
-        "@rspack/core": ">=0.7",
+        "@rspack/core": "^0.7.0 || ^1.0.0 || ^2.0.0-0",
         "typescript": "^4.9.0 || ^5.0.0",
         "vue-tsc": ">=1.0.24"
       },
@@ -2706,61 +2392,69 @@
       }
     },
     "node_modules/@module-federation/runtime": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.13.1.tgz",
-      "integrity": "sha512-ZHnYvBquDm49LiHfv6fgagMo/cVJneijNJzfPh6S0CJrPS2Tay1bnTXzy8VA5sdIrESagYPaskKMGIj7YfnPug==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.4.0.tgz",
+      "integrity": "sha512-IrLAMwUuteRgFlEkg9jrn4bk8uC897FnXvfNmkKD8/qIoNtSd+32e5ouQn+PEYbX/RjRUB1TYveY6rYHpTPkyg==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "0.13.1",
-        "@module-federation/runtime-core": "0.13.1",
-        "@module-federation/sdk": "0.13.1"
+        "@module-federation/error-codes": "2.4.0",
+        "@module-federation/runtime-core": "2.4.0",
+        "@module-federation/sdk": "2.4.0"
       }
     },
     "node_modules/@module-federation/runtime-core": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.13.1.tgz",
-      "integrity": "sha512-TfyKfkSAentKeuvSsAItk8s5tqQSMfIRTPN2e1aoaq/kFhE+7blps719csyWSX5Lg5Es7WXKMsXHy40UgtBtuw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.4.0.tgz",
+      "integrity": "sha512-0S8fDw28DXDW17lTQwq5vfJWe2lG0Lw3+w4vk3DVVImLwXXay+OGxLDxzWUfypWcMznfpnoAnFUMO3PtuXziuA==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "0.13.1",
-        "@module-federation/sdk": "0.13.1"
+        "@module-federation/error-codes": "2.4.0",
+        "@module-federation/sdk": "2.4.0"
       }
     },
     "node_modules/@module-federation/runtime-tools": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.13.1.tgz",
-      "integrity": "sha512-GEF1pxqLc80osIMZmE8j9UKZSaTm2hX2lql8tgIH/O9yK4wnF06k6LL5Ah+wJt+oJv6Dj55ri/MoxMP4SXoPNA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.4.0.tgz",
+      "integrity": "sha512-BWQsGT4EWscV9bx3bVHEwp6lERBsiYm7rnPiDpwd2fx+hGEpz1IM9Pz35VryHNDXYxw7MzaAuwTMM+L7uN8OYQ==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime": "0.13.1",
-        "@module-federation/webpack-bundler-runtime": "0.13.1"
+        "@module-federation/runtime": "2.4.0",
+        "@module-federation/webpack-bundler-runtime": "2.4.0"
       }
     },
     "node_modules/@module-federation/sdk": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.13.1.tgz",
-      "integrity": "sha512-bmf2FGQ0ymZuxYnw9bIUfhV3y6zDhaqgydEjbl4msObKMLGXZqhse2pTIIxBFpIxR1oONKX/y2FAolDCTlWKiw==",
-      "license": "MIT"
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.4.0.tgz",
+      "integrity": "sha512-eZDdF5B69W9npuka0VL24FY7XDM+YAwwfkscSeWOSqv4/8Hm0xmcmSurlP6NIOrwbeogerRCtEcnx/TFXYjoow==",
+      "license": "MIT",
+      "peerDependencies": {
+        "node-fetch": "^2.7.0 || ^3.3.2"
+      },
+      "peerDependenciesMeta": {
+        "node-fetch": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@module-federation/third-party-dts-extractor": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-0.13.1.tgz",
-      "integrity": "sha512-0kWSupoC0aTxFjJZE5TVPNsoZ9kBsZhkvRxFnUW2vDYLgtvgs2dIrDlNlIXYiS/MaQCNHGyvdNepbchKQiwFaw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.4.0.tgz",
+      "integrity": "sha512-4v24t6L3dET/6abMOM2fiM3roT0c8mi21/i+uDc6WG7U0i+Xp2SojBppTs6gnT0lkwMTe+u6xIpNQakdUftHsg==",
       "license": "MIT",
       "dependencies": {
         "find-pkg": "2.0.0",
-        "fs-extra": "9.1.0",
         "resolve": "1.22.8"
       }
     },
     "node_modules/@module-federation/webpack-bundler-runtime": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.13.1.tgz",
-      "integrity": "sha512-QSuSIGa09S8mthbB1L6xERqrz+AzPlHR6D7RwAzssAc+IHf40U6NiTLPzUqp9mmKDhC5Tm0EISU0ZHNeJpnpBQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.4.0.tgz",
+      "integrity": "sha512-Ntx0+QsgcwtXlpGjL/Vf2PMdPjUHl07b3yM4kBc1kbRogW3Ee84QneBRi/X3w4/jlz4JKbHjD+CMXaqi2W6hgw==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime": "0.13.1",
-        "@module-federation/sdk": "0.13.1"
+        "@module-federation/error-codes": "2.4.0",
+        "@module-federation/runtime": "2.4.0",
+        "@module-federation/sdk": "2.4.0"
       }
     },
     "node_modules/@naoak/workerize-transferable": {
@@ -4094,15 +3788,6 @@
         "@svgr/core": "*"
       }
     },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.13.tgz",
-      "integrity": "sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@tanstack/react-table": {
       "version": "8.21.3",
       "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
@@ -4951,19 +4636,6 @@
         "node": ">=6.5"
       }
     },
-    "node_modules/accepts": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -5000,12 +4672,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=6.0"
       }
     },
     "node_modules/ajv": {
@@ -5419,21 +5091,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -5458,17 +5115,6 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -5778,18 +5424,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/btoa": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
-      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
-      "license": "(MIT OR Apache-2.0)",
-      "bin": {
-        "btoa": "bin/btoa.js"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/bubblesets-js": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/bubblesets-js/-/bubblesets-js-2.3.4.tgz",
@@ -5876,19 +5510,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/cache-content-type": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cache-content-type/-/cache-content-type-1.0.1.tgz",
-      "integrity": "sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "^2.1.18",
-        "ylru": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
       }
     },
     "node_modules/call-bind": {
@@ -5990,19 +5611,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
@@ -6058,16 +5666,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
-      "license": "MIT",
-      "engines": {
-        "iojs": ">= 1.0.0",
-        "node": ">= 0.12.0"
-      }
-    },
     "node_modules/codemirror": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
@@ -6109,18 +5707,6 @@
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
-      }
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/comlink": {
@@ -6238,46 +5824,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cookies": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
-      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "keygrip": "~1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/copy-to-clipboard": {
       "version": "3.3.3",
@@ -6941,15 +6493,6 @@
         "url": "https://opencollective.com/date-fns"
       }
     },
-    "node_modules/date-format": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
-      "integrity": "sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/dayjs": {
       "version": "1.11.19",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
@@ -6972,12 +6515,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
-      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -7032,30 +6569,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "license": "MIT"
-    },
-    "node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/des.js": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
@@ -7065,16 +6578,6 @@
       "dependencies": {
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
-      }
-    },
-    "node_modules/destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/diffie-hellman": {
@@ -7228,12 +6731,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT"
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.256",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.256.tgz",
@@ -7280,13 +6777,14 @@
         "node": ">= 4"
       }
     },
-    "node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "devOptional": true,
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -7514,43 +7012,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/esbuild": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
-      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/android-arm": "0.17.19",
-        "@esbuild/android-arm64": "0.17.19",
-        "@esbuild/android-x64": "0.17.19",
-        "@esbuild/darwin-arm64": "0.17.19",
-        "@esbuild/darwin-x64": "0.17.19",
-        "@esbuild/freebsd-arm64": "0.17.19",
-        "@esbuild/freebsd-x64": "0.17.19",
-        "@esbuild/linux-arm": "0.17.19",
-        "@esbuild/linux-arm64": "0.17.19",
-        "@esbuild/linux-ia32": "0.17.19",
-        "@esbuild/linux-loong64": "0.17.19",
-        "@esbuild/linux-mips64el": "0.17.19",
-        "@esbuild/linux-ppc64": "0.17.19",
-        "@esbuild/linux-riscv64": "0.17.19",
-        "@esbuild/linux-s390x": "0.17.19",
-        "@esbuild/linux-x64": "0.17.19",
-        "@esbuild/netbsd-x64": "0.17.19",
-        "@esbuild/openbsd-x64": "0.17.19",
-        "@esbuild/sunos-x64": "0.17.19",
-        "@esbuild/win32-arm64": "0.17.19",
-        "@esbuild/win32-ia32": "0.17.19",
-        "@esbuild/win32-x64": "0.17.19"
-      }
-    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -7559,12 +7020,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -8467,26 +7922,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -8501,22 +7936,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/framer-motion": {
@@ -8544,30 +7963,6 @@
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/fs.realpath": {
@@ -8913,7 +8308,8 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -9102,44 +8498,6 @@
       "license": "MIT",
       "dependencies": {
         "void-elements": "3.1.0"
-      }
-    },
-    "node_modules/http-assert": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
-      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
-      "license": "MIT",
-      "dependencies": {
-        "deep-equal": "~1.0.1",
-        "http-errors": "~1.8.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/http-errors/node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/https-browserify": {
@@ -9952,18 +9310,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -9978,19 +9324,6 @@
       },
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/keygrip": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
-      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT",
-      "dependencies": {
-        "tsscmp": "1.0.6"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/keyv": {
@@ -10010,59 +9343,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/koa": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.1.tgz",
-      "integrity": "sha512-umfX9d3iuSxTQP4pnzLOz0HKnPg0FaUUIKcye2lOiz3KPu1Y3M3xlz76dISdFPQs37P9eJz1wUpcTS6KDPn9fA==",
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "^1.3.5",
-        "cache-content-type": "^1.0.0",
-        "content-disposition": "~0.5.2",
-        "content-type": "^1.0.4",
-        "cookies": "~0.9.0",
-        "debug": "^4.3.2",
-        "delegates": "^1.0.0",
-        "depd": "^2.0.0",
-        "destroy": "^1.0.4",
-        "encodeurl": "^1.0.2",
-        "escape-html": "^1.0.3",
-        "fresh": "~0.5.2",
-        "http-assert": "^1.3.0",
-        "http-errors": "^1.6.3",
-        "is-generator-function": "^1.0.7",
-        "koa-compose": "^4.1.0",
-        "koa-convert": "^2.0.0",
-        "on-finished": "^2.3.0",
-        "only": "~0.0.2",
-        "parseurl": "^1.3.2",
-        "statuses": "^1.5.0",
-        "type-is": "^1.6.16",
-        "vary": "^1.1.2"
-      },
-      "engines": {
-        "node": "^4.8.4 || ^6.10.1 || ^7.10.1 || >= 8.1.4"
-      }
-    },
-    "node_modules/koa-compose": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
-      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
-      "license": "MIT"
-    },
-    "node_modules/koa-convert": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-2.0.0.tgz",
-      "integrity": "sha512-asOvN6bFlSnxewce2e/DK3p4tltyfC4VM7ZwuTuepI7dEQVcvpyFuBcEARu1+Hxg8DIwytce2n7jrZtRlPrARA==",
-      "license": "MIT",
-      "dependencies": {
-        "co": "^4.6.0",
-        "koa-compose": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -10163,34 +9443,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
-    "node_modules/lodash.clonedeepwith": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeepwith/-/lodash.clonedeepwith-4.5.0.tgz",
-      "integrity": "sha512-QRBRSxhbtsX1nc0baxSkkK5WlVTTm/s48DSukcGcWZwIyI8Zz+lB+kFiELJXtzfH4Aj6kMWQ1VWW4U5uUDgZMA==",
-      "license": "MIT"
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/log4js": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.9.1.tgz",
-      "integrity": "sha512-1somDdy9sChrr9/f4UlzhdaGfDR2c/SaD2a4T7qEkG4jTS57/B3qmnjLYePwQ8cqWnUHZI0iAKxMBpCZICiZ2g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "date-format": "^4.0.14",
-        "debug": "^4.3.4",
-        "flatted": "^3.2.7",
-        "rfdc": "^1.3.0",
-        "streamroller": "^3.1.5"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
     },
     "node_modules/long-timeout": {
       "version": "0.1.1",
@@ -10267,15 +9525,6 @@
       "dev": true,
       "license": "CC0-1.0"
     },
-    "node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -10333,6 +9582,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -10342,6 +9592,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -10473,15 +9724,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -10498,6 +9740,27 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-releases": {
@@ -10672,18 +9935,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/on-finished": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -10693,11 +9944,6 @@
       "dependencies": {
         "wrappy": "1"
       }
-    },
-    "node_modules/only": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
-      "integrity": "sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ=="
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -10835,15 +10081,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/parseurl": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/path-browserify": {
@@ -11023,12 +10260,6 @@
         "react-is": "^16.13.1"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
-    },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
@@ -11112,12 +10343,6 @@
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
       "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
       "license": "ISC"
-    },
-    "node_modules/rambda": {
-      "version": "9.4.2",
-      "resolved": "https://registry.npmjs.org/rambda/-/rambda-9.4.2.tgz",
-      "integrity": "sha512-++euMfxnl7OgaEKwXh9QqThOjMeta2HH001N1v4mYQzBjJBnmXBh2BCK6dZAbICFVXOFUVD3xFG0R3ZPU0mxXw==",
-      "license": "MIT"
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -12098,12 +11323,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rfdc": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
-      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-      "license": "MIT"
-    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -12196,12 +11415,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/rslog": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/rslog/-/rslog-1.3.0.tgz",
-      "integrity": "sha512-93DpwwaiRrLz7fJ5z6Uwb171hHBws1VVsWjU6IruLFX63BicLA44QNu0sfn3guKHnBHZMFSKO8akfx5QhjuegQ==",
       "license": "MIT"
     },
     "node_modules/run-parallel": {
@@ -12338,6 +11551,7 @@
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -12357,6 +11571,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -12373,6 +11588,7 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -12384,7 +11600,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/scroll-into-view-if-needed": {
       "version": "3.1.0",
@@ -12470,12 +11687,6 @@
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/setprototypeof": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC"
     },
     "node_modules/sha.js": {
       "version": "2.4.12",
@@ -12709,15 +11920,6 @@
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
       "license": "MIT"
     },
-    "node_modules/statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -12784,52 +11986,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/streamroller": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.1.5.tgz",
-      "integrity": "sha512-KFxaM7XT+irxvdqSP1LGLgNWbYN7ay5owZ3r/8t77p+EtSUAfUgtl7be3xtqtOmGUl9K9YPO2ca8133RlTjvKw==",
-      "license": "MIT",
-      "dependencies": {
-        "date-format": "^4.0.14",
-        "debug": "^4.3.4",
-        "fs-extra": "^8.1.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/streamroller/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/streamroller/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/streamroller/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/string_decoder": {
@@ -13293,14 +12449,12 @@
       "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
       "license": "MIT"
     },
-    "node_modules/toidentifier": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6"
-      }
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -13449,15 +12603,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/tsscmp": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
-      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.x"
-      }
     },
     "node_modules/tsx": {
       "version": "4.20.6",
@@ -13928,19 +13073,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "license": "MIT",
-      "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -14056,15 +13188,6 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
-    },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
     },
     "node_modules/upath": {
       "version": "2.0.1",
@@ -14189,15 +13312,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/vm-browserify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
@@ -14233,6 +13347,13 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "devOptional": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
       "version": "5.103.0",
@@ -14315,6 +13436,17 @@
       "peer": true,
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -14573,15 +13705,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/ylru": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.4.0.tgz",
-      "integrity": "sha512-2OQsPNEmBCvXuFlIni/a+Rn+R2pHW9INm0BxXJ4hVDA8TirqMj+J/Rp9ItLatT/5pZqWwefVrTQcHpixsxnVlA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+    "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@babel/preset-react": "^7.23.3",
-    "@module-federation/rsbuild-plugin": "^0.13.1",
+    "@module-federation/rsbuild-plugin": "^2.4.0",
     "@rsbuild/core": "^1.3.16",
     "@rsbuild/plugin-node-polyfill": "^1.4.1",
     "@rsbuild/plugin-react": "^1.3.1",

--- a/src/CoreShop/Bundle/AddressBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/AddressBundle/Resources/assets/pimcore-studio/package.json
@@ -13,7 +13,7 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
-    "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+    "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/CoreBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/assets/pimcore-studio/package.json
@@ -13,7 +13,7 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
-    "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+    "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/CoreBundle/Resources/assets/pimcore-studio/src/components/AssignToExistingCompanyButton.tsx
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/assets/pimcore-studio/src/components/AssignToExistingCompanyButton.tsx
@@ -1,161 +1,117 @@
 /**
- * CoreShop Assign to Existing Company Button Component
+ * CoreShop Assign to Existing Company Nav-Item
  *
- * Menu button that opens the Element Selector for customer selection,
- * then for company selection, then opens a detail widget tab with the assignment form.
+ * Opens the Element Selector for customer selection, then for company
+ * selection, then opens a detail widget tab with the assignment form.
+ *
+ * The factory intentionally avoids React hooks — Pimcore calls it via an
+ * IIFE during MainNav render, so any hooks inside would be attributed to
+ * MainNav and break when menu items are added asynchronously (React #310).
  *
  * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
  * @license    CoreShop Commercial License (CCL)
  */
 
-import React from 'react'
-import { Icon } from '@pimcore/studio-ui-bundle/components'
-import { useMessage } from '@pimcore/studio-ui-bundle/components'
-import { useTranslation } from 'react-i18next'
+import { message } from 'antd'
 import { container } from '@pimcore/studio-ui-bundle'
-import { store } from '@pimcore/studio-ui-bundle/app'
-import { useElementSelector, SelectionType } from '@pimcore/studio-ui-bundle/modules/element'
+import { store, getPimcoreStudioApi } from '@pimcore/studio-ui-bundle/app'
+import { SelectionType } from '@pimcore/studio-ui-bundle/modules/element'
 import type { ResourceConfigProvider } from '@coreshop/resource/src/config'
 import { coreshopResourceServiceIds } from '@coreshop/resource/src/config'
-import { getErrorMessage, renderApiError } from '@coreshop/resource/src/entities'
-import { type MenuButtonProps } from '@coreshop/menu/src'
+import { getErrorMessage } from '@coreshop/resource/src/entities'
+import type { CustomNavItem } from '@coreshop/menu/src'
 import { customerCompanyApi } from '../modules/customer-company-assignment'
 
-let pendingAssignmentCustomer: { id: number, name: string } | null = null
-
-export const AssignToExistingCompanyButton = ({ icon, label }: MenuButtonProps): React.JSX.Element => {
-  const { t } = useTranslation()
-  const messageApi = useMessage()
-  const [allowedCustomerClasses, setAllowedCustomerClasses] = React.useState<string[]>([])
-  const [allowedCompanyClasses, setAllowedCompanyClasses] = React.useState<string[]>([])
-  const [classesLoaded, setClassesLoaded] = React.useState(false)
-  const selectedCustomerIdRef = React.useRef<number | null>(null)
-  const selectedCustomerNameRef = React.useRef<string>('')
-
-  React.useEffect(() => {
-    const loadClasses = async () => {
-      try {
-        const configProvider = container.get<ResourceConfigProvider>(coreshopResourceServiceIds.configProvider)
-        const [customerClasses, companyClasses] = await Promise.all([
-          configProvider.getAllowedClasses('coreshop.customer'),
-          configProvider.getAllowedClasses('coreshop.company'),
-        ])
-        setAllowedCustomerClasses(customerClasses)
-        setAllowedCompanyClasses(companyClasses)
-      } catch (err) {
-        messageApi.error(renderApiError(getErrorMessage(err, 'Failed to load allowed classes')))
-        setAllowedCustomerClasses(['CoreShopCustomer'])
-        setAllowedCompanyClasses(['CoreShopCompany'])
-      } finally {
-        setClassesLoaded(true)
-      }
-    }
-    loadClasses()
-  }, [messageApi])
-
-  const { open: openCompanySelector } = useElementSelector({
-    selectionType: SelectionType.Single,
-    areas: {
-      asset: false,
-      document: false,
-      object: true
-    },
-    config: {
-      objects: {
-        allowedTypes: ['object'],
-        allowedClasses: allowedCompanyClasses.length > 0 ? allowedCompanyClasses : undefined
-      }
-    },
-    onFinish: (event) => {
-      const selectedCustomerId = selectedCustomerIdRef.current ?? pendingAssignmentCustomer?.id ?? null
-      const selectedCustomerName = selectedCustomerNameRef.current || pendingAssignmentCustomer?.name || ''
-
-      if (event.items.length > 0 && selectedCustomerId) {
-        const selected = event.items[0]
-        const companyId = selected.data.id
-        const customerId = selectedCustomerId
-        const customerName = selectedCustomerName
-
-        // Open detail widget immediately; company details request is only for nice tab naming.
-        store.dispatch({
-          type: 'widget-manager/openMainWidget',
-          payload: {
-            name: 'Assign ' + customerName + ' \u2192 #' + companyId,
-            id: 'coreshop-assign-existing-company-' + customerId + '-' + companyId,
-            component: 'coreshop-customer-to-company-assign-to-existing-detail',
-            config: { customerId, companyId },
-          },
-        })
-        pendingAssignmentCustomer = null
-
-        customerCompanyApi.getEntityDetails('company', companyId).then((response) => {
-          const companyName = response.success && response.data ? response.data.name : `#${companyId}`
-          store.dispatch({
-            type: 'widget-manager/openMainWidget',
-            payload: {
-              name: 'Assign ' + customerName + ' \u2192 ' + companyName,
-              id: 'coreshop-assign-existing-company-' + customerId + '-' + companyId,
-              component: 'coreshop-customer-to-company-assign-to-existing-detail',
-              config: { customerId, companyId },
-            },
-          })
-        }).catch((err) => {
-          messageApi.error(renderApiError(getErrorMessage(err, 'Failed to load company')))
-        })
-      } else if (event.items.length > 0) {
-        messageApi.error(renderApiError('No customer selected before company selection'))
-      }
-    }
-  })
-
-  const { open: openCustomerSelector } = useElementSelector({
-    selectionType: SelectionType.Single,
-    areas: {
-      asset: false,
-      document: false,
-      object: true
-    },
-    config: {
-      objects: {
-        allowedTypes: ['object'],
-        allowedClasses: allowedCustomerClasses.length > 0 ? allowedCustomerClasses : undefined
-      }
-    },
-    onFinish: (event) => {
-      if (event.items.length > 0) {
-        const selected = event.items[0]
-        const customerId = selected.data.id
-
-        customerCompanyApi.getEntityDetails('customer', customerId).then((response) => {
-          const customerName = response.success && response.data ? response.data.name : `#${customerId}`
-          selectedCustomerIdRef.current = customerId
-          selectedCustomerNameRef.current = customerName
-          pendingAssignmentCustomer = { id: customerId, name: customerName }
-          globalThis.setTimeout(() => {
-            openCompanySelector()
-          }, 0)
-        }).catch((err) => {
-          messageApi.error(renderApiError(getErrorMessage(err, 'Failed to load customer')))
-        })
-      }
-    }
-  })
-
-  const handleClick = (e: React.MouseEvent): void => {
-    e.preventDefault()
-    e.stopPropagation()
-    if (classesLoaded) {
-      openCustomerSelector()
-    }
+const loadAllowedClasses = async (resource: string, fallback: string): Promise<string[]> => {
+  try {
+    const configProvider = container.get<ResourceConfigProvider>(coreshopResourceServiceIds.configProvider)
+    const classes = await configProvider.getAllowedClasses(resource)
+    return classes.length > 0 ? classes : [fallback]
+  } catch {
+    return [fallback]
   }
-
-  return (
-    <button
-      className="main-nav__list-btn"
-      onClick={handleClick}
-    >
-      <Icon value={icon ?? ''} />
-      {label || t('coreshop_customer_to_company_assign_to_existing', { defaultValue: 'Assign to Existing Company' })}
-    </button>
-  )
 }
+
+const dispatchAssignWidget = (customerId: number, customerName: string, companyId: number, companyLabel: string): void => {
+  store.dispatch({
+    type: 'widget-manager/openMainWidget',
+    payload: {
+      name: 'Assign ' + customerName + ' → ' + companyLabel,
+      id: 'coreshop-assign-existing-company-' + customerId + '-' + companyId,
+      component: 'coreshop-customer-to-company-assign-to-existing-detail',
+      config: { customerId, companyId },
+    },
+  })
+}
+
+const openCompanyStep = async (customerId: number, customerName: string): Promise<void> => {
+  const allowedCompanyClasses = await loadAllowedClasses('coreshop.company', 'CoreShopCompany')
+
+  getPimcoreStudioApi().element.openElementSelector({
+    selectionType: SelectionType.Single,
+    areas: {
+      asset: false,
+      document: false,
+      object: true
+    },
+    config: {
+      objects: {
+        allowedTypes: ['object'],
+        allowedClasses: allowedCompanyClasses
+      }
+    },
+    onFinish: (event) => {
+      if (event.items.length === 0) {
+        return
+      }
+
+      const companyId = event.items[0].data.id
+
+      dispatchAssignWidget(customerId, customerName, companyId, '#' + companyId)
+
+      customerCompanyApi.getEntityDetails('company', companyId).then((response) => {
+        const companyName = response.success && response.data ? response.data.name : `#${companyId}`
+        dispatchAssignWidget(customerId, customerName, companyId, companyName)
+      }).catch(() => {})
+    }
+  })
+}
+
+const openAssignToExistingCompanyFlow = async (): Promise<void> => {
+  const allowedCustomerClasses = await loadAllowedClasses('coreshop.customer', 'CoreShopCustomer')
+
+  getPimcoreStudioApi().element.openElementSelector({
+    selectionType: SelectionType.Single,
+    areas: {
+      asset: false,
+      document: false,
+      object: true
+    },
+    config: {
+      objects: {
+        allowedTypes: ['object'],
+        allowedClasses: allowedCustomerClasses
+      }
+    },
+    onFinish: (event) => {
+      if (event.items.length === 0) {
+        return
+      }
+
+      const customerId = event.items[0].data.id
+
+      customerCompanyApi.getEntityDetails('customer', customerId).then((response) => {
+        const customerName = response.success && response.data ? response.data.name : `#${customerId}`
+        window.setTimeout(() => { void openCompanyStep(customerId, customerName) }, 0)
+      }).catch((err) => {
+        void message.error(getErrorMessage(err, 'Failed to load customer'))
+      })
+    }
+  })
+}
+
+export const useAssignToExistingCompanyNavItem = (): CustomNavItem => ({
+  onClick: () => {
+    void openAssignToExistingCompanyFlow()
+  }
+})

--- a/src/CoreShop/Bundle/CoreBundle/Resources/assets/pimcore-studio/src/components/AssignToNewCompanyButton.tsx
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/assets/pimcore-studio/src/components/AssignToNewCompanyButton.tsx
@@ -1,49 +1,41 @@
 /**
- * CoreShop Assign to New Company Button Component
+ * CoreShop Assign to New Company Nav-Item
  *
- * Menu button that opens the Element Selector for customer selection,
- * then opens a detail widget tab with the assignment form.
+ * Opens the Element Selector for customer selection and, after selection,
+ * opens a detail widget tab with the assignment form.
+ *
+ * The factory intentionally avoids React hooks — Pimcore calls it via an
+ * IIFE during MainNav render, so any hooks inside would be attributed to
+ * MainNav and break when menu items are added asynchronously (React #310).
  *
  * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
  * @license    CoreShop Commercial License (CCL)
  */
 
-import React from 'react'
-import { Icon } from '@pimcore/studio-ui-bundle/components'
-import { useMessage } from '@pimcore/studio-ui-bundle/components'
-import { useTranslation } from 'react-i18next'
+import { message } from 'antd'
 import { container } from '@pimcore/studio-ui-bundle'
-import { store } from '@pimcore/studio-ui-bundle/app'
-import { useElementSelector, SelectionType } from '@pimcore/studio-ui-bundle/modules/element'
+import { store, getPimcoreStudioApi } from '@pimcore/studio-ui-bundle/app'
+import { SelectionType } from '@pimcore/studio-ui-bundle/modules/element'
 import type { ResourceConfigProvider } from '@coreshop/resource/src/config'
 import { coreshopResourceServiceIds } from '@coreshop/resource/src/config'
-import { getErrorMessage, renderApiError } from '@coreshop/resource/src/entities'
-import { type MenuButtonProps } from '@coreshop/menu/src'
+import { getErrorMessage } from '@coreshop/resource/src/entities'
+import type { CustomNavItem } from '@coreshop/menu/src'
 import { customerCompanyApi } from '../modules/customer-company-assignment'
 
-export const AssignToNewCompanyButton = ({ icon, label, closeMainNav }: MenuButtonProps): React.JSX.Element => {
-  const { t } = useTranslation()
-  const messageApi = useMessage()
-  const [allowedClasses, setAllowedClasses] = React.useState<string[]>([])
-  const [classesLoaded, setClassesLoaded] = React.useState(false)
+const loadAllowedCustomerClasses = async (): Promise<string[]> => {
+  try {
+    const configProvider = container.get<ResourceConfigProvider>(coreshopResourceServiceIds.configProvider)
+    const classes = await configProvider.getAllowedClasses('coreshop.customer')
+    return classes.length > 0 ? classes : ['CoreShopCustomer']
+  } catch {
+    return ['CoreShopCustomer']
+  }
+}
 
-  React.useEffect(() => {
-    const loadClasses = async () => {
-      try {
-        const configProvider = container.get<ResourceConfigProvider>(coreshopResourceServiceIds.configProvider)
-        const classes = await configProvider.getAllowedClasses('coreshop.customer')
-        setAllowedClasses(classes)
-      } catch (err) {
-        messageApi.error(renderApiError(getErrorMessage(err, 'Failed to load allowed customer classes')))
-        setAllowedClasses(['CoreShopCustomer'])
-      } finally {
-        setClassesLoaded(true)
-      }
-    }
-    loadClasses()
-  }, [])
+const openAssignToNewCompanyFlow = async (): Promise<void> => {
+  const allowedClasses = await loadAllowedCustomerClasses()
 
-  const { open: openCustomerSelector } = useElementSelector({
+  getPimcoreStudioApi().element.openElementSelector({
     selectionType: SelectionType.Single,
     areas: {
       asset: false,
@@ -53,49 +45,37 @@ export const AssignToNewCompanyButton = ({ icon, label, closeMainNav }: MenuButt
     config: {
       objects: {
         allowedTypes: ['object'],
-        allowedClasses: allowedClasses.length > 0 ? allowedClasses : undefined
+        allowedClasses
       }
     },
     onFinish: (event) => {
-      if (event.items.length > 0) {
-        const selected = event.items[0]
-        const customerId = selected.data.id
-
-        customerCompanyApi.getEntityDetails('customer', customerId).then((response) => {
-          const customerName = response.success && response.data ? response.data.name : `#${customerId}`
-
-          store.dispatch({
-            type: 'widget-manager/openMainWidget',
-            payload: {
-              name: 'Assign to New Company - ' + customerName,
-              id: 'coreshop-assign-new-company-' + customerId,
-              component: 'coreshop-customer-to-company-assign-to-new-detail',
-              config: { customerId },
-            },
-          })
-        }).catch((err) => {
-          messageApi.error(renderApiError(getErrorMessage(err, 'Failed to load customer')))
-        })
+      if (event.items.length === 0) {
+        return
       }
+
+      const customerId = event.items[0].data.id
+
+      customerCompanyApi.getEntityDetails('customer', customerId).then((response) => {
+        const customerName = response.success && response.data ? response.data.name : `#${customerId}`
+
+        store.dispatch({
+          type: 'widget-manager/openMainWidget',
+          payload: {
+            name: 'Assign to New Company - ' + customerName,
+            id: 'coreshop-assign-new-company-' + customerId,
+            component: 'coreshop-customer-to-company-assign-to-new-detail',
+            config: { customerId },
+          },
+        })
+      }).catch((error) => {
+        void message.error(getErrorMessage(error, 'Failed to load customer'))
+      })
     }
   })
-
-  const handleClick = (e: React.MouseEvent): void => {
-    e.preventDefault()
-    e.stopPropagation()
-    if (classesLoaded) {
-      closeMainNav?.()
-      openCustomerSelector()
-    }
-  }
-
-  return (
-    <button
-      className="main-nav__list-btn"
-      onClick={handleClick}
-    >
-      <Icon value={icon ?? ''} />
-      {label || t('coreshop_customer_to_company_assign_to_new', { defaultValue: 'Assign to New Company' })}
-    </button>
-  )
 }
+
+export const useAssignToNewCompanyNavItem = (): CustomNavItem => ({
+  onClick: () => {
+    void openAssignToNewCompanyFlow()
+  }
+})

--- a/src/CoreShop/Bundle/CoreBundle/Resources/assets/pimcore-studio/src/main.ts
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/assets/pimcore-studio/src/main.ts
@@ -28,8 +28,8 @@ import { ReportsModule } from './modules/reports'
 import { SettingsModule } from './modules/settings'
 import { PimcoreRelationWidgetModule } from './modules/pimcore-relation-widget'
 import { CustomerAddressSelectWidget } from './modules/extension/order-creation/widgets/CustomerAddressSelectWidget'
-import { AssignToNewCompanyButton } from './components/AssignToNewCompanyButton'
-import { AssignToExistingCompanyButton } from './components/AssignToExistingCompanyButton'
+import { useAssignToNewCompanyNavItem } from './components/AssignToNewCompanyButton'
+import { useAssignToExistingCompanyNavItem } from './components/AssignToExistingCompanyButton'
 import {
   AssignToNewCompanyPanel,
   AssignToExistingCompanyPanel,
@@ -67,12 +67,12 @@ const plugin: IAbstractPlugin = {
 
         registerMenuButton({
           name: 'coreshopAssignCustomerToNewCompany',
-          button: AssignToNewCompanyButton,
+          useCustomMainNavItem: useAssignToNewCompanyNavItem,
         })
 
         registerMenuButton({
           name: 'coreshopAssignCustomerToExistingCompany',
-          button: AssignToExistingCompanyButton,
+          useCustomMainNavItem: useAssignToExistingCompanyNavItem,
         })
     },
 

--- a/src/CoreShop/Bundle/CurrencyBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/CurrencyBundle/Resources/assets/pimcore-studio/package.json
@@ -13,7 +13,7 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
-    "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+    "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/CustomerBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/CustomerBundle/Resources/assets/pimcore-studio/package.json
@@ -13,7 +13,7 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
-    "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+    "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/CustomerBundle/Resources/assets/pimcore-studio/src/modules/listing-builders/index.ts
+++ b/src/CoreShop/Bundle/CustomerBundle/Resources/assets/pimcore-studio/src/modules/listing-builders/index.ts
@@ -19,10 +19,14 @@ import { type AbstractModule, container } from '@pimcore/studio-ui-bundle'
 import type { ListingBuilder } from '@pimcore/studio-ui-bundle/modules/element'
 import type { ClassDefinitionSelectionDecoratorConfig } from '@pimcore/studio-ui-bundle/modules/data-object'
 import { ResourceConfigProvider } from '@coreshop/resource/src/config/ConfigProvider'
+import { waitForAuthentication } from '@coreshop/pimcore/src/utils'
 
 export const CustomerListingBuildersModule: AbstractModule = {
   async onInit(): Promise<void> {
     try {
+      // onInit runs before login; the resource/config endpoint requires an authenticated session.
+      await waitForAuthentication()
+
       // Get the standard DataObject listing builder
       const dataObjectListingBuilder = container.get<ListingBuilder>('DataObject/Listing/Builder')
 

--- a/src/CoreShop/Bundle/FrontendBundle/Resources/assets/package-lock.json
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/assets/package-lock.json
@@ -16,7 +16,7 @@
         "css-loader": "^7.1.2",
         "file-loader": "^6.2.0",
         "flag-icons": "^7.2.3",
-        "postcss": "^8.4.45",
+        "postcss": "^8.5.14",
         "postcss-loader": "^8.1.1",
         "postcss-url": "^10.1.3",
         "sass": "^1.78.0",
@@ -5158,9 +5158,9 @@
       "peer": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -5168,6 +5168,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -5469,9 +5470,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.47",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
-      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -5487,9 +5488,10 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.1.0",
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {

--- a/src/CoreShop/Bundle/FrontendBundle/Resources/assets/package.json
+++ b/src/CoreShop/Bundle/FrontendBundle/Resources/assets/package.json
@@ -16,7 +16,7 @@
     "css-loader": "^7.1.2",
     "file-loader": "^6.2.0",
     "flag-icons": "^7.2.3",
-    "postcss": "^8.4.45",
+    "postcss": "^8.5.14",
     "postcss-loader": "^8.1.1",
     "postcss-url": "^10.1.3",
     "sass": "^1.78.0",

--- a/src/CoreShop/Bundle/IndexBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/IndexBundle/Resources/assets/pimcore-studio/package.json
@@ -13,7 +13,7 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
-    "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+    "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/IndexBundle/Worker/MysqlWorker.php
+++ b/src/CoreShop/Bundle/IndexBundle/Worker/MysqlWorker.php
@@ -294,31 +294,36 @@ class MysqlWorker extends AbstractWorker implements MysqlWorkerInterface, Worker
      * Accept both {@see TableIndex} objects (legacy programmatic setup) and plain arrays
      * (the form + JSON-stored configuration format). Returns null for empty/invalid entries.
      *
-     * @return array{type: string|null, columns: array<int, string>}|null
+     * @return array{type: string|null, columns: non-empty-list<string>}|null
      */
     private function normalizeTableIndex(mixed $tableIndex): ?array
     {
         if ($tableIndex instanceof TableIndex) {
-            $columns = $tableIndex->getColumns();
+            $rawColumns = $tableIndex->getColumns();
+            $type = $tableIndex->getType();
+        } elseif (is_array($tableIndex) && isset($tableIndex['columns']) && is_array($tableIndex['columns'])) {
+            $rawColumns = $tableIndex['columns'];
+            $type = isset($tableIndex['type']) ? (string) $tableIndex['type'] : null;
+        } else {
+            return null;
+        }
 
-            if (empty($columns)) {
-                return null;
+        $columns = [];
+        foreach ($rawColumns as $column) {
+            $column = (string) $column;
+            if ('' !== $column) {
+                $columns[] = $column;
             }
-
-            return [
-                'type' => $tableIndex->getType(),
-                'columns' => array_values($columns),
-            ];
         }
 
-        if (is_array($tableIndex) && !empty($tableIndex['columns']) && is_array($tableIndex['columns'])) {
-            return [
-                'type' => $tableIndex['type'] ?? null,
-                'columns' => array_values($tableIndex['columns']),
-            ];
+        if ([] === $columns) {
+            return null;
         }
 
-        return null;
+        return [
+            'type' => $type,
+            'columns' => $columns,
+        ];
     }
 
     protected function createRelationalTableSchema(IndexInterface $index, Schema $tableSchema)

--- a/src/CoreShop/Bundle/MenuBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/MenuBundle/Resources/assets/pimcore-studio/package.json
@@ -13,7 +13,7 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
-    "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+    "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/MenuBundle/Resources/assets/pimcore-studio/src/index.ts
+++ b/src/CoreShop/Bundle/MenuBundle/Resources/assets/pimcore-studio/src/index.ts
@@ -11,5 +11,5 @@
  */
 
 export { MenuButtonRegistry, registerMenuButton } from './services/button-registry'
-export { type ButtonConfig, type MenuButtonProps } from './types/ButtonConfig'
+export { type ButtonConfig, type CustomNavItem } from './types/ButtonConfig'
 export { CoreShopMenuExtension } from './modules/menu-extension'

--- a/src/CoreShop/Bundle/MenuBundle/Resources/assets/pimcore-studio/src/modules/menu-extension.tsx
+++ b/src/CoreShop/Bundle/MenuBundle/Resources/assets/pimcore-studio/src/modules/menu-extension.tsx
@@ -9,6 +9,7 @@ import {serviceIds} from '@pimcore/studio-ui-bundle/app'
 import {IMainNavItem, type MainNavRegistry} from '@pimcore/studio-ui-bundle/modules/app'
 import {type WidgetRegistry} from '@pimcore/studio-ui-bundle/modules/widget-manager'
 import {type IconLibrary} from '@pimcore/studio-ui-bundle/modules/icon-library'
+import {waitForAuthentication} from '@coreshop/pimcore/src/utils'
 import {menuService} from '../services/MenuService'
 import {CoreShopMenuItem} from '../types'
 import {CoreShopWidget} from '../components/CoreShopWidget'
@@ -33,6 +34,9 @@ export const CoreShopMenuExtension = {
         widgetRegistry: WidgetRegistry
     ): Promise<void> {
         try {
+            // onInit runs before login; the menus endpoint requires an authenticated session.
+            await waitForAuthentication()
+
             // Load ALL CoreShop menu structures from backend
             const menuItems = await menuService.getAllMenuStructures()
 
@@ -96,9 +100,32 @@ export const CoreShopMenuExtension = {
             // Leaf item - register with widget
             const widgetId = item.widgetId || `coreshop-${item.id}`
 
+            if (item.widgetEvent) {
+                const eventName = item.widgetEvent
+                navItem.useCustomMainNavItem = () => ({
+                    onClick: () => {
+                        window.dispatchEvent(new CustomEvent(eventName))
+                    }
+                })
+                mainNavRegistry.registerMainNavItem(navItem)
+                return
+            }
+
+            if (item.widgetButton) {
+                const buttonRegistry = container.get<MenuButtonRegistry>('CoreShopMenuButtons')
+                const buttonConfig = buttonRegistry.get(item.widgetButton)
+
+                if (buttonConfig) {
+                    navItem.useCustomMainNavItem = buttonConfig.useCustomMainNavItem
+                    mainNavRegistry.registerMainNavItem(navItem)
+                    return
+                }
+            }
+
             navItem.widgetConfig = {
                 name: item.label,
                 id: widgetId,
+                component: widgetId,
                 config: {
                     icon: {
                         type: 'name',
@@ -107,35 +134,6 @@ export const CoreShopMenuExtension = {
                 }
             }
 
-            if (item.widgetEvent) {
-                navItem.onClick = () => {
-                    const event = new CustomEvent(item.widgetEvent!)
-                    globalThis.dispatchEvent(event)
-                }
-
-                mainNavRegistry.registerMainNavItem(navItem)
-
-                return;
-            }
-
-            if (item.widgetButton) {
-                const buttonRegistry = container.get<MenuButtonRegistry>('CoreShopMenuButtons');
-                const buttonConfig = buttonRegistry.get(item.widgetButton);
-
-                if (buttonConfig) {
-                    navItem.button = (({ closeMainNav }: { closeMainNav: () => void }) => React.createElement(buttonConfig.button, {
-                        icon: item.icon!,
-                        label: item.label,
-                        closeMainNav,
-                    })) as any
-
-                    mainNavRegistry.registerMainNavItem(navItem)
-                    return;
-                }
-            }
-
-            navItem.widgetConfig.component = widgetId;
-
             mainNavRegistry.registerMainNavItem(navItem)
 
             // Only register a fallback widget if one isn't already registered
@@ -143,7 +141,7 @@ export const CoreShopMenuExtension = {
             if (!widgetRegistry.getWidget(widgetId)) {
                 widgetRegistry.registerWidget({
                     name: widgetId,
-                    component: props => CoreShopWidget({item}),
+                    component: () => CoreShopWidget({item}),
                 })
             }
         }

--- a/src/CoreShop/Bundle/MenuBundle/Resources/assets/pimcore-studio/src/types/ButtonConfig.ts
+++ b/src/CoreShop/Bundle/MenuBundle/Resources/assets/pimcore-studio/src/types/ButtonConfig.ts
@@ -10,15 +10,14 @@
  * @license    CoreShop Commercial License (CCL)
  */
 
-import * as React from 'react'
-
-export interface ButtonConfig {
-  button: React.ComponentType<MenuButtonProps>
-  name: string
+export interface CustomNavItem {
+  onClick: () => void
+  name?: string
+  icon?: string | { type: string, value: string }
+  translationKey?: string
 }
 
-export interface MenuButtonProps {
-  icon?: string
-  label?: string
-  closeMainNav?: () => void
+export interface ButtonConfig {
+  name: string
+  useCustomMainNavItem: () => CustomNavItem
 }

--- a/src/CoreShop/Bundle/MessengerBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/MessengerBundle/Resources/assets/pimcore-studio/package.json
@@ -13,7 +13,7 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
-    "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+    "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/MoneyBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/MoneyBundle/Resources/assets/pimcore-studio/package.json
@@ -13,7 +13,7 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
-    "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+    "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/NotificationBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/NotificationBundle/Resources/assets/pimcore-studio/package.json
@@ -13,7 +13,7 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
-    "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+    "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/OrderBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/assets/pimcore-studio/package.json
@@ -13,7 +13,7 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
-    "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+    "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/OrderBundle/Resources/assets/pimcore-studio/src/main.ts
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/assets/pimcore-studio/src/main.ts
@@ -61,7 +61,7 @@ import {
 import { OrderCreationStepRegistry } from './modules/order-creation/registry'
 import { orderCreationServiceIds } from './modules/order-creation/service-ids'
 import { OrderCreationPanel } from './modules/order-creation/components'
-import { OrderCreationButton } from './modules/order-creation/components/OrderCreationButton'
+import { useOrderCreationNavItem } from './modules/order-creation/components/OrderCreationButton'
 import { orderCreationWidgetRestorer } from './modules/order-creation/OrderCreationWidgetRestorer'
 import { BaseStepConfig, ProductsStepConfig, TotalsStepConfig } from './modules/order-creation/steps'
 
@@ -254,7 +254,7 @@ const plugin: IAbstractPlugin = {
 
         registerMenuButton({
           name: 'coreshopCreateOrder',
-          button: OrderCreationButton,
+          useCustomMainNavItem: useOrderCreationNavItem,
         })
     },
 

--- a/src/CoreShop/Bundle/OrderBundle/Resources/assets/pimcore-studio/src/modules/order-creation/components/CustomerSelector.tsx
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/assets/pimcore-studio/src/modules/order-creation/components/CustomerSelector.tsx
@@ -41,26 +41,26 @@ export const CustomerSelector: React.FC = () => {
   const { loadCustomer } = useOrderCreation()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [allowedClasses, setAllowedClasses] = useState<string[]>([])
+  // null = still loading from CoreShop stack config. Never fall back to a hardcoded
+  // class name — the allowed classes are authoritative from the backend resource config.
+  const [allowedClasses, setAllowedClasses] = useState<string[] | null>(null)
 
   const configProvider = useMemo(
     () => container.get<ResourceConfigProvider>(coreshopResourceServiceIds.configProvider),
     []
   )
 
-  // Load allowed customer classes from config
   useEffect(() => {
     const loadAllowedClasses = async () => {
       try {
         const classes = await configProvider.getAllowedClasses('coreshop.customer')
         setAllowedClasses(classes)
       } catch (err) {
-        messageApi.error(renderApiError(getErrorMessage(err, 'Failed to load allowed customer classes')))
-        // Fallback to default
-        setAllowedClasses(['CoreShopCustomer'])
+        void messageApi.error(renderApiError(getErrorMessage(err, 'Failed to load allowed customer classes')))
+        setAllowedClasses([])
       }
     }
-    loadAllowedClasses()
+    void loadAllowedClasses()
   }, [configProvider, messageApi])
 
   const handleCustomerSelected = useCallback(async (customerId: number) => {
@@ -75,6 +75,8 @@ export const CustomerSelector: React.FC = () => {
     }
   }, [loadCustomer])
 
+  const classesReady = allowedClasses !== null && allowedClasses.length > 0
+
   const { open: openSelector } = useElementSelector({
     selectionType: SelectionType.Single,
     areas: {
@@ -85,13 +87,13 @@ export const CustomerSelector: React.FC = () => {
     config: {
       objects: {
         allowedTypes: ['object'],
-        allowedClasses: allowedClasses.length > 0 ? allowedClasses : undefined
+        allowedClasses: classesReady ? allowedClasses : undefined
       }
     },
     onFinish: (event) => {
       if (event.items.length > 0) {
         const selected = event.items[0]
-        handleCustomerSelected(selected.data.id)
+        void handleCustomerSelected(selected.data.id)
       }
     }
   })
@@ -118,13 +120,24 @@ export const CustomerSelector: React.FC = () => {
             <Alert type="error" message={error} showIcon closable onClose={() => setError(null)} />
           )}
 
-          <Spin spinning={loading}>
+          {allowedClasses !== null && allowedClasses.length === 0 && (
+            <Alert
+              type="error"
+              showIcon
+              message={t('coreshop_order_creation_no_customer_class', {
+                defaultValue: 'No customer class is configured for the CoreShop stack (coreshop.customer).'
+              })}
+            />
+          )}
+
+          <Spin spinning={loading || allowedClasses === null}>
             <div style={{ textAlign: 'center' }}>
               <Button
                 type="primary"
                 size="large"
                 icon={<SearchOutlined />}
                 onClick={openSelector}
+                disabled={!classesReady}
                 className={styles.selectButton}
               >
                 {t('coreshop_order_creation_browse_customers', { defaultValue: 'Browse Customers' })}

--- a/src/CoreShop/Bundle/OrderBundle/Resources/assets/pimcore-studio/src/modules/order-creation/components/OrderCreationButton.tsx
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/assets/pimcore-studio/src/modules/order-creation/components/OrderCreationButton.tsx
@@ -1,50 +1,42 @@
 /**
- * CoreShop Order Creation Menu Button
+ * CoreShop Order Creation Menu Nav-Item
  *
- * Opens the Element Selector for customer selection directly from the menu
- * and then opens the Order Creation detail widget for the selected customer.
+ * Provides a useCustomMainNavItem factory that opens the Element Selector
+ * for customer selection and, after selection, opens the Order Creation
+ * detail widget for that customer.
+ *
+ * The factory intentionally avoids React hooks — Pimcore calls it via an
+ * IIFE during MainNav render, so any hooks inside would be attributed to
+ * MainNav and break when menu items are added asynchronously (React #310).
  *
  * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
  * @license    CoreShop Commercial License (CCL)
  */
 
-import React from 'react'
-import { Icon } from '@pimcore/studio-ui-bundle/components'
-import { useMessage } from '@pimcore/studio-ui-bundle/components'
-import { useTranslation } from 'react-i18next'
+import { message } from 'antd'
 import { container } from '@pimcore/studio-ui-bundle'
-import { store } from '@pimcore/studio-ui-bundle/app'
-import { useElementSelector, SelectionType } from '@pimcore/studio-ui-bundle/modules/element'
+import { store, getPimcoreStudioApi } from '@pimcore/studio-ui-bundle/app'
+import { SelectionType } from '@pimcore/studio-ui-bundle/modules/element'
 import type { ResourceConfigProvider } from '@coreshop/resource/src/config'
 import { coreshopResourceServiceIds } from '@coreshop/resource/src/config'
-import { getErrorMessage, renderApiError } from '@coreshop/resource/src/entities'
-import { type MenuButtonProps } from '@coreshop/menu/src'
+import { getErrorMessage } from '@coreshop/resource/src/entities'
+import type { CustomNavItem } from '@coreshop/menu/src'
 import { orderCreationApi } from '../api'
 
-export const OrderCreationButton = ({ icon, label, closeMainNav }: MenuButtonProps): React.JSX.Element => {
-  const { t } = useTranslation()
-  const messageApi = useMessage()
-  const [allowedClasses, setAllowedClasses] = React.useState<string[]>([])
-  const [classesLoaded, setClassesLoaded] = React.useState(false)
+const loadAllowedCustomerClasses = async (): Promise<string[]> => {
+  try {
+    const configProvider = container.get<ResourceConfigProvider>(coreshopResourceServiceIds.configProvider)
+    const classes = await configProvider.getAllowedClasses('coreshop.customer')
+    return classes.length > 0 ? classes : ['CoreShopCustomer']
+  } catch {
+    return ['CoreShopCustomer']
+  }
+}
 
-  React.useEffect(() => {
-    const loadClasses = async (): Promise<void> => {
-      try {
-        const configProvider = container.get<ResourceConfigProvider>(coreshopResourceServiceIds.configProvider)
-        const classes = await configProvider.getAllowedClasses('coreshop.customer')
-        setAllowedClasses(classes)
-      } catch (error) {
-        messageApi.error(renderApiError(getErrorMessage(error, 'Failed to load allowed customer classes')))
-        setAllowedClasses(['CoreShopCustomer'])
-      } finally {
-        setClassesLoaded(true)
-      }
-    }
+const openOrderCreationFlow = async (): Promise<void> => {
+  const allowedClasses = await loadAllowedCustomerClasses()
 
-    loadClasses()
-  }, [messageApi])
-
-  const { open: openCustomerSelector } = useElementSelector({
+  getPimcoreStudioApi().element.openElementSelector({
     selectionType: SelectionType.Single,
     areas: {
       asset: false,
@@ -54,52 +46,37 @@ export const OrderCreationButton = ({ icon, label, closeMainNav }: MenuButtonPro
     config: {
       objects: {
         allowedTypes: ['object'],
-        allowedClasses: allowedClasses.length > 0 ? allowedClasses : undefined
+        allowedClasses
       }
     },
     onFinish: (event) => {
-      if (event.items.length > 0) {
-        const selected = event.items[0]
-        const customerId = selected.data.id
-
-        orderCreationApi.getCustomerDetails(customerId).then((details) => {
-          const customerName = [details.firstname, details.lastname].filter(Boolean).join(' ') || `Customer #${customerId}`
-
-          store.dispatch({
-            type: 'widget-manager/openMainWidget',
-            payload: {
-              name: `New Order - ${customerName}`,
-              id: `coreshop-order-creation-${customerId}`,
-              component: 'coreshop-order-creation-detail',
-              config: { customerId }
-            }
-          })
-        }).catch((error) => {
-          messageApi.error(renderApiError(getErrorMessage(error, 'Failed to load customer')))
-        })
+      if (event.items.length === 0) {
+        return
       }
+
+      const customerId = event.items[0].data.id
+
+      orderCreationApi.getCustomerDetails(customerId).then((details) => {
+        const customerName = [details.firstname, details.lastname].filter(Boolean).join(' ') || `Customer #${customerId}`
+
+        store.dispatch({
+          type: 'widget-manager/openMainWidget',
+          payload: {
+            name: `New Order - ${customerName}`,
+            id: `coreshop-order-creation-${customerId}`,
+            component: 'coreshop-order-creation-detail',
+            config: { customerId }
+          }
+        })
+      }).catch((error) => {
+        void message.error(getErrorMessage(error, 'Failed to load customer'))
+      })
     }
   })
-
-  const handleClick = (event: React.MouseEvent): void => {
-    event.preventDefault()
-    event.stopPropagation()
-
-    if (!classesLoaded) {
-      return
-    }
-
-    closeMainNav?.()
-    openCustomerSelector()
-  }
-
-  return (
-    <button
-      className="main-nav__list-btn"
-      onClick={handleClick}
-    >
-      <Icon value={icon ?? ''} />
-      {label || t('coreshop_order_create', { defaultValue: 'Create Order' })}
-    </button>
-  )
 }
+
+export const useOrderCreationNavItem = (): CustomNavItem => ({
+  onClick: () => {
+    void openOrderCreationFlow()
+  }
+})

--- a/src/CoreShop/Bundle/OrderBundle/Resources/assets/pimcore-studio/src/modules/order-creation/components/index.ts
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/assets/pimcore-studio/src/modules/order-creation/components/index.ts
@@ -11,5 +11,5 @@
  */
 
 export { OrderCreationPanel } from './OrderCreationPanel'
-export { OrderCreationButton } from './OrderCreationButton'
+export { useOrderCreationNavItem } from './OrderCreationButton'
 export { CustomerInfoCard } from './CustomerSelector'

--- a/src/CoreShop/Bundle/OrderBundle/Resources/assets/pimcore-studio/src/modules/sales/listing-builders/index.ts
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/assets/pimcore-studio/src/modules/sales/listing-builders/index.ts
@@ -24,6 +24,7 @@ import { ResourceConfigProvider } from '@coreshop/resource/src/config/ConfigProv
 import { useWidgetManager } from '@pimcore/studio-ui-bundle/modules/widget-manager'
 import { type AbstractDecorator, type AbstractDecoratorProps } from '@pimcore/studio-ui-bundle/modules/element'
 import { createPresetFilterDecorator } from '@coreshop/pimcore/src/modules/grid/decorators/PresetFilterDecorator'
+import { waitForAuthentication } from '@coreshop/pimcore/src/utils'
 import { openSaleWidget } from '../hooks'
 import type { SaleType } from '../types'
 
@@ -64,6 +65,9 @@ const createRowDoubleClickDecorator = (saleType: SaleType): AbstractDecorator =>
 export const SalesListingBuildersModule: AbstractModule = {
   async onInit(): Promise<void> {
     try {
+      // onInit runs before login; the resource/config endpoint requires an authenticated session.
+      await waitForAuthentication()
+
       // Get the standard DataObject listing builder
       const dataObjectListingBuilder = container.get<ListingBuilder>('DataObject/Listing/Builder')
 

--- a/src/CoreShop/Bundle/PaymentBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/PaymentBundle/Resources/assets/pimcore-studio/package.json
@@ -13,7 +13,7 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
-    "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+    "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/PimcoreBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/PimcoreBundle/Resources/assets/pimcore-studio/package.json
@@ -13,7 +13,7 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
-    "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+    "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/PimcoreBundle/Resources/assets/pimcore-studio/src/utils/authentication.ts
+++ b/src/CoreShop/Bundle/PimcoreBundle/Resources/assets/pimcore-studio/src/utils/authentication.ts
@@ -1,0 +1,38 @@
+/**
+ * CoreShop PimcoreBundle Authentication Utilities
+ *
+ * This source file is available under the terms of the
+ * CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    CoreShop Commercial License (CCL)
+ */
+
+import { store } from '@pimcore/studio-ui-bundle/app'
+
+const isAuthenticated = (): boolean =>
+  (store.getState() as Record<string, any>)?.authentication?.isAuthenticated === true
+
+/**
+ * Resolves once the Pimcore Studio Redux store reports the user as authenticated.
+ *
+ * Module `onInit()` runs during app bootstrap — before login — so any API calls made
+ * there fail with 401. Gate post-auth work (menu/nav registration, stack config lookups,
+ * etc.) behind this helper so it runs after the login transition.
+ */
+export const waitForAuthentication = async (): Promise<void> => {
+  if (isAuthenticated()) {
+    return
+  }
+
+  return new Promise<void>((resolve) => {
+    const unsubscribe = store.subscribe(() => {
+      if (isAuthenticated()) {
+        unsubscribe()
+        resolve()
+      }
+    })
+  })
+}

--- a/src/CoreShop/Bundle/PimcoreBundle/Resources/assets/pimcore-studio/src/utils/index.ts
+++ b/src/CoreShop/Bundle/PimcoreBundle/Resources/assets/pimcore-studio/src/utils/index.ts
@@ -11,3 +11,4 @@
  */
 
 export * from './date'
+export * from './authentication'

--- a/src/CoreShop/Bundle/ProductBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/assets/pimcore-studio/package.json
@@ -13,7 +13,7 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
-    "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+    "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/assets/pimcore-studio/package.json
@@ -13,7 +13,7 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
-    "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+    "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/ResourceBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/ResourceBundle/Resources/assets/pimcore-studio/package.json
@@ -13,7 +13,7 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
-    "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+    "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/RuleBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/RuleBundle/Resources/assets/pimcore-studio/package.json
@@ -13,7 +13,7 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
-    "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+    "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/ShippingBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/ShippingBundle/Resources/assets/pimcore-studio/package.json
@@ -13,7 +13,7 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
-    "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+    "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/StoreBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/StoreBundle/Resources/assets/pimcore-studio/package.json
@@ -13,7 +13,7 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
-    "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+    "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/StudioFormBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/StudioFormBundle/Resources/assets/pimcore-studio/package.json
@@ -13,7 +13,7 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
-    "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+    "@pimcore/studio-ui-bundle": "2025.4.3",
     "antd": "^5.12.0",
     "react": "18.3.x",
     "react-dom": "18.3.x"

--- a/src/CoreShop/Bundle/TaxationBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/TaxationBundle/Resources/assets/pimcore-studio/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
     "@coreshop/studio-form": "*",
-    "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+    "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/TestBundle/Page/SymfonyPage.php
+++ b/src/CoreShop/Bundle/TestBundle/Page/SymfonyPage.php
@@ -34,7 +34,7 @@ abstract class SymfonyPage extends BaseSymfonyPage implements SymfonyPageInterfa
     public function verifyRoute(array $requiredUrlParameters = []): void
     {
         $url = $this->getDriver()->getCurrentUrl();
-        $path = $this->stripFrontController(parse_url($url)['path']);
+        $path = $this->stripFrontController((string) parse_url($url, PHP_URL_PATH));
 
         $matchedRoute = $this->router->match($path);
 
@@ -62,7 +62,7 @@ abstract class SymfonyPage extends BaseSymfonyPage implements SymfonyPageInterfa
     protected function verifyUrl(array $urlParameters = []): void
     {
         $url = $this->getDriver()->getCurrentUrl();
-        $path = $this->stripFrontController(parse_url($url)['path']);
+        $path = $this->stripFrontController((string) parse_url($url, PHP_URL_PATH));
 
         $matchedRoute = $this->router->match($path);
 

--- a/src/CoreShop/Bundle/TestBundle/Page/SymfonyPage.php
+++ b/src/CoreShop/Bundle/TestBundle/Page/SymfonyPage.php
@@ -20,6 +20,7 @@ namespace CoreShop\Bundle\TestBundle\Page;
 use Behat\Mink\Element\NodeElement;
 use CoreShop\Bundle\TestBundle\Service\DriverHelper;
 use FriendsOfBehat\PageObjectExtension\Page\SymfonyPage as BaseSymfonyPage;
+use FriendsOfBehat\PageObjectExtension\Page\UnexpectedPageException;
 
 abstract class SymfonyPage extends BaseSymfonyPage implements SymfonyPageInterface
 {
@@ -28,5 +29,62 @@ abstract class SymfonyPage extends BaseSymfonyPage implements SymfonyPageInterfa
         DriverHelper::waitForPageToLoad($this->getSession());
 
         return parent::getElement($name, $parameters);
+    }
+
+    public function verifyRoute(array $requiredUrlParameters = []): void
+    {
+        $url = $this->getDriver()->getCurrentUrl();
+        $path = $this->stripFrontController(parse_url($url)['path']);
+
+        $matchedRoute = $this->router->match($path);
+
+        if ($matchedRoute['_route'] !== $this->getRouteName()) {
+            throw new UnexpectedPageException(sprintf(
+                "Matched route '%s' does not match the expected route '%s' for URL '%s'",
+                $matchedRoute['_route'],
+                $this->getRouteName(),
+                $url,
+            ));
+        }
+
+        foreach ($requiredUrlParameters as $key => $value) {
+            if (!isset($matchedRoute[$key]) || (string) $matchedRoute[$key] !== (string) $value) {
+                throw new UnexpectedPageException(sprintf(
+                    "Required route parameter '%s' with value '%s' not found in URL '%s'",
+                    $key,
+                    $value,
+                    $url,
+                ));
+            }
+        }
+    }
+
+    protected function verifyUrl(array $urlParameters = []): void
+    {
+        $url = $this->getDriver()->getCurrentUrl();
+        $path = $this->stripFrontController(parse_url($url)['path']);
+
+        $matchedRoute = $this->router->match($path);
+
+        if (isset($matchedRoute['_locale'])) {
+            $urlParameters += ['_locale' => $matchedRoute['_locale']];
+        }
+
+        if ($this->getSession()->getCurrentUrl() !== $this->getUrl($urlParameters)) {
+            throw new UnexpectedPageException(sprintf(
+                'Expected to be on "%s" but found "%s" instead',
+                $this->getUrl($urlParameters),
+                $this->getSession()->getCurrentUrl(),
+            ));
+        }
+    }
+
+    private function stripFrontController(string $path): string
+    {
+        return preg_replace(
+            '#^/(app(_dev|_test|_test_cached)?|index(_test|_test_precision)?)\.php/#',
+            '/',
+            $path,
+        );
     }
 }

--- a/src/CoreShop/Bundle/TestBundle/Service/Resolver/CurrentPageResolver.php
+++ b/src/CoreShop/Bundle/TestBundle/Service/Resolver/CurrentPageResolver.php
@@ -35,10 +35,14 @@ final class CurrentPageResolver implements CurrentPageResolverInterface
      */
     public function getCurrentPageWithForm(array $pages): SymfonyPageInterface
     {
-        /**
-         * @psalm-suppress PossiblyFalseArgument
-         */
-        $routeParameters = $this->urlMatcher->match(parse_url($this->session->getCurrentUrl(), \PHP_URL_PATH));
+        $path = (string) parse_url($this->session->getCurrentUrl(), \PHP_URL_PATH);
+        $path = preg_replace(
+            '#^/(app(_dev|_test|_test_cached)?|index(_test|_test_precision)?)\.php/#',
+            '/',
+            $path,
+        );
+
+        $routeParameters = $this->urlMatcher->match($path);
 
         Assert::allIsInstanceOf($pages, SymfonyPageInterface::class);
 

--- a/src/CoreShop/Bundle/UserBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/UserBundle/Resources/assets/pimcore-studio/package.json
@@ -13,7 +13,7 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
-    "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+    "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/VariantBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/VariantBundle/Resources/assets/pimcore-studio/package.json
@@ -14,7 +14,7 @@
   "private": true,
   "dependencies": {
     "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
-    "@pimcore/studio-ui-bundle": "1.0.0-canary.20251119-143005-1b35b01",
+    "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Component/Order/Distributor/ProportionalIntegerDistributor.php
+++ b/src/CoreShop/Component/Order/Distributor/ProportionalIntegerDistributor.php
@@ -34,6 +34,7 @@ final class ProportionalIntegerDistributor implements ProportionalIntegerDistrib
 
         $missingAmount = $amount - array_sum($distributedAmounts);
         for ($i = 0, $iMax = abs($missingAmount); $i < $iMax; ++$i) {
+            /** @psalm-suppress InvalidArrayOffset — $i is always >= 0, abs() never returns negative */
             $distributedAmounts[$i] += $missingAmount >= 0 ? 1 : -1;
         }
 


### PR DESCRIPTION
## Summary

Cherry-picks bug fixes and Studio improvements from `2026.x` that are applicable to `5.1`. Skips the Pimcore 2026.1 migration (ExtJS removal, PHP 8.5, DBAL 4, install profile, web-to-print drop) and 2026-only CI/workflow changes.

### Cherry-picked commits

- `9dc4dc47ed` suppress psalm InvalidArrayOffset in `ProportionalIntegerDistributor`
- `40f60158ca` add `verifyRoute`/`verifyUrl` helpers on `SymfonyPage` for native Symfony routing
- `5cea7b8fdf` strip Pimcore front controller in Behat page resolvers
- `7a7e559082` [Index] tighten `normalizeTableIndex` return to `non-empty-list<string>` for Psalm
- `eb6d2dd9b1` Bump koa + `@module-federation/rsbuild-plugin`
- `4d30c208e2` Add Dependabot configuration for updates
- `f8b0935ca1` Bump postcss
- `94616aeccd` **partial backport of `b1f1eabd2f` "studio fixes"** — Studio TSX/TS changes only

### The key fix: Order-Creation customer popup

`OrderCreationButton` previously used `useElementSelector` hook inside a component rendered through Pimcore's `MainNav` registry. When menu items get added asynchronously, React attributes the hook to `MainNav` and crashes with React #310.

The fix switches the menu integration to the `useCustomMainNavItem` factory pattern and calls `getPimcoreStudioApi().element.openElementSelector` imperatively (no hooks inside the factory). Also touches `AssignToExisting/NewCompanyButton`, `CustomerSelector`, `MenuBundle/menu-extension`, related `ButtonConfig` typing, `PimcoreBundle/utils/authentication`, listing-builders cleanup.

### Deliberately skipped

- 14 Pimcore-2026.1-migration commits (Pimcore/PHP/DBAL bumps, install profile, ExtJS removal, web-to-print drop, etc.)
- 12 CI/workflow commits (2026-specific Pimcore 12.x matrix split, reusable workflow refactor)
- 2 docs commits (describe 2026 install profile / ExtJS-free state)
- 5 Dependabot lockfile-only bumps (axios, fast-uri ×2, babel-plugin, svgo, node-forge) — will be regenerated by `npm install`

### From `b1f1eabd2f` excluded
ORM XMLs (DBAL 4 native ENUM), 17 bundle `package.json` Pimcore version bumps, root `package.json` / `config/reference.php` / `config/bundles.php`, ExtJS public-file deletes, local mercure yaml, `PimcoreGenericExecutionEngineBundle` registration drop.

## Test plan

- [ ] `npm install` to regenerate lockfile
- [ ] Build studio bundles
- [ ] Open admin → menu → "Create Order" → element-selector popup for customer selection appears
- [ ] Run Behat suite with new `verifyRoute`/`verifyUrl` helpers
- [ ] `vendor/bin/psalm` + `vendor/bin/phpstan`