### PR TITLE
ci(dependabot): restrict composer to minor/patch, ignore risky majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,44 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     groups:
+      symfony:
+        patterns:
+          - "symfony/*"
+        update-types:
+          - "minor"
+          - "patch"
+      doctrine:
+        patterns:
+          - "doctrine/*"
+        update-types:
+          - "minor"
+          - "patch"
       composer:
         patterns:
           - "*"
+        exclude-patterns:
+          - "symfony/*"
+          - "doctrine/*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # Symfony major bumps must be coordinated across all symfony/* packages
+      # and aligned with pimcore's symfony constraint.
+      - dependency-name: "symfony/*"
+        update-types: ["version-update:semver-major"]
+      # Doctrine ORM/DBAL/Fixtures majors require coordinated upgrades.
+      - dependency-name: "doctrine/*"
+        update-types: ["version-update:semver-major"]
+      # Known BC-breaking majors — upgrade manually.
+      - dependency-name: "webmozart/assert"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "symplify/easy-coding-standard"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "phpstan/phpstan"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "vimeo/psalm"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary
- Composer has no peer-dependency concept, so dependabot happily proposes major bumps that violate transitive constraints from `pimcore/*` etc. (see #3054 which would have bumped only some symfony/* packages to ^8 while pimcore stays on ^6/^7).
- Restrict the composer ecosystem to `minor` + `patch` updates only, grouped as `symfony`, `doctrine`, and `composer` (rest).
- Explicitly `ignore` major bumps for `symfony/*`, `doctrine/*`, `webmozart/assert`, `symplify/easy-coding-standard`, `phpstan/phpstan`, `vimeo/psalm` — these need coordinated manual upgrades.
- npm + github-actions config unchanged.

## Test plan
- [ ] Dependabot stops proposing #3054-style mixed-major PRs.
- [ ] Patch/minor updates still come through (grouped per ecosystem).