### PR TITLE
[Dependabot] cover split packages & target both 5.0 and 5.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,18 @@
 version: 2
 updates:
+  # ---------------------------------------------------------------------------
+  # composer — 5.0
+  # Covers the root manifest AND every split bundle/component manifest so a
+  # shared dependency (e.g. friends-of-behat/page-object-extension) is bumped in
+  # lockstep across all of them. The grouped PR spans every directory, keeping
+  # the root and sub-package constraints compatible.
+  # ---------------------------------------------------------------------------
   - package-ecosystem: "composer"
-    directory: "/"
-    # Version updates target 5.1 and get upmerged into 2026.x.
-    # Note: security updates always target the default branch regardless.
-    target-branch: "5.1"
+    target-branch: "5.0"
+    directories:
+      - "/"
+      - "/src/CoreShop/Bundle/*"
+      - "/src/CoreShop/Component/*"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
@@ -48,9 +56,61 @@ updates:
       - dependency-name: "vimeo/psalm"
         update-types: ["version-update:semver-major"]
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  # ---------------------------------------------------------------------------
+  # composer — 5.1 (upmerged into 2026.x)
+  # Note: security updates always target the default branch regardless.
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "composer"
     target-branch: "5.1"
+    directories:
+      - "/"
+      - "/src/CoreShop/Bundle/*"
+      - "/src/CoreShop/Component/*"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      symfony:
+        patterns:
+          - "symfony/*"
+        update-types:
+          - "minor"
+          - "patch"
+      doctrine:
+        patterns:
+          - "doctrine/*"
+        update-types:
+          - "minor"
+          - "patch"
+      composer:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "symfony/*"
+          - "doctrine/*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "symfony/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "doctrine/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "webmozart/assert"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "symplify/easy-coding-standard"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "phpstan/phpstan"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "vimeo/psalm"
+        update-types: ["version-update:semver-major"]
+
+  # ---------------------------------------------------------------------------
+  # github-actions — 5.0 + 5.1
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "github-actions"
+    target-branch: "5.0"
+    directory: "/"
     schedule:
       interval: "weekly"
     groups:
@@ -58,10 +118,23 @@ updates:
         patterns:
           - "*"
 
+  - package-ecosystem: "github-actions"
+    target-branch: "5.1"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # ---------------------------------------------------------------------------
+  # npm — 5.1 only (Studio v2 assets do not exist on 5.0)
+  # ---------------------------------------------------------------------------
   - package-ecosystem: "npm"
+    target-branch: "5.1"
     directories:
       - "/src/CoreShop/Bundle/*/Resources/assets/pimcore-studio"
-    target-branch: "5.1"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10


### PR DESCRIPTION
## Why
Two gaps in the current Dependabot setup surfaced while fixing the upmerge CI:

1. **Split-package drift.** Dependabot only scanned the root `composer.json`. When a shared dev-dependency was bumped (e.g. `friends-of-behat/page-object-extension` → `^0.4.0`), the per-bundle split manifests (like `TestBundle/composer.json`, still `^0.3.2`) were left behind, producing incompatible constraints and failing the monorepo-split CI jobs.
2. **Only 5.1 was targeted.** 5.0 received no version updates of its own.

## What
- **composer** now uses `directories` globs (`/`, `/src/CoreShop/Bundle/*`, `/src/CoreShop/Component/*`) so a shared dependency is bumped in lockstep across the root and every split manifest within a single grouped PR.
- The **composer** and **github-actions** ecosystems are duplicated for `target-branch: "5.0"` in addition to `"5.1"`, so both maintained release lines get updates within their own constraints (upmerge reconciles).
- **npm** (Studio v2 assets) stays 5.1-only — those assets do not exist on 5.0.

> Note: Dependabot reads its config from the default branch (`2026.x`), which is why this change lands here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)