### PR TITLE
[Deps] Cap doctrine/orm < 3.6.8 until doctrine/dbal ^4.5 is released

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
     "doctrine/dbal": "^4.2",
     "doctrine/doctrine-bundle": "^2.4",
     "doctrine/doctrine-fixtures-bundle": "^3.4",
-    "doctrine/orm": "^3.0",
+    "doctrine/orm": "^3.0,<3.6.8",
     "fakerphp/faker": "^1.16",
     "gedmo/doctrine-extensions": "^3.11",
     "jms/serializer-bundle": "^5.5",


### PR DESCRIPTION
## Problem

`coreshop:install` (and any `coreshop:resources:create-tables` run) fails on current dependencies with:

```
In GenerateSchemaEventArgs.php line 41:
  The setSchema() method requires the DBAL Schema::edit() API which is not
  available in the current DBAL version. This feature requires doctrine/dbal
  ^4.5 or higher.
```

This currently breaks the **Behat** / **Behat UI** / **Deps highest** CI jobs on every PR against `5.0`/`5.1`.

## Root cause

- **doctrine/orm 3.6.8** added a guard to `GenerateSchemaEventArgs::setSchema()` that throws unless the DBAL `Schema::edit()` API is available (`doctrine/dbal ^4.5`). `Schema::edit()` currently exists **only in `doctrine/dbal 4.5.x-dev`** — there is no stable 4.5 release yet (latest stable is 4.4.4). orm 3.6.7 and earlier do **not** have this guard.
- Symfony's `doctrine-bridge` `postGenerateSchema` listeners (messenger transport, cache adapter, lock store, remember-me, PDO session) call `$event->setSchema(...)` during `SchemaTool::getSchemaFromMetadata()`.
- CoreShop's `AbstractDatabaseTablesCommand::createDiffSchemaSqls()` (used by `coreshop:resources:create-tables`) calls `getSchemaFromMetadata()`, so the guard is hit as soon as orm 3.6.8 + stable dbal are resolved.

`prefer-stable: true` means DBAL 4.5.x-dev cannot be pulled, so there is no stable dependency set that satisfies orm 3.6.8's requirement today.

## Fix

Cap `doctrine/orm` to `< 3.6.8` until `doctrine/dbal ^4.5` is released as stable. Verified locally (Pimcore 12.3.12 + dbal 4.2.5): with orm 3.6.7, `coreshop:resources:create-tables` completes successfully (exit 0); with orm 3.6.8 it throws the error above.

The cap should be lifted once DBAL 4.5 stable is available (then orm 3.6.8+ works again).
