### PR TITLE
[CI] derive Studio build ids from sources, build PRs without committing

### DIFF
--- a/.github/workflows/frontend-build.yaml
+++ b/.github/workflows/frontend-build.yaml
@@ -21,8 +21,10 @@ permissions:
   contents: read
 
 jobs:
+  # Pull requests and manual runs verify only. Gating on `push` rather than on "not a pull
+  # request" keeps a manual run on a feature branch from committing assets to that branch.
   verify:
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name != 'push' }}
     permissions:
       contents: read
     uses: ./.github/workflows/shared-frontend-build.yaml
@@ -30,7 +32,7 @@ jobs:
       commit: false
 
   build:
-    if: ${{ github.event_name != 'pull_request' }}
+    if: ${{ github.event_name == 'push' }}
     permissions:
       contents: write
     uses: ./.github/workflows/shared-frontend-build.yaml

--- a/.github/workflows/frontend-build.yaml
+++ b/.github/workflows/frontend-build.yaml
@@ -1,19 +1,38 @@
 name: CoreShop Studio Frontend Build
 
-# Rebuild trigger: regenerate Studio bundles via PR to satisfy branch ruleset.
 on:
+  # Pull requests only verify that the Studio bundles type-check and build. Nothing is committed,
+  # so the diff of a pull request stays limited to the actual source changes.
   pull_request:
     branches: [ '5.1' ]
+  # The built assets are committed once per push to the release branch. That commit is what the
+  # monorepo split picks up, so consumers keep getting prebuilt assets.
+  #
+  # The commit itself only touches the built assets, so `paths-ignore` keeps it from triggering
+  # another (no-op) build. It deliberately carries no `[skip ci]` marker: that would skip every
+  # workflow for the push, including the monorepo split that has to pick the assets up.
+  push:
+    branches: [ '5.1' ]
+    paths-ignore:
+      - 'src/CoreShop/Bundle/*/Resources/public/studio/**'
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
+  verify:
+    if: ${{ github.event_name == 'pull_request' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/shared-frontend-build.yaml
+    with:
+      commit: false
+
   build:
-    # Only run on same-repo branches. Fork PRs get a read-only token under
-    # `pull_request`, so the auto-commit push would fail anyway.
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name != 'pull_request' }}
     permissions:
       contents: write
     uses: ./.github/workflows/shared-frontend-build.yaml
+    with:
+      commit: true

--- a/.github/workflows/shared-frontend-build.yaml
+++ b/.github/workflows/shared-frontend-build.yaml
@@ -11,12 +11,14 @@ on:
         type: boolean
         default: false
 
-permissions:
-  contents: read
-
+# No workflow-level `permissions`: it would override what the calling job grants, leaving the
+# build job read-only even on the push build. Jobs declare what they need instead.
 jobs:
   check-types:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code

--- a/.github/workflows/shared-frontend-build.yaml
+++ b/.github/workflows/shared-frontend-build.yaml
@@ -2,46 +2,25 @@ name: shared-frontend-build
 
 on:
   workflow_call:
-
-env:
-  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+    inputs:
+      commit:
+        description: >-
+          Commit the built Studio assets back to the branch. Only enabled for pushes to a
+          release branch — pull requests build for verification only, so their diffs stay
+          readable.
+        type: boolean
+        default: false
 
 permissions:
   contents: read
 
 jobs:
-  install:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ env.BRANCH_NAME }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Run esbuild install script
-        run: npm rebuild esbuild
-
   check-types:
-    needs: install
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
-        with:
-          ref: ${{ env.BRANCH_NAME }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v7
@@ -58,19 +37,15 @@ jobs:
       - name: Run type checks
         run: npm run check-types
 
+  # No job-level `permissions` block: the job inherits what the calling workflow grants, so the
+  # write scope needed for the commit only exists on the push build.
   build:
     needs: check-types
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: write
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
-        with:
-          ref: ${{ env.BRANCH_NAME }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v7
@@ -95,9 +70,40 @@ jobs:
       - name: Run production build
         run: npm run build
 
-      - uses: stefanzweifel/git-auto-commit-action@v7
-        with:
-          file_pattern: 'src/CoreShop/Bundle/*/Resources/public/studio/*/**'
-          add_options: '-f'
-          skip_dirty_check: true
-          commit_message: "Build CoreShop Studio bundles [skip ci]"
+      # Build ids are derived from the sources, so an unchanged bundle produces an unchanged
+      # output directory and anything reported here is a real asset change.
+      #
+      # `git add --all` also stages deletions of stale build directories. The previous
+      # `file_pattern` glob missed those: the shell expands it against the working tree, so
+      # directories that no longer exist never reached `git add` and piled up in the repository.
+      - name: Stage built assets
+        id: stage
+        run: |
+          git add --all --force -- 'src/CoreShop/Bundle/*/Resources/public/studio/*'
+          if git diff --cached --quiet; then
+            echo 'changed=false' >> "$GITHUB_OUTPUT"
+            echo 'Studio assets are up to date.' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo 'changed=true' >> "$GITHUB_OUTPUT"
+            {
+              echo '### Studio assets changed by this build'
+              echo
+              echo '```'
+              git diff --cached --stat
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Commit built assets
+        if: ${{ inputs.commit && steps.stage.outputs.changed == 'true' }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git commit -m 'Build CoreShop Studio bundles'
+
+          # If the branch moved on in the meantime, that newer push runs its own build and
+          # supersedes these assets. Report it and stop rather than failing the job.
+          if ! git push origin HEAD:"${GITHUB_REF_NAME}"; then
+            echo "::notice::${GITHUB_REF_NAME} moved on during the build; the newer push rebuilds the assets."
+            echo 'Push skipped: branch moved on during the build.' >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/studio-build.ts
+++ b/studio-build.ts
@@ -7,10 +7,10 @@
  */
 
 import { execSync } from 'child_process'
+import crypto from 'crypto'
 import path from 'path'
 import fs from 'fs'
 import { fileURLToPath } from 'url'
-import { v4 as uuidv4 } from 'uuid'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -19,6 +19,49 @@ interface Plugin {
   name: string
   path: string
   color: string
+}
+
+/**
+ * Root files that influence the output of every bundle build.
+ */
+const rootConfigFiles = [
+  'rsbuild.template.config.ts',
+  'package.json',
+  'package-lock.json',
+  'tsconfig.json',
+  'tsconfig.studio.json',
+  'studio-build.ts'
+]
+
+/**
+ * Build a map of bundle -> the bundles it depends on, resolved from the
+ * `file:` entries in its package.json.
+ */
+function buildBundleDepsMap(plugins: Plugin[]): Map<string, string[]> {
+  const bundleDeps = new Map<string, string[]>()
+
+  for (const plugin of plugins) {
+    const pkgPath = path.resolve(__dirname, plugin.path, 'package.json')
+    try {
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'))
+      const deps = Object.values({ ...pkg.dependencies, ...pkg.devDependencies }) as string[]
+      const fileDeps: string[] = []
+      for (const dep of deps) {
+        if (dep.startsWith('file:')) {
+          // Extract bundle name from file: path like "file:../../ResourceBundle/Resources/assets/pimcore-studio"
+          const depMatch = dep.match(/(\w+Bundle)\/Resources\/assets\/pimcore-studio/)
+          if (depMatch) {
+            fileDeps.push(depMatch[1])
+          }
+        }
+      }
+      bundleDeps.set(plugin.name, fileDeps)
+    } catch {
+      // If package.json can't be read, no deps
+    }
+  }
+
+  return bundleDeps
 }
 
 /**
@@ -47,14 +90,6 @@ function getChangedBundles(plugins: Plugin[]): Plugin[] | null {
   }
 
   // If root build config changed, rebuild everything
-  const rootConfigFiles = [
-    'rsbuild.template.config.ts',
-    'package.json',
-    'package-lock.json',
-    'tsconfig.json',
-    'tsconfig.studio.json',
-    'studio-build.ts'
-  ]
   if (changedFiles.some(f => rootConfigFiles.includes(f))) {
     console.log('Root config changed, building all bundles')
     return null
@@ -74,28 +109,7 @@ function getChangedBundles(plugins: Plugin[]): Plugin[] | null {
   }
 
   // Expand dependency graph: if a dependency changed, dependents must rebuild too
-  // Build a map of bundle -> its file: dependencies from package.json
-  const bundleDeps = new Map<string, string[]>()
-  for (const plugin of plugins) {
-    const pkgPath = path.resolve(__dirname, plugin.path, 'package.json')
-    try {
-      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'))
-      const deps = Object.values({ ...pkg.dependencies, ...pkg.devDependencies }) as string[]
-      const fileDeps: string[] = []
-      for (const dep of deps) {
-        if (dep.startsWith('file:')) {
-          // Extract bundle name from file: path like "file:../../ResourceBundle/Resources/assets/pimcore-studio"
-          const depMatch = dep.match(/(\w+Bundle)\/Resources\/assets\/pimcore-studio/)
-          if (depMatch) {
-            fileDeps.push(depMatch[1])
-          }
-        }
-      }
-      bundleDeps.set(plugin.name, fileDeps)
-    } catch {
-      // If package.json can't be read, no deps
-    }
-  }
+  const bundleDeps = buildBundleDepsMap(plugins)
 
   // Iteratively expand: if any dependency is in changedBundleNames, add the dependent
   let expanded = true
@@ -115,6 +129,96 @@ function getChangedBundles(plugins: Plugin[]): Plugin[] | null {
   }
 
   return plugins.filter(p => changedBundleNames.has(p.name))
+}
+
+/**
+ * Collect the transitive `file:` dependency closure of a bundle, including the bundle itself.
+ */
+function collectDependencyClosure(bundleName: string, bundleDeps: Map<string, string[]>): string[] {
+  const closure = new Set<string>()
+  const queue = [bundleName]
+
+  while (queue.length > 0) {
+    const current = queue.shift()!
+    if (closure.has(current)) {
+      continue
+    }
+    closure.add(current)
+    queue.push(...(bundleDeps.get(current) ?? []))
+  }
+
+  return [...closure].sort()
+}
+
+/**
+ * Recursively collect the source files of a bundle's studio assets, relative to the repo root.
+ */
+function collectSourceFiles(dir: string, files: string[] = []): string[] {
+  const ignored = new Set(['node_modules', 'dist', '.rsbuild', '.turbo'])
+
+  let entries: fs.Dirent[]
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true })
+  } catch {
+    return files
+  }
+
+  for (const entry of entries) {
+    if (ignored.has(entry.name)) {
+      continue
+    }
+
+    const full = path.resolve(dir, entry.name)
+    if (entry.isDirectory()) {
+      collectSourceFiles(full, files)
+    } else if (entry.isFile()) {
+      files.push(full)
+    }
+  }
+
+  return files
+}
+
+/**
+ * Derive a deterministic build id for a bundle from its sources.
+ *
+ * The build id doubles as the output directory name and as the asset prefix, so it has to
+ * change whenever the emitted assets change (cache busting) — but *only* then. Using a random
+ * id per build made every build a full delete/add of all assets in git, which drowned out the
+ * actual changes in pull requests.
+ *
+ * Inputs are the bundle's own sources, the sources of every bundle it depends on (they get
+ * inlined via the aliases in rsbuild.template.config.ts) and the root build configuration.
+ */
+function computeBuildId(plugin: Plugin, plugins: Plugin[], bundleDeps: Map<string, string[]>): string {
+  const hash = crypto.createHash('sha256')
+  const pluginsByName = new Map(plugins.map(p => [p.name, p]))
+
+  for (const file of rootConfigFiles) {
+    const full = path.resolve(__dirname, file)
+    if (fs.existsSync(full)) {
+      hash.update(`${file}\0`)
+      hash.update(fs.readFileSync(full))
+    }
+  }
+
+  for (const bundleName of collectDependencyClosure(plugin.name, bundleDeps)) {
+    const dependency = pluginsByName.get(bundleName)
+    if (!dependency) {
+      continue
+    }
+
+    const root = path.resolve(__dirname, dependency.path)
+    const files = collectSourceFiles(root).sort()
+
+    for (const file of files) {
+      // Hash the path relative to the repo root so the id is independent of the checkout location
+      hash.update(`${path.relative(__dirname, file).split(path.sep).join('/')}\0`)
+      hash.update(fs.readFileSync(file))
+    }
+  }
+
+  return hash.digest('hex').slice(0, 32)
 }
 
 // Color codes for console output
@@ -291,10 +395,11 @@ async function main() {
     log(`Found ${buildPlugins.length} bundles to build concurrently`, colors.cyan);
 
     // Build all plugins in parallel using concurrently for better output management
+    const bundleDeps = buildBundleDepsMap(plugins);
     const commands = buildPlugins.map(plugin => {
       const bundleName = plugin.name.replace(/Bundle$/, '').toLowerCase();
       const bundleDir = plugin.name.replace(/Bundle$/, '');
-      const buildId = uuidv4();
+      const buildId = computeBuildId(plugin, plugins, bundleDeps);
 
       return `CORESHOP_BUNDLE_NAME=${bundleName} CORESHOP_BUNDLE_DIR=${bundleDir} CORESHOP_BUILD_ID=${buildId} rsbuild build --config rsbuild.template.config.ts`;
     });


### PR DESCRIPTION
Follow-up to #3116. Pull requests currently drown in built Studio assets — #3116 itself showed 2757 changed files for a workflow fix.

## Why the diffs were that large

`studio-build.ts` generated a fresh `uuidv4()` as the output directory per bundle per build. For git that makes every build a complete delete/add of all 858 asset files, even for bundles that did not change. The existing `.gitattributes` rules (`linguist-generated`, `binary`, `merge=ours`) collapse the *content* but cannot help against the file *list*.

## Changes

**Deterministic build ids.** The build id is now a SHA-256 over the bundle's own sources, the sources of its transitive `file:` dependencies (they get inlined via the aliases in `rsbuild.template.config.ts`) and the root build configuration. An unchanged bundle keeps its directory, so only bundles that actually changed show up in a diff. Cache busting is preserved — the id still changes whenever an input changes. `WebpackEntryPointProvider` globs `studio/*/entrypoints.json` and does not care about the directory name.

**Build in PRs, commit on push.** `pull_request` now only runs `check-types` + `build` for verification and commits nothing. The assets are committed once per push to `5.1`, which is also what triggers the monorepo split. The commit deliberately carries no `[skip ci]` marker — that would skip the split too — so the push trigger uses `paths-ignore` on the asset paths to avoid a no-op rebuild loop.

Two side effects:
- Fork PRs get build verification again. They were skipped before because the auto-commit could not push with a read-only token.
- `pull_request_target` and `contents: write` are no longer needed on the PR path at all, so the pwn-request surface that #3116 had to defend against is gone rather than merely guarded.

**Stale build directories.** Every bundle currently ships *two* build directories, so `WebpackEntryPointProvider` loads each remote twice. Cause: `file_pattern: 'src/CoreShop/Bundle/*/Resources/public/studio/*/**'` was expanded by the shell against the working tree, so directories that no longer existed never reached `git add` as deletions. Replaced by an explicit `git add --all --force -- 'src/CoreShop/Bundle/*/Resources/public/studio/*'`, which stages deletions. The first push build after this merge cleans the duplicates up.

## Verification

Ran the full `npm run build` repeatedly in a local worktree:

- Build ids are stable across runs — all 22 bundles keep their directory, and each bundle has exactly one.
- Asset content is reproducible for most bundles; 3–6 bundles per run still flap in their entry chunk only. Two causes, both upstream: the license banner embeds the chunk's own content hash, and `@module-federation/rsbuild-plugin` emits `initialConsumes`/`chunkMapping` in unsorted order. That is ~24–48 files per build instead of 858, and it only affects the post-merge build commit, never a PR diff.

## Requires a settings change

Branch `5.1` is covered by the "Version Branches" ruleset (`pull_request` rule, bypass for admins only), so `GITHUB_TOKEN` cannot push the build commit. The GitHub Actions app has to be added as a bypass actor on ruleset 15287918 before this is merged, otherwise the push build commits nothing.

Once this settles on `5.1` it should be applied to `2026.x` via the usual upmerge.