### PR TITLE
studio: declare host-provided libs as peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13789,14 +13789,16 @@
       "dependencies": {
         "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
+        "zustand": "^5.0.7"
+      },
+      "peerDependencies": {
         "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
         "react": "18.3.x",
         "react-dom": "18.3.x",
-        "react-redux": "^9.0.4",
-        "zustand": "^5.0.7"
+        "react-redux": "^9.0.4"
       }
     },
     "src/CoreShop/Bundle/CoreBundle/Resources/assets/pimcore-studio": {
@@ -13818,14 +13820,16 @@
         "@coreshop/store": "file:../../../../StoreBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
         "@coreshop/taxation": "file:../../../../TaxationBundle/Resources/assets/pimcore-studio",
+        "zustand": "^5.0.7"
+      },
+      "peerDependencies": {
         "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
         "react": "18.3.x",
         "react-dom": "18.3.x",
-        "react-redux": "^9.0.4",
-        "zustand": "^5.0.7"
+        "react-redux": "^9.0.4"
       }
     },
     "src/CoreShop/Bundle/CurrencyBundle/Resources/assets/pimcore-studio": {
@@ -13835,14 +13839,16 @@
       "dependencies": {
         "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
+        "zustand": "^5.0.7"
+      },
+      "peerDependencies": {
         "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
         "react": "18.3.x",
         "react-dom": "18.3.x",
-        "react-redux": "^9.0.4",
-        "zustand": "^5.0.7"
+        "react-redux": "^9.0.4"
       }
     },
     "src/CoreShop/Bundle/CustomerBundle/Resources/assets/pimcore-studio": {
@@ -13851,14 +13857,16 @@
       "license": "CCL",
       "dependencies": {
         "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
+        "zustand": "^5.0.7"
+      },
+      "peerDependencies": {
         "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
         "react": "18.3.x",
         "react-dom": "18.3.x",
-        "react-redux": "^9.0.4",
-        "zustand": "^5.0.7"
+        "react-redux": "^9.0.4"
       }
     },
     "src/CoreShop/Bundle/IndexBundle/Resources/assets/pimcore-studio": {
@@ -13868,14 +13876,16 @@
       "dependencies": {
         "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
+        "zustand": "^5.0.7"
+      },
+      "peerDependencies": {
         "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
         "react": "18.3.x",
         "react-dom": "18.3.x",
-        "react-redux": "^9.0.4",
-        "zustand": "^5.0.7"
+        "react-redux": "^9.0.4"
       }
     },
     "src/CoreShop/Bundle/MenuBundle/Resources/assets/pimcore-studio": {
@@ -13883,14 +13893,16 @@
       "version": "1.0.0",
       "license": "CCL",
       "dependencies": {
+        "zustand": "^5.0.7"
+      },
+      "peerDependencies": {
         "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
         "react": "18.3.x",
         "react-dom": "18.3.x",
-        "react-redux": "^9.0.4",
-        "zustand": "^5.0.7"
+        "react-redux": "^9.0.4"
       }
     },
     "src/CoreShop/Bundle/MessengerBundle/Resources/assets/pimcore-studio": {
@@ -13898,14 +13910,16 @@
       "version": "1.0.0",
       "license": "CCL",
       "dependencies": {
+        "zustand": "^5.0.7"
+      },
+      "peerDependencies": {
         "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
         "react": "18.3.x",
         "react-dom": "18.3.x",
-        "react-redux": "^9.0.4",
-        "zustand": "^5.0.7"
+        "react-redux": "^9.0.4"
       }
     },
     "src/CoreShop/Bundle/MoneyBundle/Resources/assets/pimcore-studio": {
@@ -13913,14 +13927,16 @@
       "version": "1.0.0",
       "license": "CCL",
       "dependencies": {
+        "zustand": "^5.0.7"
+      },
+      "peerDependencies": {
         "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
         "react": "18.3.x",
         "react-dom": "18.3.x",
-        "react-redux": "^9.0.4",
-        "zustand": "^5.0.7"
+        "react-redux": "^9.0.4"
       }
     },
     "src/CoreShop/Bundle/NotificationBundle/Resources/assets/pimcore-studio": {
@@ -13933,14 +13949,16 @@
         "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
         "@coreshop/store": "file:../../../../StoreBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
+        "zustand": "^5.0.7"
+      },
+      "peerDependencies": {
         "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
         "react": "18.3.x",
         "react-dom": "18.3.x",
-        "react-redux": "^9.0.4",
-        "zustand": "^5.0.7"
+        "react-redux": "^9.0.4"
       }
     },
     "src/CoreShop/Bundle/OrderBundle/Resources/assets/pimcore-studio": {
@@ -13953,14 +13971,16 @@
         "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
         "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
+        "zustand": "^5.0.7"
+      },
+      "peerDependencies": {
         "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
         "react": "18.3.x",
         "react-dom": "18.3.x",
-        "react-redux": "^9.0.4",
-        "zustand": "^5.0.7"
+        "react-redux": "^9.0.4"
       }
     },
     "src/CoreShop/Bundle/PaymentBundle/Resources/assets/pimcore-studio": {
@@ -13971,14 +13991,16 @@
         "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
         "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
+        "zustand": "^5.0.7"
+      },
+      "peerDependencies": {
         "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
         "react": "18.3.x",
         "react-dom": "18.3.x",
-        "react-redux": "^9.0.4",
-        "zustand": "^5.0.7"
+        "react-redux": "^9.0.4"
       }
     },
     "src/CoreShop/Bundle/PimcoreBundle/Resources/assets/pimcore-studio": {
@@ -13987,14 +14009,16 @@
       "license": "CCL",
       "dependencies": {
         "@coreshop/studio-form": "*",
+        "zustand": "^5.0.7"
+      },
+      "peerDependencies": {
         "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
         "react": "18.3.x",
         "react-dom": "18.3.x",
-        "react-redux": "^9.0.4",
-        "zustand": "^5.0.7"
+        "react-redux": "^9.0.4"
       }
     },
     "src/CoreShop/Bundle/ProductBundle/Resources/assets/pimcore-studio": {
@@ -14006,14 +14030,16 @@
         "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
         "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
+        "zustand": "^5.0.7"
+      },
+      "peerDependencies": {
         "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
         "react": "18.3.x",
         "react-dom": "18.3.x",
-        "react-redux": "^9.0.4",
-        "zustand": "^5.0.7"
+        "react-redux": "^9.0.4"
       }
     },
     "src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/assets/pimcore-studio": {
@@ -14023,14 +14049,16 @@
       "dependencies": {
         "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
+        "zustand": "^5.0.7"
+      },
+      "peerDependencies": {
         "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
         "react": "18.3.x",
         "react-dom": "18.3.x",
-        "react-redux": "^9.0.4",
-        "zustand": "^5.0.7"
+        "react-redux": "^9.0.4"
       }
     },
     "src/CoreShop/Bundle/ResourceBundle/Resources/assets/pimcore-studio": {
@@ -14039,14 +14067,16 @@
       "license": "CCL",
       "dependencies": {
         "@coreshop/pimcore": "file:../../../../PimcoreBundle/Resources/assets/pimcore-studio",
+        "zustand": "^5.0.7"
+      },
+      "peerDependencies": {
         "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
         "react": "18.3.x",
         "react-dom": "18.3.x",
-        "react-redux": "^9.0.4",
-        "zustand": "^5.0.7"
+        "react-redux": "^9.0.4"
       }
     },
     "src/CoreShop/Bundle/RuleBundle/Resources/assets/pimcore-studio": {
@@ -14056,14 +14086,16 @@
       "dependencies": {
         "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
+        "zustand": "^5.0.7"
+      },
+      "peerDependencies": {
         "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
         "react": "18.3.x",
         "react-dom": "18.3.x",
-        "react-redux": "^9.0.4",
-        "zustand": "^5.0.7"
+        "react-redux": "^9.0.4"
       }
     },
     "src/CoreShop/Bundle/ShippingBundle/Resources/assets/pimcore-studio": {
@@ -14074,14 +14106,16 @@
         "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
         "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
+        "zustand": "^5.0.7"
+      },
+      "peerDependencies": {
         "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
         "react": "18.3.x",
         "react-dom": "18.3.x",
-        "react-redux": "^9.0.4",
-        "zustand": "^5.0.7"
+        "react-redux": "^9.0.4"
       }
     },
     "src/CoreShop/Bundle/StoreBundle/Resources/assets/pimcore-studio": {
@@ -14092,21 +14126,23 @@
         "@coreshop/currency": "file:../../../../CurrencyBundle/Resources/assets/pimcore-studio",
         "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
+        "zustand": "^5.0.7"
+      },
+      "peerDependencies": {
         "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
         "react": "18.3.x",
         "react-dom": "18.3.x",
-        "react-redux": "^9.0.4",
-        "zustand": "^5.0.7"
+        "react-redux": "^9.0.4"
       }
     },
     "src/CoreShop/Bundle/StudioFormBundle/Resources/assets/pimcore-studio": {
       "name": "@coreshop/studio-form",
       "version": "1.0.0",
       "license": "CCL",
-      "dependencies": {
+      "peerDependencies": {
         "@pimcore/studio-ui-bundle": "2025.4.3",
         "antd": "^5.12.0",
         "react": "18.3.x",
@@ -14120,14 +14156,16 @@
       "dependencies": {
         "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
         "@coreshop/studio-form": "*",
+        "zustand": "^5.0.7"
+      },
+      "peerDependencies": {
         "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
         "react": "18.3.x",
         "react-dom": "18.3.x",
-        "react-redux": "^9.0.4",
-        "zustand": "^5.0.7"
+        "react-redux": "^9.0.4"
       }
     },
     "src/CoreShop/Bundle/UserBundle/Resources/assets/pimcore-studio": {
@@ -14135,14 +14173,16 @@
       "version": "1.0.0",
       "license": "CCL",
       "dependencies": {
+        "zustand": "^5.0.7"
+      },
+      "peerDependencies": {
         "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
         "react": "18.3.x",
         "react-dom": "18.3.x",
-        "react-redux": "^9.0.4",
-        "zustand": "^5.0.7"
+        "react-redux": "^9.0.4"
       }
     },
     "src/CoreShop/Bundle/VariantBundle/Resources/assets/pimcore-studio": {
@@ -14151,14 +14191,16 @@
       "license": "CCL",
       "dependencies": {
         "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
+        "zustand": "^5.0.7"
+      },
+      "peerDependencies": {
         "@pimcore/studio-ui-bundle": "2025.4.3",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
         "react": "18.3.x",
         "react-dom": "18.3.x",
-        "react-redux": "^9.0.4",
-        "zustand": "^5.0.7"
+        "react-redux": "^9.0.4"
       }
     }
   }

--- a/src/CoreShop/Bundle/AddressBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/AddressBundle/Resources/assets/pimcore-studio/package.json
@@ -13,15 +13,17 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
+    "zustand": "^5.0.7",
+    "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
+    "@coreshop/studio-form": "*"
+  },
+  "peerDependencies": {
     "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",
     "react": "18.3.x",
     "react-dom": "18.3.x",
-    "react-redux": "^9.0.4",
-    "zustand": "^5.0.7",
-    "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
-    "@coreshop/studio-form": "*"
+    "react-redux": "^9.0.4"
   }
 }

--- a/src/CoreShop/Bundle/CoreBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/assets/pimcore-studio/package.json
@@ -13,13 +13,6 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
-    "@pimcore/studio-ui-bundle": "2025.4.3",
-    "@reduxjs/toolkit": "^2.0.1",
-    "antd": "^5.12.0",
-    "immer": "^10.1.1",
-    "react": "18.3.x",
-    "react-dom": "18.3.x",
-    "react-redux": "^9.0.4",
     "zustand": "^5.0.7",
     "@coreshop/address": "file:../../../../AddressBundle/Resources/assets/pimcore-studio",
     "@coreshop/currency": "file:../../../../CurrencyBundle/Resources/assets/pimcore-studio",
@@ -35,5 +28,14 @@
     "@coreshop/store": "file:../../../../StoreBundle/Resources/assets/pimcore-studio",
     "@coreshop/studio-form": "*",
     "@coreshop/taxation": "file:../../../../TaxationBundle/Resources/assets/pimcore-studio"
+  },
+  "peerDependencies": {
+    "@pimcore/studio-ui-bundle": "2025.4.3",
+    "@reduxjs/toolkit": "^2.0.1",
+    "antd": "^5.12.0",
+    "immer": "^10.1.1",
+    "react": "18.3.x",
+    "react-dom": "18.3.x",
+    "react-redux": "^9.0.4"
   }
 }

--- a/src/CoreShop/Bundle/CurrencyBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/CurrencyBundle/Resources/assets/pimcore-studio/package.json
@@ -13,15 +13,17 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
+    "zustand": "^5.0.7",
+    "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
+    "@coreshop/studio-form": "*"
+  },
+  "peerDependencies": {
     "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",
     "react": "18.3.x",
     "react-dom": "18.3.x",
-    "react-redux": "^9.0.4",
-    "zustand": "^5.0.7",
-    "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
-    "@coreshop/studio-form": "*"
+    "react-redux": "^9.0.4"
   }
 }

--- a/src/CoreShop/Bundle/CustomerBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/CustomerBundle/Resources/assets/pimcore-studio/package.json
@@ -13,14 +13,16 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
+    "zustand": "^5.0.7",
+    "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio"
+  },
+  "peerDependencies": {
     "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",
     "react": "18.3.x",
     "react-dom": "18.3.x",
-    "react-redux": "^9.0.4",
-    "zustand": "^5.0.7",
-    "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio"
+    "react-redux": "^9.0.4"
   }
 }

--- a/src/CoreShop/Bundle/IndexBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/IndexBundle/Resources/assets/pimcore-studio/package.json
@@ -13,15 +13,17 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
+    "zustand": "^5.0.7",
+    "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
+    "@coreshop/studio-form": "*"
+  },
+  "peerDependencies": {
     "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",
     "react": "18.3.x",
     "react-dom": "18.3.x",
-    "react-redux": "^9.0.4",
-    "zustand": "^5.0.7",
-    "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
-    "@coreshop/studio-form": "*"
+    "react-redux": "^9.0.4"
   }
 }

--- a/src/CoreShop/Bundle/MenuBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/MenuBundle/Resources/assets/pimcore-studio/package.json
@@ -13,13 +13,15 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
+    "zustand": "^5.0.7"
+  },
+  "peerDependencies": {
     "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",
     "react": "18.3.x",
     "react-dom": "18.3.x",
-    "react-redux": "^9.0.4",
-    "zustand": "^5.0.7"
+    "react-redux": "^9.0.4"
   }
 }

--- a/src/CoreShop/Bundle/MessengerBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/MessengerBundle/Resources/assets/pimcore-studio/package.json
@@ -13,13 +13,15 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
+    "zustand": "^5.0.7"
+  },
+  "peerDependencies": {
     "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",
     "react": "18.3.x",
     "react-dom": "18.3.x",
-    "react-redux": "^9.0.4",
-    "zustand": "^5.0.7"
+    "react-redux": "^9.0.4"
   }
 }

--- a/src/CoreShop/Bundle/MoneyBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/MoneyBundle/Resources/assets/pimcore-studio/package.json
@@ -13,13 +13,15 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
+    "zustand": "^5.0.7"
+  },
+  "peerDependencies": {
     "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",
     "react": "18.3.x",
     "react-dom": "18.3.x",
-    "react-redux": "^9.0.4",
-    "zustand": "^5.0.7"
+    "react-redux": "^9.0.4"
   }
 }

--- a/src/CoreShop/Bundle/NotificationBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/NotificationBundle/Resources/assets/pimcore-studio/package.json
@@ -13,18 +13,20 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
-    "@pimcore/studio-ui-bundle": "2025.4.3",
-    "@reduxjs/toolkit": "^2.0.1",
-    "antd": "^5.12.0",
-    "immer": "^10.1.1",
-    "react": "18.3.x",
-    "react-dom": "18.3.x",
-    "react-redux": "^9.0.4",
     "zustand": "^5.0.7",
     "@coreshop/pimcore": "file:../../../../PimcoreBundle/Resources/assets/pimcore-studio",
     "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
     "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
     "@coreshop/store": "file:../../../../StoreBundle/Resources/assets/pimcore-studio",
     "@coreshop/studio-form": "*"
+  },
+  "peerDependencies": {
+    "@pimcore/studio-ui-bundle": "2025.4.3",
+    "@reduxjs/toolkit": "^2.0.1",
+    "antd": "^5.12.0",
+    "immer": "^10.1.1",
+    "react": "18.3.x",
+    "react-dom": "18.3.x",
+    "react-redux": "^9.0.4"
   }
 }

--- a/src/CoreShop/Bundle/OrderBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/assets/pimcore-studio/package.json
@@ -13,18 +13,20 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
-    "@pimcore/studio-ui-bundle": "2025.4.3",
-    "@reduxjs/toolkit": "^2.0.1",
-    "antd": "^5.12.0",
-    "immer": "^10.1.1",
-    "react": "18.3.x",
-    "react-dom": "18.3.x",
-    "react-redux": "^9.0.4",
     "zustand": "^5.0.7",
     "@coreshop/payment": "file:../../../../PaymentBundle/Resources/assets/pimcore-studio",
     "@coreshop/pimcore": "file:../../../../PimcoreBundle/Resources/assets/pimcore-studio",
     "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
     "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
     "@coreshop/studio-form": "*"
+  },
+  "peerDependencies": {
+    "@pimcore/studio-ui-bundle": "2025.4.3",
+    "@reduxjs/toolkit": "^2.0.1",
+    "antd": "^5.12.0",
+    "immer": "^10.1.1",
+    "react": "18.3.x",
+    "react-dom": "18.3.x",
+    "react-redux": "^9.0.4"
   }
 }

--- a/src/CoreShop/Bundle/OrderBundle/Resources/assets/pimcore-studio/src/grid-cell-types/order-state/order-state-cell.tsx
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/assets/pimcore-studio/src/grid-cell-types/order-state/order-state-cell.tsx
@@ -7,7 +7,6 @@
 
 import React from 'react'
 import { Tag } from 'antd'
-import { isNil } from 'lodash'
 import { type DefaultCellProps } from '@pimcore/studio-ui-bundle/components'
 
 interface OrderStateValue {
@@ -18,13 +17,13 @@ interface OrderStateValue {
 export const OrderStateCell = (props: DefaultCellProps): React.JSX.Element => {
   const value = props.getValue() as OrderStateValue | null
 
-  if (isNil(value) || isNil(value.label)) {
+  if (value == null || value.label == null) {
     return <div className='default-cell__content' />
   }
 
   const { label, color } = value
 
-  if (isNil(color)) {
+  if (color == null) {
     return (
       <div className='default-cell__content default-cell__content--padded'>
         {label}

--- a/src/CoreShop/Bundle/PaymentBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/PaymentBundle/Resources/assets/pimcore-studio/package.json
@@ -13,16 +13,18 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
+    "zustand": "^5.0.7",
+    "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
+    "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
+    "@coreshop/studio-form": "*"
+  },
+  "peerDependencies": {
     "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",
     "react": "18.3.x",
     "react-dom": "18.3.x",
-    "react-redux": "^9.0.4",
-    "zustand": "^5.0.7",
-    "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
-    "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
-    "@coreshop/studio-form": "*"
+    "react-redux": "^9.0.4"
   }
 }

--- a/src/CoreShop/Bundle/PimcoreBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/PimcoreBundle/Resources/assets/pimcore-studio/package.json
@@ -13,14 +13,16 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
+    "zustand": "^5.0.7",
+    "@coreshop/studio-form": "*"
+  },
+  "peerDependencies": {
     "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",
     "react": "18.3.x",
     "react-dom": "18.3.x",
-    "react-redux": "^9.0.4",
-    "zustand": "^5.0.7",
-    "@coreshop/studio-form": "*"
+    "react-redux": "^9.0.4"
   }
 }

--- a/src/CoreShop/Bundle/ProductBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/assets/pimcore-studio/package.json
@@ -13,17 +13,19 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
+    "zustand": "^5.0.7",
+    "@coreshop/pimcore": "file:../../../../PimcoreBundle/Resources/assets/pimcore-studio",
+    "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
+    "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
+    "@coreshop/studio-form": "*"
+  },
+  "peerDependencies": {
     "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",
     "react": "18.3.x",
     "react-dom": "18.3.x",
-    "react-redux": "^9.0.4",
-    "zustand": "^5.0.7",
-    "@coreshop/pimcore": "file:../../../../PimcoreBundle/Resources/assets/pimcore-studio",
-    "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
-    "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
-    "@coreshop/studio-form": "*"
+    "react-redux": "^9.0.4"
   }
 }

--- a/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/assets/pimcore-studio/package.json
@@ -13,15 +13,17 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
+    "zustand": "^5.0.7",
+    "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
+    "@coreshop/studio-form": "*"
+  },
+  "peerDependencies": {
     "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",
     "react": "18.3.x",
     "react-dom": "18.3.x",
-    "react-redux": "^9.0.4",
-    "zustand": "^5.0.7",
-    "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
-    "@coreshop/studio-form": "*"
+    "react-redux": "^9.0.4"
   }
 }

--- a/src/CoreShop/Bundle/ResourceBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/ResourceBundle/Resources/assets/pimcore-studio/package.json
@@ -13,14 +13,16 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
+    "zustand": "^5.0.7",
+    "@coreshop/pimcore": "file:../../../../PimcoreBundle/Resources/assets/pimcore-studio"
+  },
+  "peerDependencies": {
     "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",
     "react": "18.3.x",
     "react-dom": "18.3.x",
-    "react-redux": "^9.0.4",
-    "zustand": "^5.0.7",
-    "@coreshop/pimcore": "file:../../../../PimcoreBundle/Resources/assets/pimcore-studio"
+    "react-redux": "^9.0.4"
   }
 }

--- a/src/CoreShop/Bundle/ResourceBundle/Resources/assets/pimcore-studio/src/dynamic-types/DynamicTypeObjectDataCoreShopRelation.tsx
+++ b/src/CoreShop/Bundle/ResourceBundle/Resources/assets/pimcore-studio/src/dynamic-types/DynamicTypeObjectDataCoreShopRelation.tsx
@@ -17,7 +17,6 @@ import {
   RelationList,
   type ManyToOneRelationValue
 } from '@pimcore/studio-ui-bundle/modules/element'
-import { isNil } from 'lodash'
 
 interface ClassDefinitionProps {
   assetsAllowed?: boolean
@@ -75,7 +74,7 @@ export class DynamicTypeObjectDataCoreShopRelation extends DynamicTypeObjectData
 
   getGridCellPreviewComponent(props: any): React.ReactElement {
     const value: ManyToOneRelationValue | null = props.cellProps.getValue()
-    return isNil(value) ? <></> : <RelationList relations={[value]} />
+    return value == null ? <></> : <RelationList relations={[value]} />
   }
 
   getDefaultGridColumnWidth(): number | undefined {

--- a/src/CoreShop/Bundle/RuleBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/RuleBundle/Resources/assets/pimcore-studio/package.json
@@ -13,15 +13,17 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
+    "zustand": "^5.0.7",
+    "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
+    "@coreshop/studio-form": "*"
+  },
+  "peerDependencies": {
     "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",
     "react": "18.3.x",
     "react-dom": "18.3.x",
-    "react-redux": "^9.0.4",
-    "zustand": "^5.0.7",
-    "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
-    "@coreshop/studio-form": "*"
+    "react-redux": "^9.0.4"
   }
 }

--- a/src/CoreShop/Bundle/ShippingBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/ShippingBundle/Resources/assets/pimcore-studio/package.json
@@ -13,16 +13,18 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
+    "zustand": "^5.0.7",
+    "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
+    "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
+    "@coreshop/studio-form": "*"
+  },
+  "peerDependencies": {
     "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",
     "react": "18.3.x",
     "react-dom": "18.3.x",
-    "react-redux": "^9.0.4",
-    "zustand": "^5.0.7",
-    "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
-    "@coreshop/rule": "file:../../../../RuleBundle/Resources/assets/pimcore-studio",
-    "@coreshop/studio-form": "*"
+    "react-redux": "^9.0.4"
   }
 }

--- a/src/CoreShop/Bundle/StoreBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/StoreBundle/Resources/assets/pimcore-studio/package.json
@@ -13,16 +13,18 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
+    "zustand": "^5.0.7",
+    "@coreshop/currency": "file:../../../../CurrencyBundle/Resources/assets/pimcore-studio",
+    "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
+    "@coreshop/studio-form": "*"
+  },
+  "peerDependencies": {
     "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",
     "react": "18.3.x",
     "react-dom": "18.3.x",
-    "react-redux": "^9.0.4",
-    "zustand": "^5.0.7",
-    "@coreshop/currency": "file:../../../../CurrencyBundle/Resources/assets/pimcore-studio",
-    "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
-    "@coreshop/studio-form": "*"
+    "react-redux": "^9.0.4"
   }
 }

--- a/src/CoreShop/Bundle/StudioFormBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/StudioFormBundle/Resources/assets/pimcore-studio/package.json
@@ -12,7 +12,7 @@
   },
   "license": "CCL",
   "private": true,
-  "dependencies": {
+  "peerDependencies": {
     "@pimcore/studio-ui-bundle": "2025.4.3",
     "antd": "^5.12.0",
     "react": "18.3.x",

--- a/src/CoreShop/Bundle/TaxationBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/TaxationBundle/Resources/assets/pimcore-studio/package.json
@@ -15,13 +15,15 @@
   "dependencies": {
     "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
     "@coreshop/studio-form": "*",
+    "zustand": "^5.0.7"
+  },
+  "peerDependencies": {
     "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",
     "react": "18.3.x",
     "react-dom": "18.3.x",
-    "react-redux": "^9.0.4",
-    "zustand": "^5.0.7"
+    "react-redux": "^9.0.4"
   }
 }

--- a/src/CoreShop/Bundle/UserBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/UserBundle/Resources/assets/pimcore-studio/package.json
@@ -13,13 +13,15 @@
   "license": "CCL",
   "private": true,
   "dependencies": {
+    "zustand": "^5.0.7"
+  },
+  "peerDependencies": {
     "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",
     "react": "18.3.x",
     "react-dom": "18.3.x",
-    "react-redux": "^9.0.4",
-    "zustand": "^5.0.7"
+    "react-redux": "^9.0.4"
   }
 }

--- a/src/CoreShop/Bundle/VariantBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/VariantBundle/Resources/assets/pimcore-studio/package.json
@@ -14,13 +14,15 @@
   "private": true,
   "dependencies": {
     "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio",
+    "zustand": "^5.0.7"
+  },
+  "peerDependencies": {
     "@pimcore/studio-ui-bundle": "2025.4.3",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",
     "react": "18.3.x",
     "react-dom": "18.3.x",
-    "react-redux": "^9.0.4",
-    "zustand": "^5.0.7"
+    "react-redux": "^9.0.4"
   }
 }


### PR DESCRIPTION
## Summary
- Move `react`, `react-dom`, `antd`, `immer`, `@reduxjs/toolkit`, `react-redux` and `@pimcore/studio-ui-bundle` from `dependencies` to `peerDependencies` in all 23 studio bundle `package.json`s.
- These libs are shared by the Pimcore Studio host via Module Federation, so the bundles should declare them as peers rather than direct deps.
- Side effect: Dependabot stops proposing major bumps (e.g. react 19, antd 6, immer 11) that pimcore studio-ui-bundle doesn't support.
- Replace 2 trivial `isNil` usages from `lodash` with `value == null` so `lodash` doesn't need to be declared as a dep/peer.

## Test plan
- [ ] `npm install` clean
- [ ] `npm run check-types --workspaces --if-present`
- [ ] `npm run build`
- [ ] Studio UI loads (order state cell + relation field still render correctly)