### PR TITLE
[CI] fail the Studio build when the asset commit cannot be pushed

### DIFF
--- a/.github/workflows/shared-frontend-build.yaml
+++ b/.github/workflows/shared-frontend-build.yaml
@@ -103,9 +103,22 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git commit -m 'Build CoreShop Studio bundles'
 
-          # If the branch moved on in the meantime, that newer push runs its own build and
-          # supersedes these assets. Report it and stop rather than failing the job.
-          if ! git push origin HEAD:"${GITHUB_REF_NAME}"; then
+          if git push origin HEAD:"${GITHUB_REF_NAME}"; then
+            exit 0
+          fi
+
+          # A rejected push has two very different causes, and only one of them is benign:
+          # the branch moved on while we were building, in which case the newer push runs its
+          # own build and supersedes these assets. Anything else — a ruleset rejection, a
+          # missing write scope — means the assets never land, and that must not pass as a
+          # green job. HEAD~1 is the commit this build started from.
+          git fetch --quiet origin "${GITHUB_REF_NAME}"
+          if [ "$(git rev-parse "origin/${GITHUB_REF_NAME}")" != "$(git rev-parse HEAD~1)" ]; then
             echo "::notice::${GITHUB_REF_NAME} moved on during the build; the newer push rebuilds the assets."
             echo 'Push skipped: branch moved on during the build.' >> "$GITHUB_STEP_SUMMARY"
+            exit 0
           fi
+
+          echo "::error::Could not push the built Studio assets to ${GITHUB_REF_NAME}. The branch did not move on, so the push was refused — check that the GitHub Actions app is a bypass actor on the branch ruleset."
+          echo 'Push failed: built assets were not committed.' >> "$GITHUB_STEP_SUMMARY"
+          exit 1


### PR DESCRIPTION
Follow-up to #3119, fixing a defect it introduced.

The push build on `5.1` after #3119 merged ([run 30244704315](https://github.com/coreshop/CoreShop/actions/runs/30244704315)) reported success, but the assets were never committed:

```
remote: error: GH013: Repository rule violations found for refs/heads/5.1
remote: - Changes must be made through a pull request.
##[notice]5.1 moved on during the build; the newer push rebuilds the assets.
```

The fallback was meant to tolerate one specific race — the branch moving on while the build runs, where the newer push supersedes the assets anyway. It tolerated *every* push failure instead, so a ruleset rejection passed as a green job.

Now the benign case is detected explicitly by comparing the remote ref against `HEAD~1`, the commit the build started from. If the branch did not move on, the push was refused for another reason and the job fails with a pointer at the likely cause.

Note this does not make the push succeed — the GitHub Actions app still has to be added as a bypass actor on the "Version Branches" ruleset (15287918). Until then this job now correctly fails instead of hiding it.