### PR TITLE
[Studio] Render CoreShop document editables in the Studio document editor

### DIFF
--- a/src/CoreShop/Bundle/AddressBundle/Resources/assets/pimcore-studio/src/main.ts
+++ b/src/CoreShop/Bundle/AddressBundle/Resources/assets/pimcore-studio/src/main.ts
@@ -18,6 +18,9 @@ import { DynamicTypeObjectDataRegistry } from '@pimcore/studio-ui-bundle/modules
 import { widgetRegistryServiceId } from '@coreshop/studio-form'
 import type { WidgetRegistry as StudioFormWidgetRegistry } from '@coreshop/studio-form'
 import { EntityChoiceWidget } from '@coreshop/resource/src/components/EntityChoiceWidget'
+// Deep import (bundled, not a shared remote) so the document editable registration also works
+// inside the reduced document editor iframe app.
+import { registerCoreShopDocumentEditableSelects } from '@coreshop/resource/src/dynamic-types/DynamicTypeDocumentEditableCoreShopSelect'
 import {ZoneManager} from './modules/zones/ZoneManager'
 import { CountryManager } from './modules/countries/CountryManager'
 import { StateManager } from './modules/states/StateManager'
@@ -35,51 +38,64 @@ const plugin: IAbstractPlugin = {
     name: 'coreshop-address-plugin',
 
     onInit() {
-        const objectDataRegistry = container.get<DynamicTypeObjectDataRegistry>(
-            serviceIds['DynamicTypes/ObjectDataRegistry']
-        )
+        // Register this bundle's document editables. Runs in the main app and in the reduced
+        // document editor iframe; only depends on the core DocumentEditableRegistry.
+        registerCoreShopDocumentEditableSelects(['coreshop_country', 'coreshop_state', 'coreshop_zone'])
 
-        objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopCountry())
-        objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopCountryMultiselect())
-        objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopState())
-        objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopAddressIdentifier())
+        try {
+            const objectDataRegistry = container.get<DynamicTypeObjectDataRegistry>(
+                serviceIds['DynamicTypes/ObjectDataRegistry']
+            )
 
-        // Register StudioForm widgets for ChoiceTypes
-        const formWidgetRegistry = container.get<StudioFormWidgetRegistry>(widgetRegistryServiceId)
+            objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopCountry())
+            objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopCountryMultiselect())
+            objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopState())
+            objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopAddressIdentifier())
 
-        formWidgetRegistry.register('coreshop_country_choice', (field) => ({
-            component: EntityChoiceWidget,
-            props: { loadOptions: loadCountries, getCachedOptions: getCountryCache, droppableAccept: 'coreshop:country', mode: field.multiple ? 'multiple' as const : undefined }
-        }))
+            // Register StudioForm widgets for ChoiceTypes
+            const formWidgetRegistry = container.get<StudioFormWidgetRegistry>(widgetRegistryServiceId)
 
-        formWidgetRegistry.register('coreshop_state_choice', (field) => ({
-            component: EntityChoiceWidget,
-            props: { loadOptions: loadStates, getCachedOptions: getStateCache, droppableAccept: 'coreshop:state', mode: field.multiple ? 'multiple' as const : undefined }
-        }))
+            formWidgetRegistry.register('coreshop_country_choice', (field) => ({
+                component: EntityChoiceWidget,
+                props: { loadOptions: loadCountries, getCachedOptions: getCountryCache, droppableAccept: 'coreshop:country', mode: field.multiple ? 'multiple' as const : undefined }
+            }))
 
-        formWidgetRegistry.register('coreshop_zone_choice', (field) => ({
-            component: EntityChoiceWidget,
-            props: { loadOptions: loadZones, getCachedOptions: getZoneCache, droppableAccept: 'coreshop:zone', mode: field.multiple ? 'multiple' as const : undefined }
-        }))
+            formWidgetRegistry.register('coreshop_state_choice', (field) => ({
+                component: EntityChoiceWidget,
+                props: { loadOptions: loadStates, getCachedOptions: getStateCache, droppableAccept: 'coreshop:state', mode: field.multiple ? 'multiple' as const : undefined }
+            }))
+
+            formWidgetRegistry.register('coreshop_zone_choice', (field) => ({
+                component: EntityChoiceWidget,
+                props: { loadOptions: loadZones, getCachedOptions: getZoneCache, droppableAccept: 'coreshop:zone', mode: field.multiple ? 'multiple' as const : undefined }
+            }))
+        } catch {
+            // Main Studio app only — object editor / StudioForm services are absent in the
+            // reduced document editor iframe. The document editables are already registered above.
+        }
     },
 
     onStartup({moduleSystem}) {
         moduleSystem.registerModule(AddressBundleIconModule)
 
-        const widgets = container.get<WidgetRegistry>(serviceIds.widgetManager)
+        try {
+            const widgets = container.get<WidgetRegistry>(serviceIds.widgetManager)
 
-        widgets.registerWidget({
-            name:  'coreshop-address-zones',
-            component: ZoneManager
-        })
-        widgets.registerWidget({
-            name: 'coreshop-address-countries',
-            component: CountryManager
-        })
-        widgets.registerWidget({
-            name: 'coreshop-address-states',
-            component: StateManager
-        })
+            widgets.registerWidget({
+                name:  'coreshop-address-zones',
+                component: ZoneManager
+            })
+            widgets.registerWidget({
+                name: 'coreshop-address-countries',
+                component: CountryManager
+            })
+            widgets.registerWidget({
+                name: 'coreshop-address-states',
+                component: StateManager
+            })
+        } catch {
+            // Main Studio app only — widget manager absent in the document editor iframe.
+        }
     }
 }
 

--- a/src/CoreShop/Bundle/AddressBundle/Resources/config/services/studio.yml
+++ b/src/CoreShop/Bundle/AddressBundle/Resources/config/services/studio.yml
@@ -2,3 +2,4 @@ services:
   CoreShop\Bundle\AddressBundle\Studio\WebpackEntryPointProvider:
     tags:
       - { name: pimcore_studio_ui.webpack_entry_point_provider }
+      - { name: pimcore_studio_ui.webpack_entry_point_provider.document_editor_iframe }

--- a/src/CoreShop/Bundle/CurrencyBundle/Resources/assets/pimcore-studio/src/main.ts
+++ b/src/CoreShop/Bundle/CurrencyBundle/Resources/assets/pimcore-studio/src/main.ts
@@ -18,6 +18,9 @@ import { DynamicTypeObjectDataRegistry } from '@pimcore/studio-ui-bundle/modules
 import { widgetRegistryServiceId } from '@coreshop/studio-form'
 import type { WidgetRegistry as StudioFormWidgetRegistry } from '@coreshop/studio-form'
 import { EntityChoiceWidget } from '@coreshop/resource/src/components/EntityChoiceWidget'
+// Deep import (bundled, not a shared remote) so the document editable registration also works
+// inside the reduced document editor iframe app.
+import { registerCoreShopDocumentEditableSelects } from '@coreshop/resource/src/dynamic-types/DynamicTypeDocumentEditableCoreShopSelect'
 import { CurrencyManager } from './modules/currencies/CurrencyManager'
 import { ExchangeRateManager } from './modules/exchange-rates/ExchangeRateManager'
 import { loadCurrencies, getCurrencyCache } from './components/CurrencySelect'
@@ -32,41 +35,54 @@ const plugin: IAbstractPlugin = {
     name: 'coreshop-currency',
 
     onInit() {
-        // Load currency config (decimal_factor, decimal_precision) for price formatting
-        void initCurrencyConfig()
+        // Register this bundle's document editables. Runs in the main app and in the reduced
+        // document editor iframe; only depends on the core DocumentEditableRegistry.
+        registerCoreShopDocumentEditableSelects(['coreshop_currency'])
 
-        const objectDataRegistry = container.get<DynamicTypeObjectDataRegistry>(
-            serviceIds['DynamicTypes/ObjectDataRegistry']
-        )
+        try {
+            // Load currency config (decimal_factor, decimal_precision) for price formatting
+            void initCurrencyConfig()
 
-        objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopCurrency())
-        objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopCurrencyMultiselect())
-        objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopMoneyCurrency())
+            const objectDataRegistry = container.get<DynamicTypeObjectDataRegistry>(
+                serviceIds['DynamicTypes/ObjectDataRegistry']
+            )
 
-        // Register StudioForm widget for CurrencyChoiceType
-        const formWidgetRegistry = container.get<StudioFormWidgetRegistry>(widgetRegistryServiceId)
+            objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopCurrency())
+            objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopCurrencyMultiselect())
+            objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopMoneyCurrency())
 
-        formWidgetRegistry.register('coreshop_currency_choice', (field) => ({
-            component: EntityChoiceWidget,
-            props: { loadOptions: loadCurrencies, getCachedOptions: getCurrencyCache, droppableAccept: 'coreshop:currency', mode: field.multiple ? 'multiple' as const : undefined }
-        }))
+            // Register StudioForm widget for CurrencyChoiceType
+            const formWidgetRegistry = container.get<StudioFormWidgetRegistry>(widgetRegistryServiceId)
+
+            formWidgetRegistry.register('coreshop_currency_choice', (field) => ({
+                component: EntityChoiceWidget,
+                props: { loadOptions: loadCurrencies, getCachedOptions: getCurrencyCache, droppableAccept: 'coreshop:currency', mode: field.multiple ? 'multiple' as const : undefined }
+            }))
+        } catch {
+            // Main Studio app only — object editor / StudioForm services are absent in the
+            // reduced document editor iframe. The document editables are already registered above.
+        }
     },
 
     onStartup({ moduleSystem }) {
         moduleSystem.registerModule(CurrencyBundleIconModule)
 
-        // Register Currency entity widget (used by menu)
-        const widgets = container.get<WidgetRegistry>(serviceIds.widgetManager)
+        try {
+            // Register Currency entity widget (used by menu)
+            const widgets = container.get<WidgetRegistry>(serviceIds.widgetManager)
 
-        widgets.registerWidget({
-            name: 'coreshop-currency-currencies',
-            component: CurrencyManager
-        })
+            widgets.registerWidget({
+                name: 'coreshop-currency-currencies',
+                component: CurrencyManager
+            })
 
-        widgets.registerWidget({
-            name: 'coreshop-currency-exchange-rates',
-            component: ExchangeRateManager
-        })
+            widgets.registerWidget({
+                name: 'coreshop-currency-exchange-rates',
+                component: ExchangeRateManager
+            })
+        } catch {
+            // Main Studio app only — widget manager absent in the document editor iframe.
+        }
     }
 }
 

--- a/src/CoreShop/Bundle/CurrencyBundle/Resources/config/services/studio.yml
+++ b/src/CoreShop/Bundle/CurrencyBundle/Resources/config/services/studio.yml
@@ -2,3 +2,4 @@ services:
   CoreShop\Bundle\CurrencyBundle\Studio\WebpackEntryPointProvider:
     tags:
       - { name: pimcore_studio_ui.webpack_entry_point_provider }
+      - { name: pimcore_studio_ui.webpack_entry_point_provider.document_editor_iframe }

--- a/src/CoreShop/Bundle/IndexBundle/Resources/assets/pimcore-studio/src/main.ts
+++ b/src/CoreShop/Bundle/IndexBundle/Resources/assets/pimcore-studio/src/main.ts
@@ -15,6 +15,9 @@ import { serviceIds as pimcoreServiceIds } from '@pimcore/studio-ui-bundle/app'
 import type { WidgetRegistry as PimcoreWidgetRegistry } from '@pimcore/studio-ui-bundle/modules/widget-manager'
 import { DynamicTypeObjectDataRegistry } from '@pimcore/studio-ui-bundle/modules/element'
 import { widgetRegistryServiceId, type WidgetRegistry } from '@coreshop/studio-form'
+// Deep import (bundled, not a shared remote) so the document editable registration also works
+// inside the reduced document editor iframe app.
+import { registerCoreShopDocumentEditableSelects } from '@coreshop/resource/src/dynamic-types/DynamicTypeDocumentEditableCoreShopSelect'
 import { Input } from 'antd'
 import { IndexBundleIconModule } from './modules/icon-library'
 import { DynamicTypeObjectDataCoreShopFilter } from './dynamic-types'
@@ -30,6 +33,11 @@ const plugin: IAbstractPlugin = {
     name: 'coreshop-index',
 
     onInit() {
+        // Register this bundle's document editables. Runs in the main app and in the reduced
+        // document editor iframe; only depends on the core DocumentEditableRegistry.
+        registerCoreShopDocumentEditableSelects(['coreshop_filter', 'coreshop_index'])
+
+        try {
         // Register Dynamic Types
         const objectDataRegistry = container.get<DynamicTypeObjectDataRegistry>(
             pimcoreServiceIds['DynamicTypes/ObjectDataRegistry']
@@ -80,16 +88,25 @@ const plugin: IAbstractPlugin = {
             component: InterpreterCollectionWidget,
             props: { field },
         }))
+        } catch {
+            // Everything above targets the main Studio app (object editor, widgets, schema
+            // forms). Those services are absent in the reduced document editor iframe app —
+            // skip them there; the document editables are already registered above.
+        }
     },
 
     onStartup({ moduleSystem }) {
-        // Hide IndexBundle-owned rule collection prefixes from generic schema forms
-        const formWidgetRegistry = container.get<WidgetRegistry>(widgetRegistryServiceId)
-        const hiddenWidget = () => ({ component: Input, extra: { hidden: true } })
-        ;[
-          'coreshop_filter_pre_condition_collection',
-          'coreshop_filter_user_condition_collection',
-        ].forEach((prefix) => formWidgetRegistry.register(prefix, hiddenWidget))
+        try {
+            // Hide IndexBundle-owned rule collection prefixes from generic schema forms
+            const formWidgetRegistry = container.get<WidgetRegistry>(widgetRegistryServiceId)
+            const hiddenWidget = () => ({ component: Input, extra: { hidden: true } })
+            ;[
+              'coreshop_filter_pre_condition_collection',
+              'coreshop_filter_user_condition_collection',
+            ].forEach((prefix) => formWidgetRegistry.register(prefix, hiddenWidget))
+        } catch {
+            // Main Studio app only — StudioForm registry absent in the document editor iframe.
+        }
 
         moduleSystem.registerModule(IndexBundleIconModule)
     }

--- a/src/CoreShop/Bundle/IndexBundle/Resources/config/services/studio.yml
+++ b/src/CoreShop/Bundle/IndexBundle/Resources/config/services/studio.yml
@@ -2,3 +2,4 @@ services:
   CoreShop\Bundle\IndexBundle\Studio\WebpackEntryPointProvider:
     tags:
       - { name: pimcore_studio_ui.webpack_entry_point_provider }
+      - { name: pimcore_studio_ui.webpack_entry_point_provider.document_editor_iframe }

--- a/src/CoreShop/Bundle/PaymentBundle/Resources/assets/pimcore-studio/src/main.ts
+++ b/src/CoreShop/Bundle/PaymentBundle/Resources/assets/pimcore-studio/src/main.ts
@@ -18,6 +18,9 @@ import { Input } from 'antd'
 import { widgetRegistryServiceId } from '@coreshop/studio-form'
 import type { WidgetRegistry as StudioFormWidgetRegistry } from '@coreshop/studio-form'
 import { EntityChoiceWidget } from '@coreshop/resource/src/components/EntityChoiceWidget'
+// Deep import (bundled, not a shared remote) so the document editable registration also works
+// inside the reduced document editor iframe app.
+import { registerCoreShopDocumentEditableSelects } from '@coreshop/resource/src/dynamic-types/DynamicTypeDocumentEditableCoreShopSelect'
 import { loadPaymentProviders, getPaymentProviderCache } from './components/PaymentProviderSelect'
 import { PaymentBundleIconModule } from './modules/icon-library'
 import { PaymentProviderWidgetsModule } from './modules/payment-providers/widgets'
@@ -35,6 +38,11 @@ const plugin: IAbstractPlugin = {
   name: 'coreshop-payment',
 
   onInit() {
+    // Register this bundle's document editables. Runs in the main app and in the reduced
+    // document editor iframe; only depends on the core DocumentEditableRegistry.
+    registerCoreShopDocumentEditableSelects(['coreshop_payment_provider'])
+
+    try {
     // ============================================
     // Dynamic Types Registration
     // ============================================
@@ -104,16 +112,24 @@ const plugin: IAbstractPlugin = {
       name: 'coreshop_payment_provider_rules',
       component: PaymentProviderRuleManager
     })
+    } catch {
+      // Main Studio app only — object editor / StudioForm / rule registries are absent in the
+      // reduced document editor iframe. The document editables are already registered above.
+    }
   },
 
   onStartup({ moduleSystem }) {
-    // Hide PaymentBundle-owned rule collection prefixes from generic schema forms
-    const formWidgetRegistry = container.get<StudioFormWidgetRegistry>(widgetRegistryServiceId)
-    const hiddenWidget = () => ({ component: Input, extra: { hidden: true } })
-    ;[
-      'coreshop_payment_provider_rule_condition_collection',
-      'coreshop_payment_action_collection',
-    ].forEach((prefix) => formWidgetRegistry.register(prefix, hiddenWidget))
+    try {
+      // Hide PaymentBundle-owned rule collection prefixes from generic schema forms
+      const formWidgetRegistry = container.get<StudioFormWidgetRegistry>(widgetRegistryServiceId)
+      const hiddenWidget = () => ({ component: Input, extra: { hidden: true } })
+      ;[
+        'coreshop_payment_provider_rule_condition_collection',
+        'coreshop_payment_action_collection',
+      ].forEach((prefix) => formWidgetRegistry.register(prefix, hiddenWidget))
+    } catch {
+      // Main Studio app only — StudioForm registry absent in the document editor iframe.
+    }
 
     moduleSystem.registerModule(PaymentBundleIconModule)
     moduleSystem.registerModule(PaymentProviderWidgetsModule)

--- a/src/CoreShop/Bundle/PaymentBundle/Resources/config/services/studio.yml
+++ b/src/CoreShop/Bundle/PaymentBundle/Resources/config/services/studio.yml
@@ -2,3 +2,4 @@ services:
   CoreShop\Bundle\PaymentBundle\Studio\WebpackEntryPointProvider:
     tags:
       - { name: pimcore_studio_ui.webpack_entry_point_provider }
+      - { name: pimcore_studio_ui.webpack_entry_point_provider.document_editor_iframe }

--- a/src/CoreShop/Bundle/ResourceBundle/Resources/assets/pimcore-studio/src/dynamic-types/DynamicTypeDocumentEditableCoreShopSelect.tsx
+++ b/src/CoreShop/Bundle/ResourceBundle/Resources/assets/pimcore-studio/src/dynamic-types/DynamicTypeDocumentEditableCoreShopSelect.tsx
@@ -1,0 +1,109 @@
+/**
+ * CoreShop ResourceBundle Studio Plugin
+ *
+ * This source file is available under the terms of the
+ * CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    CoreShop Commercial License (CCL)
+ */
+
+import React from 'react'
+import { Select } from 'antd'
+import { container } from '@pimcore/studio-ui-bundle'
+import { serviceIds } from '@pimcore/studio-ui-bundle/app'
+import {
+  DynamicTypeDocumentEditableAbstract,
+  type AbstractDocumentEditableDefinition,
+  type DynamicTypeDocumentEditableRegistry
+} from '@pimcore/studio-ui-bundle/modules/element'
+
+type StoreEntry = [string | number | null, string] | string | number
+
+/**
+ * The CoreShop editable emits its option list as `config.store` (array of `[id, label]`
+ * tuples) via the PHP CoreExtension\Document\Select. We map that straight to antd options.
+ */
+const toOptions = (store?: StoreEntry[]): Array<{ value: string, label: string }> =>
+  (store ?? []).map((entry) => {
+    if (Array.isArray(entry)) {
+      return { value: String(entry[0]), label: String(entry[1]) }
+    }
+
+    return { value: String(entry), label: String(entry) }
+  })
+
+const CoreShopDocumentSelect: React.FC<{
+  value?: string | number | null
+  onChange?: (value: any) => void
+  store?: StoreEntry[]
+  width?: number
+}> = ({ value, onChange, store, width }) => (
+  <Select
+    allowClear
+    // Render the dropdown inside the editable's own container instead of document.body:
+    // the Studio document editor renders editables inside an iframe overlay where a
+    // body-portalled popup gets clipped / is invisible.
+    getPopupContainer={ (node) => (node?.parentElement ?? document.body) }
+    onChange={ (next) => onChange?.(next ?? null) }
+    optionFilterProp="label"
+    options={ toOptions(store) }
+    popupMatchSelectWidth={ false }
+    showSearch
+    style={ { width: width ?? '100%', minWidth: 200 } }
+    value={ value !== null && value !== undefined && value !== '' ? String(value) : undefined }
+  />
+)
+
+/**
+ * Studio document editable for CoreShop resource-backed select editables
+ * (`coreshop_filter`, `coreshop_index`, `coreshop_country`, ...).
+ *
+ * It extends the framework's `DynamicTypeDocumentEditableAbstract` (not the concrete
+ * `DynamicTypeDocumentEditableSelect`, which is not part of the public SDK surface on all
+ * Studio versions) and renders its own antd select from the backend-provided `config.store`.
+ * The only thing that differs per feature bundle is the editable `type` id, bound here.
+ */
+export class DynamicTypeDocumentEditableCoreShopSelect extends DynamicTypeDocumentEditableAbstract {
+  id: string
+
+  constructor (type: string) {
+    super()
+    this.id = type
+  }
+
+  getEditableDataComponent (
+    props: AbstractDocumentEditableDefinition
+  ): React.ReactElement<AbstractDocumentEditableDefinition> {
+    return (
+      <CoreShopDocumentSelect
+        onChange={ props.onChange }
+        store={ props.config?.store }
+        value={ props.value }
+        width={ props.config?.width }
+      />
+    ) as React.ReactElement<AbstractDocumentEditableDefinition>
+  }
+
+  isEmpty (value: any): boolean {
+    return value === null || value === undefined || value === ''
+  }
+}
+
+/**
+ * Registers CoreShop select-style document editables in the Studio document editor.
+ *
+ * Safe to call from any bundle plugin's `onInit`, including inside the document editor
+ * iframe (a reduced Studio app), as it only depends on the core DocumentEditableRegistry.
+ */
+export function registerCoreShopDocumentEditableSelects (types: string[]): void {
+  const registry = container.get<DynamicTypeDocumentEditableRegistry>(
+    serviceIds['DynamicTypes/DocumentEditableRegistry']
+  )
+
+  for (const type of types) {
+    registry.registerDynamicType(new DynamicTypeDocumentEditableCoreShopSelect(type))
+  }
+}

--- a/src/CoreShop/Bundle/ResourceBundle/Resources/assets/pimcore-studio/src/dynamic-types/index.ts
+++ b/src/CoreShop/Bundle/ResourceBundle/Resources/assets/pimcore-studio/src/dynamic-types/index.ts
@@ -14,3 +14,7 @@ export { DynamicTypeObjectDataCoreShopRelation } from './DynamicTypeObjectDataCo
 export { DynamicTypeObjectDataCoreShopRelations } from './DynamicTypeObjectDataCoreShopRelations'
 export { DynamicTypeObjectDataCoreShopSelect } from './DynamicTypeObjectDataCoreShopSelect'
 export { DynamicTypeObjectDataCoreShopMultiSelect } from './DynamicTypeObjectDataCoreShopMultiSelect'
+export {
+  DynamicTypeDocumentEditableCoreShopSelect,
+  registerCoreShopDocumentEditableSelects
+} from './DynamicTypeDocumentEditableCoreShopSelect'

--- a/src/CoreShop/Bundle/ResourceBundle/Resources/assets/pimcore-studio/src/index.ts
+++ b/src/CoreShop/Bundle/ResourceBundle/Resources/assets/pimcore-studio/src/index.ts
@@ -12,3 +12,9 @@
 
 // Export all entities components and types
 export * from './entities'
+
+// Export reusable CoreShop dynamic types (object data + document editables)
+export {
+  DynamicTypeDocumentEditableCoreShopSelect,
+  registerCoreShopDocumentEditableSelects
+} from './dynamic-types'

--- a/src/CoreShop/Bundle/ShippingBundle/Resources/assets/pimcore-studio/src/main.ts
+++ b/src/CoreShop/Bundle/ShippingBundle/Resources/assets/pimcore-studio/src/main.ts
@@ -26,6 +26,9 @@ import { widgetRegistryServiceId } from '@coreshop/studio-form'
 import type { WidgetRegistry as StudioFormWidgetRegistry } from '@coreshop/studio-form'
 import { CarrierSelect, loadCarriers, getCarrierCache } from './components/CarrierSelect'
 import { EntityChoiceWidget } from '@coreshop/resource/src/components/EntityChoiceWidget'
+// Deep import (bundled, not a shared remote) so the document editable registration also works
+// inside the reduced document editor iframe app.
+import { registerCoreShopDocumentEditableSelects } from '@coreshop/resource/src/dynamic-types/DynamicTypeDocumentEditableCoreShopSelect'
 import {
     DynamicTypeObjectDataCoreShopCarrier,
     DynamicTypeObjectDataCoreShopCarrierMultiselect
@@ -35,48 +38,61 @@ const plugin: IAbstractPlugin = {
     name: 'coreshop-shipping',
 
     onInit() {
-        // Register Dynamic Types
-        const objectDataRegistry = container.get<DynamicTypeObjectDataRegistry>(
-            serviceIds['DynamicTypes/ObjectDataRegistry']
-        )
-        objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopCarrier())
-        objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopCarrierMultiselect())
+        // Register this bundle's document editables. Runs in the main app and in the reduced
+        // document editor iframe; only depends on the core DocumentEditableRegistry.
+        registerCoreShopDocumentEditableSelects(['coreshop_carrier'])
 
-        // Register Carrier widget
-        const widgetManager = container.get<WidgetRegistry>(serviceIds.widgetManager)
-        widgetManager.registerWidget({
-            name: 'coreshop-shipping-carriers',
-            component: CarrierManager
-        })
+        try {
+            // Register Dynamic Types
+            const objectDataRegistry = container.get<DynamicTypeObjectDataRegistry>(
+                serviceIds['DynamicTypes/ObjectDataRegistry']
+            )
+            objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopCarrier())
+            objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopCarrierMultiselect())
 
-        // Register ShippingRule widget
-        widgetManager.registerWidget({
-            name: 'coreshop-shipping-shipping-rules',
-            component: ShippingRuleManager
-        })
+            // Register Carrier widget
+            const widgetManager = container.get<WidgetRegistry>(serviceIds.widgetManager)
+            widgetManager.registerWidget({
+                name: 'coreshop-shipping-carriers',
+                component: CarrierManager
+            })
 
-        // Create and bind ShippingRule registries
-        container.bind(coreshopShippingServiceIds.shippingRuleConditionRegistry).to(ConditionRegistry).inSingletonScope()
-        container.bind(coreshopShippingServiceIds.shippingRuleActionRegistry).to(ActionRegistry).inSingletonScope()
+            // Register ShippingRule widget
+            widgetManager.registerWidget({
+                name: 'coreshop-shipping-shipping-rules',
+                component: ShippingRuleManager
+            })
 
-        // Get registries
-        const conditionRegistry = container.get<ConditionRegistry>(coreshopShippingServiceIds.shippingRuleConditionRegistry)
-        container.get<ActionRegistry>(coreshopShippingServiceIds.shippingRuleActionRegistry)
+            // Create and bind ShippingRule registries
+            container.bind(coreshopShippingServiceIds.shippingRuleConditionRegistry).to(ConditionRegistry).inSingletonScope()
+            container.bind(coreshopShippingServiceIds.shippingRuleActionRegistry).to(ActionRegistry).inSingletonScope()
 
-        // Register non-schema custom condition(s).
-        // Schema-based conditions/actions are auto-registered at runtime from backend mappings.
-        conditionRegistry.register('nested', NestedCondition)
+            // Get registries
+            const conditionRegistry = container.get<ConditionRegistry>(coreshopShippingServiceIds.shippingRuleConditionRegistry)
+            container.get<ActionRegistry>(coreshopShippingServiceIds.shippingRuleActionRegistry)
+
+            // Register non-schema custom condition(s).
+            // Schema-based conditions/actions are auto-registered at runtime from backend mappings.
+            conditionRegistry.register('nested', NestedCondition)
+        } catch {
+            // Main Studio app only — object editor / widget manager / rule registries are absent
+            // in the reduced document editor iframe. The document editables are registered above.
+        }
     },
 
     onStartup({ moduleSystem }) {
-        const formWidgetRegistry = container.get<StudioFormWidgetRegistry>(widgetRegistryServiceId)
+        try {
+            const formWidgetRegistry = container.get<StudioFormWidgetRegistry>(widgetRegistryServiceId)
 
-        // Hide ShippingBundle-owned rule collection prefixes from generic schema forms
-        const hiddenWidget = () => ({ component: Input, extra: { hidden: true } })
-        ;[
-          'coreshop_shipping_rule_condition_collection',
-          'coreshop_product_shipping_action_collection',
-        ].forEach((prefix) => formWidgetRegistry.register(prefix, hiddenWidget))
+            // Hide ShippingBundle-owned rule collection prefixes from generic schema forms
+            const hiddenWidget = () => ({ component: Input, extra: { hidden: true } })
+            ;[
+              'coreshop_shipping_rule_condition_collection',
+              'coreshop_product_shipping_action_collection',
+            ].forEach((prefix) => formWidgetRegistry.register(prefix, hiddenWidget))
+        } catch {
+            // Main Studio app only — StudioForm registry absent in the document editor iframe.
+        }
 
         moduleSystem.registerModule(ShippingBundleIconModule)
         moduleSystem.registerModule(CarrierWidgetsModule)

--- a/src/CoreShop/Bundle/ShippingBundle/Resources/config/services/studio.yml
+++ b/src/CoreShop/Bundle/ShippingBundle/Resources/config/services/studio.yml
@@ -2,3 +2,4 @@ services:
   CoreShop\Bundle\ShippingBundle\Studio\WebpackEntryPointProvider:
     tags:
       - { name: pimcore_studio_ui.webpack_entry_point_provider }
+      - { name: pimcore_studio_ui.webpack_entry_point_provider.document_editor_iframe }

--- a/src/CoreShop/Bundle/StoreBundle/Resources/assets/pimcore-studio/src/main.ts
+++ b/src/CoreShop/Bundle/StoreBundle/Resources/assets/pimcore-studio/src/main.ts
@@ -17,6 +17,9 @@ import { DynamicTypeObjectDataRegistry } from '@pimcore/studio-ui-bundle/modules
 import { widgetRegistryServiceId } from '@coreshop/studio-form'
 import type { WidgetRegistry as StudioFormWidgetRegistry } from '@coreshop/studio-form'
 import { EntityChoiceWidget } from '@coreshop/resource/src/components/EntityChoiceWidget'
+// Deep import (bundled, not a shared remote) so the document editable registration also works
+// inside the reduced document editor iframe app.
+import { registerCoreShopDocumentEditableSelects } from '@coreshop/resource/src/dynamic-types/DynamicTypeDocumentEditableCoreShopSelect'
 import { StoreBundleIconModule } from './modules/icon-library'
 import { StoreManager } from './modules/stores/StoreManager'
 import { loadStores, getStoreCache } from './components/StoreSelect'
@@ -29,31 +32,44 @@ const plugin: IAbstractPlugin = {
     name: 'coreshop-store',
 
     onInit() {
-        const objectDataRegistry = container.get<DynamicTypeObjectDataRegistry>(
-            serviceIds['DynamicTypes/ObjectDataRegistry']
-        )
+        // Register this bundle's document editables. Runs in the main app and in the reduced
+        // document editor iframe; only depends on the core DocumentEditableRegistry.
+        registerCoreShopDocumentEditableSelects(['coreshop_store'])
 
-        objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopStore())
-        objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopStoreMultiselect())
+        try {
+            const objectDataRegistry = container.get<DynamicTypeObjectDataRegistry>(
+                serviceIds['DynamicTypes/ObjectDataRegistry']
+            )
 
-        // Register StudioForm widget for StoreChoiceType
-        const formWidgetRegistry = container.get<StudioFormWidgetRegistry>(widgetRegistryServiceId)
+            objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopStore())
+            objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopStoreMultiselect())
 
-        formWidgetRegistry.register('coreshop_store_choice', (field) => ({
-            component: EntityChoiceWidget,
-            props: { loadOptions: loadStores, getCachedOptions: getStoreCache, droppableAccept: 'coreshop:store', mode: field.multiple ? 'multiple' as const : undefined }
-        }))
+            // Register StudioForm widget for StoreChoiceType
+            const formWidgetRegistry = container.get<StudioFormWidgetRegistry>(widgetRegistryServiceId)
+
+            formWidgetRegistry.register('coreshop_store_choice', (field) => ({
+                component: EntityChoiceWidget,
+                props: { loadOptions: loadStores, getCachedOptions: getStoreCache, droppableAccept: 'coreshop:store', mode: field.multiple ? 'multiple' as const : undefined }
+            }))
+        } catch {
+            // Main Studio app only — object editor / StudioForm services are absent in the
+            // reduced document editor iframe. The document editables are already registered above.
+        }
     },
 
     onStartup({ moduleSystem }) {
         moduleSystem.registerModule(StoreBundleIconModule)
 
-        // Register Store Manager widget
-        const widgets = container.get<WidgetRegistry>(serviceIds.widgetManager)
-        widgets.registerWidget({
-            name: 'coreshop-store-store',
-            component: StoreManager
-        })
+        try {
+            // Register Store Manager widget
+            const widgets = container.get<WidgetRegistry>(serviceIds.widgetManager)
+            widgets.registerWidget({
+                name: 'coreshop-store-store',
+                component: StoreManager
+            })
+        } catch {
+            // Main Studio app only — widget manager absent in the document editor iframe.
+        }
     }
 }
 

--- a/src/CoreShop/Bundle/StoreBundle/Resources/config/services/studio.yml
+++ b/src/CoreShop/Bundle/StoreBundle/Resources/config/services/studio.yml
@@ -2,3 +2,4 @@ services:
   CoreShop\Bundle\StoreBundle\Studio\WebpackEntryPointProvider:
     tags:
       - { name: pimcore_studio_ui.webpack_entry_point_provider }
+      - { name: pimcore_studio_ui.webpack_entry_point_provider.document_editor_iframe }

--- a/src/CoreShop/Bundle/StudioFormBundle/Resources/assets/pimcore-studio/src/main.ts
+++ b/src/CoreShop/Bundle/StudioFormBundle/Resources/assets/pimcore-studio/src/main.ts
@@ -21,6 +21,11 @@ import { DemoModule } from './modules/demo'
 const plugin: IAbstractPlugin = {
   name: 'coreshop-studio-form-plugin',
 
+  // Init before the feature bundle plugins (index, address, ...) that resolve the
+  // StudioForm WidgetRegistry in their own onInit. Plugins are ordered ascending by
+  // priority, so a low value guarantees this plugin binds the registry first.
+  priority: -1000,
+
   onInit() {
     // Bind WidgetRegistry as singleton
     container.bind(widgetRegistryServiceId).to(WidgetRegistry).inSingletonScope()

--- a/src/CoreShop/Bundle/StudioFormBundle/Resources/config/services/studio.yml
+++ b/src/CoreShop/Bundle/StudioFormBundle/Resources/config/services/studio.yml
@@ -2,3 +2,4 @@ services:
   CoreShop\Bundle\StudioFormBundle\Studio\WebpackEntryPointProvider:
     tags:
       - { name: pimcore_studio_ui.webpack_entry_point_provider }
+      - { name: pimcore_studio_ui.webpack_entry_point_provider.document_editor_iframe }

--- a/src/CoreShop/Bundle/TaxationBundle/Resources/assets/pimcore-studio/src/main.ts
+++ b/src/CoreShop/Bundle/TaxationBundle/Resources/assets/pimcore-studio/src/main.ts
@@ -18,6 +18,9 @@ import { DynamicTypeObjectDataRegistry } from '@pimcore/studio-ui-bundle/modules
 import { widgetRegistryServiceId } from '@coreshop/studio-form'
 import type { WidgetRegistry as StudioFormWidgetRegistry } from '@coreshop/studio-form'
 import { EntityChoiceWidget } from '@coreshop/resource/src/components/EntityChoiceWidget'
+// Deep import (bundled, not a shared remote) so the document editable registration also works
+// inside the reduced document editor iframe app.
+import { registerCoreShopDocumentEditableSelects } from '@coreshop/resource/src/dynamic-types/DynamicTypeDocumentEditableCoreShopSelect'
 import { TaxRateManager } from './modules/tax-rates/TaxRateManager'
 import { TaxRuleGroupManager } from './modules/tax-rule-groups/TaxRuleGroupManager'
 import { loadTaxRates, getTaxRateCache } from './components/TaxRateSelect'
@@ -31,40 +34,53 @@ const plugin: IAbstractPlugin = {
     name: 'coreshop-taxation',
 
     onInit() {
-        const objectDataRegistry = container.get<DynamicTypeObjectDataRegistry>(
-            serviceIds['DynamicTypes/ObjectDataRegistry']
-        )
+        // Register this bundle's document editables. Runs in the main app and in the reduced
+        // document editor iframe; only depends on the core DocumentEditableRegistry.
+        registerCoreShopDocumentEditableSelects(['coreshop_tax_rate', 'coreshop_tax_rule_group'])
 
-        objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopTaxRate())
-        objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopTaxRuleGroup())
+        try {
+            const objectDataRegistry = container.get<DynamicTypeObjectDataRegistry>(
+                serviceIds['DynamicTypes/ObjectDataRegistry']
+            )
 
-        // Register StudioForm widgets for TaxationChoiceTypes
-        const formWidgetRegistry = container.get<StudioFormWidgetRegistry>(widgetRegistryServiceId)
+            objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopTaxRate())
+            objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopTaxRuleGroup())
 
-        formWidgetRegistry.register('coreshop_tax_rule_choice', (field) => ({
-            component: EntityChoiceWidget,
-            props: { loadOptions: loadTaxRates, getCachedOptions: getTaxRateCache, droppableAccept: 'coreshop:tax_rate', mode: field.multiple ? 'multiple' as const : undefined }
-        }))
+            // Register StudioForm widgets for TaxationChoiceTypes
+            const formWidgetRegistry = container.get<StudioFormWidgetRegistry>(widgetRegistryServiceId)
 
-        formWidgetRegistry.register('coreshop_tax_rule_group_choice', (field) => ({
-            component: EntityChoiceWidget,
-            props: { loadOptions: loadTaxRuleGroups, getCachedOptions: getTaxRuleGroupCache, droppableAccept: 'coreshop:tax_rule_group', mode: field.multiple ? 'multiple' as const : undefined }
-        }))
+            formWidgetRegistry.register('coreshop_tax_rule_choice', (field) => ({
+                component: EntityChoiceWidget,
+                props: { loadOptions: loadTaxRates, getCachedOptions: getTaxRateCache, droppableAccept: 'coreshop:tax_rate', mode: field.multiple ? 'multiple' as const : undefined }
+            }))
+
+            formWidgetRegistry.register('coreshop_tax_rule_group_choice', (field) => ({
+                component: EntityChoiceWidget,
+                props: { loadOptions: loadTaxRuleGroups, getCachedOptions: getTaxRuleGroupCache, droppableAccept: 'coreshop:tax_rule_group', mode: field.multiple ? 'multiple' as const : undefined }
+            }))
+        } catch {
+            // Main Studio app only — object editor / StudioForm services are absent in the
+            // reduced document editor iframe. The document editables are already registered above.
+        }
     },
 
     onStartup({ moduleSystem }) {
         moduleSystem.registerModule(TaxationBundleIconModule)
 
-        const widgets = container.get<WidgetRegistry>(serviceIds.widgetManager)
+        try {
+            const widgets = container.get<WidgetRegistry>(serviceIds.widgetManager)
 
-        widgets.registerWidget({
-            name: 'coreshop-taxation-tax-rates',
-            component: TaxRateManager
-        })
-        widgets.registerWidget({
-            name: 'coreshop-taxation-tax-rule-groups',
-            component: TaxRuleGroupManager
-        })
+            widgets.registerWidget({
+                name: 'coreshop-taxation-tax-rates',
+                component: TaxRateManager
+            })
+            widgets.registerWidget({
+                name: 'coreshop-taxation-tax-rule-groups',
+                component: TaxRuleGroupManager
+            })
+        } catch {
+            // Main Studio app only — widget manager absent in the document editor iframe.
+        }
     }
 }
 

--- a/src/CoreShop/Bundle/TaxationBundle/Resources/config/services/studio.yml
+++ b/src/CoreShop/Bundle/TaxationBundle/Resources/config/services/studio.yml
@@ -2,3 +2,4 @@ services:
   CoreShop\Bundle\TaxationBundle\Studio\WebpackEntryPointProvider:
     tags:
       - { name: pimcore_studio_ui.webpack_entry_point_provider }
+      - { name: pimcore_studio_ui.webpack_entry_point_provider.document_editor_iframe }


### PR DESCRIPTION
## Problem

CoreShop's resource-backed document editables (`coreshop_filter`, `coreshop_index`, `coreshop_country`, `coreshop_currency`, `coreshop_store`, `coreshop_carrier`, …) are not rendered by the new Studio document editor. No dynamic type is registered for them, so the field falls back to a plain text input instead of the resource select.

## Solution

**ResourceBundle**
- New generic `DynamicTypeDocumentEditableCoreShopSelect`. It extends the framework's `DynamicTypeDocumentEditableAbstract` (not the concrete select type, which is not part of the public SDK surface on all Studio versions) and renders an antd `Select` from the editable's `config.store`. `getPopupContainer` keeps the dropdown inside the editable container so it stays visible in the document editor iframe overlay.
- New `registerCoreShopDocumentEditableSelects(types)` helper.

**Feature bundles** (index, address, currency, payment, store, taxation, shipping)
- Each registers its own editable type(s) via the helper in `onInit` and is tagged for the document editor iframe (`pimcore_studio_ui.webpack_entry_point_provider.document_editor_iframe`).
- The main-app-only plugin logic (object editor dynamic types, widgets, StudioForm/rule registries) is guarded so the bundles still load in the reduced iframe app.

**StudioFormBundle**
- Initializes with a low priority and is tagged for the document editor iframe, so its `WidgetRegistry` is bound before the dependent bundles resolve it.

## Notes
- Source-only; built Studio assets are produced by the frontend build CI.
- Follows the approach from Pimcore's "How to Add a Custom Document Editable" guide (same plugin tagged for both the main app and the document editor iframe).