### PR TITLE
[CI] trigger monorepo split on 5.1 branch

### DIFF
--- a/.github/workflows/gitsplit.yml
+++ b/.github/workflows/gitsplit.yml
@@ -12,6 +12,7 @@ on:
             - 4.0
             - 4.1
             - 5.0
+            - 5.1
         paths:
             - 'src/CoreShop/Bundle/**'
             - 'src/CoreShop/Component/**'


### PR DESCRIPTION
The `gitsplit` workflow's push trigger did not include the `5.1` branch, so pushes to `5.1` never triggered the monorepo split (the `.gitsplit.yml` origins regex `^\d+\.\d+$` already covers it).

This adds `5.1` to the workflow's branch list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)