### PR TITLE
[StorageListBundle] Fix authentication (remember me token)

### DIFF
--- a/src/CoreShop/Bundle/StorageListBundle/Controller/StorageMultiListController.php
+++ b/src/CoreShop/Bundle/StorageListBundle/Controller/StorageMultiListController.php
@@ -62,7 +62,7 @@ class StorageMultiListController extends AbstractController
 
     public function createNamedStorageListAction(Request $request): Response
     {
-        $this->denyAccessUnlessGranted('IS_AUTHENTICATED_FULLY');
+        $this->denyAccessUnlessGranted('IS_AUTHENTICATED_REMEMBERED');
         $this->denyAccessUnlessGranted(sprintf('CORESHOP_STORAGE_LIST_CREATED_%s', strtoupper($this->identifier)));
 
         $form = $this->formFactory->createNamed('coreshop', CreatedNamedStorageListType::class);
@@ -107,7 +107,7 @@ class StorageMultiListController extends AbstractController
 
     public function listStorageListAction(Request $request): Response
     {
-        $this->denyAccessUnlessGranted('IS_AUTHENTICATED_FULLY');
+        $this->denyAccessUnlessGranted('IS_AUTHENTICATED_REMEMBERED');
         $this->denyAccessUnlessGranted('CORESHOP_STORAGE_LIST_MULTI_LIST_' . $this->identifier);
 
         $storageLists = $this->listResolver->getStorageLists($this->contextProvider->getCurrentContext());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? |no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

**Allow cart creation for remembered users**

Creating a named cart (StorageMultiListController::createNamedStorageListAction) required IS_AUTHENTICATED_FULLY. The firewall has a long-lived remember-me cookie (CoreBundle/Resources/config/pimcore/security.yml). Once the session expires, users get silently re-authenticated via that cookie,  producing a RememberMeToken IS_AUTHENTICATED_REMEMBERED, but not IS_AUTHENTICATED_FULLY. The cart creation throws AccessDeniedException (403).
