### PR TITLE
[Messenger] fix Studio widget not rendering in navigation

### DIFF
--- a/src/CoreShop/Bundle/MessengerBundle/Menu/MessengerMenuBuilder.php
+++ b/src/CoreShop/Bundle/MessengerBundle/Menu/MessengerMenuBuilder.php
@@ -30,6 +30,7 @@ class MessengerMenuBuilder implements MenuBuilderInterface
             ->setLabel('coreshop_messenger')
             ->setAttribute('permission', 'coreshop_permission_messenger')
             ->setAttribute('iconCls', 'coreshop_nav_icon_messenger')
+            ->setAttribute('widgetId', 'coreshop-messenger-widget')
             ->setAttribute('resource', 'coreshop.messenger')
             ->setAttribute('function', 'list')
         ;


### PR DESCRIPTION
## Problem

Opening the Messenger entry from the Pimcore Studio main navigation renders an empty widget showing only the label (`coreshop_messenger`) instead of the real `MessengerList` UI.

## Cause

The Studio menu bridge in `CoreShopMenuBundle` (`menu-extension.tsx`) derives the widget id for a leaf menu item as:

```js
const widgetId = item.widgetId || `coreshop-${item.id}`
```

The messenger menu item (`MessengerMenuBuilder`) did not set a `widgetId` attribute, so the bridge computed `coreshop-coreshop_messenger`. That id does not match the widget the messenger Studio plugin actually registers:

```ts
widgetRegistryService.registerWidget({ name: 'coreshop-messenger-widget', component: MessengerList })
```

Because no widget is registered under the computed id, the bridge falls back to its placeholder `CoreShopWidget`, which only renders the item label — hence the empty screen. (After linking works, a leftover persisted tab may throw `Widget coreshop-coreshop_messenger not found` once, which is the stale pre-fix tab.)

## Fix

Set the `widgetId` attribute on the messenger menu item to the id the Studio plugin registers, so the navigation entry resolves to the real widget:

```php
->setAttribute('widgetId', 'coreshop-messenger-widget')
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)