### PR TITLE
[CI] push the Studio asset commit with a GitHub App token

### DIFF
--- a/.github/workflows/frontend-build.yaml
+++ b/.github/workflows/frontend-build.yaml
@@ -36,5 +36,7 @@ jobs:
     permissions:
       contents: write
     uses: ./.github/workflows/shared-frontend-build.yaml
+    # Needed for STUDIO_BUILD_APP_PRIVATE_KEY: a called workflow gets no secrets by default.
+    secrets: inherit
     with:
       commit: true

--- a/.github/workflows/shared-frontend-build.yaml
+++ b/.github/workflows/shared-frontend-build.yaml
@@ -103,9 +103,22 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git commit -m 'Build CoreShop Studio bundles'
 
-          # If the branch moved on in the meantime, that newer push runs its own build and
-          # supersedes these assets. Report it and stop rather than failing the job.
-          if ! git push origin HEAD:"${GITHUB_REF_NAME}"; then
+          if git push origin HEAD:"${GITHUB_REF_NAME}"; then
+            exit 0
+          fi
+
+          # A rejected push has two very different causes, and only one of them is benign:
+          # the branch moved on while we were building, in which case the newer push runs its
+          # own build and supersedes these assets. Anything else — a ruleset rejection, a
+          # missing write scope — means the assets never land, and that must not pass as a
+          # green job. HEAD~1 is the commit this build started from.
+          git fetch --quiet origin "${GITHUB_REF_NAME}"
+          if [ "$(git rev-parse "origin/${GITHUB_REF_NAME}")" != "$(git rev-parse HEAD~1)" ]; then
             echo "::notice::${GITHUB_REF_NAME} moved on during the build; the newer push rebuilds the assets."
             echo 'Push skipped: branch moved on during the build.' >> "$GITHUB_STEP_SUMMARY"
+            exit 0
           fi
+
+          echo "::error::Could not push the built Studio assets to ${GITHUB_REF_NAME}. The branch did not move on, so the push was refused — check that the GitHub Actions app is a bypass actor on the branch ruleset."
+          echo 'Push failed: built assets were not committed.' >> "$GITHUB_STEP_SUMMARY"
+          exit 1

--- a/.github/workflows/shared-frontend-build.yaml
+++ b/.github/workflows/shared-frontend-build.yaml
@@ -46,8 +46,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # `GITHUB_TOKEN` cannot push to a release branch: the "Version Branches" ruleset requires
+      # a pull request and only bypasses for admins, and GitHub Actions itself is not an app
+      # that can be added to the bypass list. The CoreShop Studio Build app is, so the commit is
+      # made with its installation token instead.
+      - name: Generate a token for the asset commit
+        id: app-token
+        if: ${{ inputs.commit && vars.STUDIO_BUILD_APP_ID != '' }}
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.STUDIO_BUILD_APP_ID }}
+          private-key: ${{ secrets.STUDIO_BUILD_APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          # Falls back to the default token when no app is configured. The push then fails
+          # loudly in the commit step rather than silently skipping the assets.
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v7
@@ -98,9 +114,23 @@ jobs:
 
       - name: Commit built assets
         if: ${{ inputs.commit && steps.stage.outputs.changed == 'true' }}
+        env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
         run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          # Attribute the commit to whichever identity actually pushes it. The numeric id in the
+          # noreply address is what links a commit to the bot account on GitHub.
+          if [ -n "$APP_SLUG" ]; then
+            BOT_ID="$(gh api "/users/${APP_SLUG}%5Bbot%5D" --jq .id 2>/dev/null || true)"
+          fi
+          if [ -n "${BOT_ID:-}" ]; then
+            git config user.name "${APP_SLUG}[bot]"
+            git config user.email "${BOT_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+          else
+            git config user.name 'github-actions[bot]'
+            git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          fi
+
           git commit -m 'Build CoreShop Studio bundles'
 
           if git push origin HEAD:"${GITHUB_REF_NAME}"; then
@@ -119,6 +149,6 @@ jobs:
             exit 0
           fi
 
-          echo "::error::Could not push the built Studio assets to ${GITHUB_REF_NAME}. The branch did not move on, so the push was refused — check that the GitHub Actions app is a bypass actor on the branch ruleset."
+          echo "::error::Could not push the built Studio assets to ${GITHUB_REF_NAME}. The branch did not move on, so the push was refused — check that the STUDIO_BUILD_APP_ID variable and STUDIO_BUILD_APP_PRIVATE_KEY secret are set and that the app is a bypass actor on the branch ruleset."
           echo 'Push failed: built assets were not committed.' >> "$GITHUB_STEP_SUMMARY"
           exit 1

--- a/.github/workflows/shared-frontend-build.yaml
+++ b/.github/workflows/shared-frontend-build.yaml
@@ -50,12 +50,29 @@ jobs:
       # a pull request and only bypasses for admins, and GitHub Actions itself is not an app
       # that can be added to the bypass list. The CoreShop Studio Build app is, so the commit is
       # made with its installation token instead.
+      #
+      # Secrets cannot be read in an `if:` condition, so whether the app is configured is
+      # determined in a step that can see them. Without this the workflow would break the
+      # moment it lands on a branch where the credentials are not set up yet.
+      - name: Check whether the build app is configured
+        id: app-config
+        if: ${{ inputs.commit }}
+        env:
+          APP_ID: ${{ secrets.STUDIO_BUILD_APP_ID }}
+          PRIVATE_KEY: ${{ secrets.STUDIO_BUILD_APP_PRIVATE_KEY }}
+        run: |
+          if [ -n "$APP_ID" ] && [ -n "$PRIVATE_KEY" ]; then
+            echo 'configured=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'configured=false' >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Generate a token for the asset commit
         id: app-token
-        if: ${{ inputs.commit && vars.STUDIO_BUILD_APP_ID != '' }}
+        if: ${{ steps.app-config.outputs.configured == 'true' }}
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ vars.STUDIO_BUILD_APP_ID }}
+          app-id: ${{ secrets.STUDIO_BUILD_APP_ID }}
           private-key: ${{ secrets.STUDIO_BUILD_APP_PRIVATE_KEY }}
 
       - name: Checkout code
@@ -149,6 +166,6 @@ jobs:
             exit 0
           fi
 
-          echo "::error::Could not push the built Studio assets to ${GITHUB_REF_NAME}. The branch did not move on, so the push was refused — check that the STUDIO_BUILD_APP_ID variable and STUDIO_BUILD_APP_PRIVATE_KEY secret are set and that the app is a bypass actor on the branch ruleset."
+          echo "::error::Could not push the built Studio assets to ${GITHUB_REF_NAME}. The branch did not move on, so the push was refused — check that the STUDIO_BUILD_APP_ID and STUDIO_BUILD_APP_PRIVATE_KEY secrets are set and that the app is a bypass actor on the branch ruleset."
           echo 'Push failed: built assets were not committed.' >> "$GITHUB_STEP_SUMMARY"
           exit 1


### PR DESCRIPTION
Stacked on #3121 — it contains that commit until #3121 merges.

## Why

`GITHUB_TOKEN` cannot push the asset commit to a release branch. The "Version Branches" ruleset (15287918) requires a pull request and bypasses only for `Repository admin`. Adding GitHub Actions as a bypass actor is not possible: the bypass list only accepts roles, teams and apps *installed on the organisation*, and `GITHUB_TOKEN` is not one.

The `coreshop-bot` app is installed and has been added to the bypass list, so the commit is made with its installation token.

## Changes

- Mint an installation token via `actions/create-github-app-token`, only on the committing build and only when the app is configured.
- Hand that token to `actions/checkout` so the push uses it.
- Attribute the commit to the app's bot identity, resolving the numeric user id so GitHub links the commit to the bot account.
- Pass `secrets: inherit` from the caller — a called workflow gets no secrets by default.

If the app is not configured the token step is skipped, checkout keeps the default token, and the push fails loudly through the check added in #3121. It does not silently skip the assets.

## Configuration

Already in place:

- App `coreshop-bot` (id 4403933), installed on the organisation
- Bypass actor `Integration id=4403933`, mode `always`, on ruleset 15287918
- Secrets `STUDIO_BUILD_APP_ID` and `STUDIO_BUILD_APP_PRIVATE_KEY`

The app needs exactly one repository permission, **Contents: Read and write** (plus the Metadata read that GitHub adds automatically). `Workflows: write` is deliberately not needed — the commit is restricted to `src/CoreShop/Bundle/*/Resources/public/studio/*`.

## After merging

The next push to `5.1` commits the rebuilt assets, which also clears out the duplicate build directories every bundle currently ships.