### PR TITLE
[Security] fix pull_request_target workflow injection (pwn request)

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -9,7 +9,7 @@ on:
       - '*.php'
       - 'src/**'
       - '.github/workflows/behat.yml'
-  pull_request_target:
+  pull_request:
     branches: [ '5.0', 'next' ]
     paths:
       - 'composer.json'

--- a/.github/workflows/behat_ui.yml
+++ b/.github/workflows/behat_ui.yml
@@ -9,7 +9,7 @@ on:
       - '*.php'
       - 'src/**'
       - '.github/workflows/behat_ui.yml'
-  pull_request_target:
+  pull_request:
     branches: [ '5.0', 'next' ]
     paths:
       - 'composer.json'

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -6,7 +6,7 @@ on:
       - 'composer.json'
       - '*/**/composer.json'
       - '.github/workflows/license-check.yaml'
-  pull_request_target:
+  pull_request:
     branches: [ '5.0', 'next' ]
     paths:
       - 'composer.json'

--- a/.github/workflows/packages_bundles.yml
+++ b/.github/workflows/packages_bundles.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - 'src/CoreShop/Bundle/**'
       - '.github/workflows/packages_bundles.yml'
-  pull_request_target:
+  pull_request:
     branches: [ '5.0', 'next' ]
     paths:
       - 'src/CoreShop/Bundle/**'

--- a/.github/workflows/packages_components.yml
+++ b/.github/workflows/packages_components.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - 'src/CoreShop/Component/**'
       - '.github/workflows/packages_components.yml'
-  pull_request_target:
+  pull_request:
     branches: [ '5.0', 'next' ]
     paths:
       - 'src/CoreShop/Component/**'

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -11,7 +11,7 @@ on:
       - '*.xml'
       - 'composer.json'
       - '.github/workflows/static.yml'
-  pull_request_target:
+  pull_request:
     branches: [ '5.0', 'next' ]
     paths:
       - 'features/**'


### PR DESCRIPTION
## Security: fix `pull_request_target` pwn-request vulnerability

The CI workflows below trigger on `pull_request_target` **and** check out the PR head from the fork (`ref: …head.sha`, `repository: …head.repo.full_name`). That runs untrusted fork code in the trusted base-repo context — with access to repository secrets (`PIMCORE_PRODUCT_KEY`, `PIMCORE_INSTANCE_IDENTIFIER`, `PIMCORE_SECRET`) and a writable `GITHUB_TOKEN`. This is the classic ["pwn request"](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) pattern; `actions/checkout@v6` now hard-blocks it.

### Fix
Switch these workflows from `pull_request_target` to `pull_request`. Fork PRs then run in the fork's restricted context: no secrets, read-only token. The same code still runs, but there is nothing sensitive to steal and nothing to push — the trust boundary is respected.

**Trade-off:** fork PRs no longer receive the Pimcore secrets. Same-repo branches/PRs and `push` keep them. If `pimcore-install` requires the product key, external fork PRs may fail at install and need a key-less test install path.

`cla-check.yml` intentionally keeps `pull_request_target` — it only reads PR metadata / comments and never checks out fork code, which is the safe use of that trigger.

Affected files (this branch): `behat.yml`, `behat_ui.yml`, `license-check.yaml`, `packages_bundles.yml`, `packages_components.yml`, `static.yml`.

> Part of a set of PRs fixing the same issue across supported branches (5.0 → 5.1 → 2026.x). `4.1` was already fixed. Each branch is fixed independently because the affected file sets differ per branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
