### PR TITLE
[Rule] Fix nested conditions/actions lost with JSON configuration column

### DIFF
--- a/features/domain/cart/rules/cart_item/amount_condition.feature
+++ b/features/domain/cart/rules/cart_item/amount_condition.feature
@@ -50,3 +50,14 @@ Feature: Adding a new cart item rule
     And the cart item action has a action discount-percent with 10% discount
     Then the cart rule should be valid for my cart
     And the cart discount should be "0" excluding tax
+
+  Scenario: A cart-item-action keeps its nested condition and action after reloading from the database
+    Given adding a cart price rule named "amount"
+    And the cart rule is active
+    And the cart rule is not a voucher rule
+    And the cart rule has a cart-item-action action
+    And the cart item action has a condition amount with value "90" to "150"
+    And the cart item action has a action discount-percent with 10% discount
+    And the cart price rules are reloaded from the database
+    Then I refresh my cart
+    And the cart item discount should be "-1000" excluding tax

--- a/src/CoreShop/Behat/Context/Setup/CartPriceRuleContext.php
+++ b/src/CoreShop/Behat/Context/Setup/CartPriceRuleContext.php
@@ -552,6 +552,18 @@ final class CartPriceRuleContext implements Context
     }
 
     /**
+     * Detaches all managed entities so the next cart calculation reloads the cart price rules
+     * (and their JSON "configuration") fresh from the database, exercising the serialize/
+     * deserialize round-trip of nested conditions/actions.
+     *
+     * @Given /^the cart price rules are reloaded from the database$/
+     */
+    public function theCartPriceRulesAreReloadedFromTheDatabase(): void
+    {
+        $this->objectManager->clear();
+    }
+
+    /**
      * @Given /^the (cart item action) has a condition amount with value "([^"]+)" to "([^"]+)"$/
      */
     public function theCartItemActionHasAAmountCondition(ActionInterface $action, $minAmount, $maxAmount): void

--- a/src/CoreShop/Bundle/RuleBundle/Form/Type/AbstractConfigurableRuleElementType.php
+++ b/src/CoreShop/Bundle/RuleBundle/Form/Type/AbstractConfigurableRuleElementType.php
@@ -63,7 +63,15 @@ abstract class AbstractConfigurableRuleElementType extends AbstractResourceType
             ->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event): void {
                 $data = $event->getData();
 
-                if (!isset($data['type'])) {
+                // Nested rule elements (stored inside a JSON "configuration") have no entity id.
+                // The admin JS falls back to submitting the whole element as "id" when the loaded
+                // data has no "id" key; drop any non-scalar id so it does not fail integer validation.
+                if (is_array($data) && isset($data['id']) && !is_scalar($data['id'])) {
+                    unset($data['id']);
+                    $event->setData($data);
+                }
+
+                if (!is_array($data) || !isset($data['type'])) {
                     return;
                 }
 

--- a/src/CoreShop/Component/Order/Cart/Rule/Action/CartItemActionProcessor.php
+++ b/src/CoreShop/Component/Order/Cart/Rule/Action/CartItemActionProcessor.php
@@ -27,6 +27,7 @@ use CoreShop\Component\Order\Repository\CartPriceRuleVoucherRepositoryInterface;
 use CoreShop\Component\Registry\ServiceRegistryInterface;
 use CoreShop\Component\Resource\Factory\FactoryInterface;
 use CoreShop\Component\Rule\Condition\RuleConditionsValidationProcessorInterface;
+use CoreShop\Component\Rule\Model\Action;
 use Webmozart\Assert\Assert;
 
 class CartItemActionProcessor implements CartPriceRuleActionProcessorInterface
@@ -77,6 +78,7 @@ class CartItemActionProcessor implements CartPriceRuleActionProcessorInterface
             }
 
             foreach ($configuration['actions'] as $action) {
+                $action = Action::denormalize($action);
                 $actionCommand = $this->actionServiceRegistry->get($action->getType());
 
                 /**
@@ -132,6 +134,7 @@ class CartItemActionProcessor implements CartPriceRuleActionProcessorInterface
             }
 
             foreach ($configuration['actions'] as $action) {
+                $action = Action::denormalize($action);
                 $actionCommand = $this->actionServiceRegistry->get($action->getType());
 
                 /**

--- a/src/CoreShop/Component/Rule/Condition/RuleConditionsValidationProcessor.php
+++ b/src/CoreShop/Component/Rule/Condition/RuleConditionsValidationProcessor.php
@@ -19,6 +19,7 @@ namespace CoreShop\Component\Rule\Condition;
 
 use CoreShop\Component\Registry\ServiceRegistryInterface;
 use CoreShop\Component\Resource\Model\ResourceInterface;
+use CoreShop\Component\Rule\Model\Condition;
 use CoreShop\Component\Rule\Model\ConditionInterface;
 use CoreShop\Component\Rule\Model\RuleInterface;
 
@@ -46,7 +47,7 @@ class RuleConditionsValidationProcessor implements RuleConditionsValidationProce
         }
 
         foreach ($conditions as $condition) {
-            if (!$this->isConditionValid($subject, $rule, $condition, $params)) {
+            if (!$this->isConditionValid($subject, $rule, Condition::denormalize($condition), $params)) {
                 return false;
             }
         }

--- a/src/CoreShop/Component/Rule/Condition/TraceableRuleConditionsValidationProcessor.php
+++ b/src/CoreShop/Component/Rule/Condition/TraceableRuleConditionsValidationProcessor.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace CoreShop\Component\Rule\Condition;
 
 use CoreShop\Component\Resource\Model\ResourceInterface;
+use CoreShop\Component\Rule\Model\Condition;
 use CoreShop\Component\Rule\Model\ConditionInterface;
 use CoreShop\Component\Rule\Model\RuleInterface;
 
@@ -49,6 +50,7 @@ class TraceableRuleConditionsValidationProcessor implements TraceableRuleConditi
         $ruleResult = true;
 
         foreach ($conditions as $condition) {
+            $condition = Condition::denormalize($condition);
             $conditionResult = $this->isConditionValid($subject, $rule, $condition, $params);
 
             if (!$conditionResult) {

--- a/src/CoreShop/Component/Rule/Model/Action.php
+++ b/src/CoreShop/Component/Rule/Model/Action.php
@@ -58,7 +58,7 @@ class Action implements ActionInterface
             return $action;
         }
 
-        $model = new static();
+        $model = new self();
         $model->setType($action['type'] ?? null);
         $model->setConfiguration($action['configuration'] ?? []);
 

--- a/src/CoreShop/Component/Rule/Model/Action.php
+++ b/src/CoreShop/Component/Rule/Model/Action.php
@@ -46,6 +46,29 @@ class Action implements ActionInterface
      */
     protected $configuration;
 
+    /**
+     * Rehydrate an action that was stored inside a JSON "configuration" column (and therefore
+     * comes back as a plain array) into an ActionInterface object. Objects are returned as-is.
+     *
+     * @param ActionInterface|array $action
+     */
+    public static function denormalize($action): ActionInterface
+    {
+        if ($action instanceof ActionInterface) {
+            return $action;
+        }
+
+        $model = new static();
+        $model->setType($action['type'] ?? null);
+        $model->setConfiguration($action['configuration'] ?? []);
+
+        if (isset($action['sort'])) {
+            $model->setSort($action['sort']);
+        }
+
+        return $model;
+    }
+
     public function getId(): ?int
     {
         return $this->id;
@@ -80,8 +103,32 @@ class Action implements ActionInterface
 
     public function setConfiguration(array $configuration)
     {
-        $this->configuration = $configuration;
+        $this->configuration = $this->normalizeConfiguration($configuration);
 
         return $this;
+    }
+
+    /**
+     * Nested conditions/actions (e.g. inside a cartItemAction) are stored inside this JSON
+     * "configuration" column. json_encode() cannot serialize the model objects (they end up as
+     * "{}"), so convert them to plain arrays for storage. They are rehydrated on read via
+     * Condition::denormalize() / self::denormalize().
+     */
+    private function normalizeConfiguration(array $configuration): array
+    {
+        foreach ($configuration as $key => $value) {
+            if ($value instanceof ConditionInterface || $value instanceof ActionInterface) {
+                $configuration[$key] = [
+                    'id' => $value->getId(),
+                    'type' => $value->getType(),
+                    'sort' => $value->getSort(),
+                    'configuration' => $value->getConfiguration(),
+                ];
+            } elseif (is_array($value)) {
+                $configuration[$key] = $this->normalizeConfiguration($value);
+            }
+        }
+
+        return $configuration;
     }
 }

--- a/src/CoreShop/Component/Rule/Model/Condition.php
+++ b/src/CoreShop/Component/Rule/Model/Condition.php
@@ -46,6 +46,29 @@ class Condition implements ConditionInterface
      */
     protected $configuration;
 
+    /**
+     * Rehydrate a condition that was stored inside a JSON "configuration" column (and therefore
+     * comes back as a plain array) into a ConditionInterface object. Objects are returned as-is.
+     *
+     * @param ConditionInterface|array $condition
+     */
+    public static function denormalize($condition): ConditionInterface
+    {
+        if ($condition instanceof ConditionInterface) {
+            return $condition;
+        }
+
+        $model = new static();
+        $model->setType($condition['type'] ?? null);
+        $model->setConfiguration($condition['configuration'] ?? []);
+
+        if (isset($condition['sort'])) {
+            $model->setSort($condition['sort']);
+        }
+
+        return $model;
+    }
+
     public function getId(): ?int
     {
         return $this->id;
@@ -80,8 +103,32 @@ class Condition implements ConditionInterface
 
     public function setConfiguration(array $configuration)
     {
-        $this->configuration = $configuration;
+        $this->configuration = $this->normalizeConfiguration($configuration);
 
         return $this;
+    }
+
+    /**
+     * Nested conditions/actions (e.g. inside a "nested" bracket condition or a cartItemAction) are
+     * stored inside this JSON "configuration" column. json_encode() cannot serialize the model
+     * objects (they end up as "{}"), so convert them to plain arrays for storage. They are
+     * rehydrated on read via self::denormalize() / Action::denormalize().
+     */
+    private function normalizeConfiguration(array $configuration): array
+    {
+        foreach ($configuration as $key => $value) {
+            if ($value instanceof ConditionInterface || $value instanceof ActionInterface) {
+                $configuration[$key] = [
+                    'id' => $value->getId(),
+                    'type' => $value->getType(),
+                    'sort' => $value->getSort(),
+                    'configuration' => $value->getConfiguration(),
+                ];
+            } elseif (is_array($value)) {
+                $configuration[$key] = $this->normalizeConfiguration($value);
+            }
+        }
+
+        return $configuration;
     }
 }

--- a/src/CoreShop/Component/Rule/Model/Condition.php
+++ b/src/CoreShop/Component/Rule/Model/Condition.php
@@ -58,7 +58,7 @@ class Condition implements ConditionInterface
             return $condition;
         }
 
-        $model = new static();
+        $model = new self();
         $model->setType($condition['type'] ?? null);
         $model->setConfiguration($condition['configuration'] ?? []);
 


### PR DESCRIPTION
## Problem

Saving a Cart Price Rule with a `cartItemAction` (or any nested / "bracket" condition) loses the nested conditions/actions — they are persisted as `{}` and the admin then shows `coreshop_condition_undefined` / "No Configuration available". Re-saving an existing one fails with `id: Please enter an integer`.

## Root cause

`Action.orm.xml` / `Condition.orm.xml` `configuration` column was switched from `type="array"` (PHP `serialize`) to `type="json"` for the Pimcore 12 / DBAL 4 migration. The `array` type preserved the nested `ConditionInterface` / `ActionInterface` object graph; `json_encode()` serializes those model objects to `{}` (data lost on save), and `json_decode()` returns plain arrays that the runtime — which type-hints `ConditionInterface` / `ActionInterface` (`RuleConditionsValidationProcessor`, `CartItemActionProcessor`, `NestedConditionChecker`) — can no longer consume.

## Fix

- **Save**: `Condition` / `Action::setConfiguration()` normalizes nested rule-element objects into plain arrays `{id, type, sort, configuration}` before they reach the JSON column.
- **Runtime**: `Condition` / `Action::denormalize()` rehydrates a stored array back into an object; `RuleConditionsValidationProcessor`, `TraceableRuleConditionsValidationProcessor` and `CartItemActionProcessor` use it so evaluation keeps receiving objects.
- **Save robustness**: `AbstractConfigurableRuleElementType` drops a non-scalar submitted `id`. The admin JS (`rules/abstract.js`) falls back to `this.id = data` — i.e. submits the whole element as `id` — when the loaded nested element has no `id` key, which otherwise fails the `id` integer validation. Including `id` in the normalized array (above) also prevents this for freshly saved data.

## Testing

Verified on a Pimcore 12 / CoreShop 5.1 install:

- A `cartItemAction` with nested `amount` + `products` conditions now persists
  `{"conditions":[{"id":null,"type":"amount","sort":1,"configuration":{...}}, {"id":null,"type":"products",...}],"actions":[]}`
  instead of `{"conditions":[{}]}`.
- Reloading + re-saving no longer throws `id: Please enter an integer`.
- Runtime evaluation of the nested conditions returns correct results (min/max amount boundaries respected, rehydration no longer throws a `TypeError`).

## Notes

Targeting `5.0` for upmerge. The `5.1` line already carries a fuller `normalizeConfiguration()` on the models (with `Collection` / `ResourceInterface` handling), so the two model methods will need a trivial merge resolution on upmerge — keep the nested object → array branch from this PR.
