### PR TITLE
[Docs] fix three broken documentation links

### DIFF
--- a/docs/03_Development/02_Localization/01_Currencies/01_CRUD.md
+++ b/docs/03_Development/02_Localization/01_Currencies/01_CRUD.md
@@ -231,5 +231,5 @@ const plugin: IAbstractPlugin = {
 ### See Also
 
 - [ResourceBundle Documentation](../../14_Studio/02_Base_Infrastructure/01_ResourceBundle.md) - EntityApi and EntityTabbedManager
-- [Exchange Rates](../01_Currencies/02_ExchangeRates.md) - Managing currency exchange rates
+- [Exchange Rates](../../../02_User_Documentation/04_Localization/04_Currencies.md#exchange-rates) - Managing currency exchange rates
 - [Countries](../02_Countries/01_CRUD.md) - Countries can have default currencies

--- a/docs/03_Development/02_Localization/05_Taxes/01_Tax_Rate/01_CRUD.md
+++ b/docs/03_Development/02_Localization/05_Taxes/01_Tax_Rate/01_CRUD.md
@@ -245,5 +245,5 @@ const plugin: IAbstractPlugin = {
 
 ### See Also
 
-- [ResourceBundle Documentation](../../../../14_Studio/02_Base_Infrastructure/01_ResourceBundle.md) - EntityApi and EntityTabbedManager
+- [ResourceBundle Documentation](../../../14_Studio/02_Base_Infrastructure/01_ResourceBundle.md) - EntityApi and EntityTabbedManager
 - [Tax Rule Groups](../02_Tax_Rule/01_CRUD.md) - Managing tax rule groups (combines tax rates)

--- a/docs/03_Development/14_Studio/02_Base_Infrastructure/03_FormBuilder.md
+++ b/docs/03_Development/14_Studio/02_Base_Infrastructure/03_FormBuilder.md
@@ -923,4 +923,4 @@ The FormBuilder pattern provides:
 
 - [ResourceBundle](01_ResourceBundle.md) - Entity APIs and managers
 - [RuleBundle](02_RuleBundle.md) - Rule system infrastructure
-- [Extension System](../04_Extension_System/) - Other extension points
+- [Extension System](../index.md#3-extension-system) - Other extension points


### PR DESCRIPTION
The `Documentation` workflow fails because Docusaurus treats broken links as build errors — seen on the 5.0 → 5.1 upmerge, [run 30246020977](https://github.com/coreshop/CoreShop/actions/runs/30246020977/job/89913162786). The upmerge only surfaced them: all three links are already broken on `5.1` and none of them exist on `5.0`, so this targets `5.1`.

| Page | Was | Now |
|------|-----|-----|
| `02_Localization/01_Currencies/01_CRUD.md` | `../01_Currencies/02_ExchangeRates.md` | `../../../02_User_Documentation/04_Localization/04_Currencies.md#exchange-rates` |
| `02_Localization/05_Taxes/01_Tax_Rate/01_CRUD.md` | `../../../../14_Studio/...` | `../../../14_Studio/...` |
| `14_Studio/02_Base_Infrastructure/03_FormBuilder.md` | `../04_Extension_System/` | `../index.md#3-extension-system` |

Details:

- **Exchange Rates** — no such page exists anywhere in the tree, and this was its only reference. The topic is covered by the "Exchange Rates" section of the user documentation, which the link now points at.
- **ResourceBundle** — the target exists, the link just had one `../` too many. The same link on the currencies page, one directory level up, uses the correct depth.
- **Extension System** — likewise never written as its own page; the 7 extension types are documented in the Studio `index.md` under "3. Extension System".

Verified that all three targets resolve as files and that both heading anchors exist. A sweep over every relative link in `docs/` found no other broken targets.