### PR TITLE
Studio: render a no-configuration note for form-less rule conditions and actions

### DIFF
--- a/src/CoreShop/Bundle/NotificationBundle/Resources/assets/pimcore-studio/src/modules/notification-rules/NotificationRuleManager.tsx
+++ b/src/CoreShop/Bundle/NotificationBundle/Resources/assets/pimcore-studio/src/modules/notification-rules/NotificationRuleManager.tsx
@@ -40,6 +40,8 @@ export const NotificationRuleManager: React.FC = () => {
 
         const conditionMap: Record<string, string> = {}
         const actionMap: Record<string, string> = {}
+        const knownConditionTypes: string[] = []
+        const knownActionTypes: string[] = []
 
         for (const type of cfg.types) {
           for (const [conditionName, blockPrefix] of Object.entries(cfg.conditionSchemaByType?.[type] ?? {})) {
@@ -49,9 +51,19 @@ export const NotificationRuleManager: React.FC = () => {
           for (const [actionName, blockPrefix] of Object.entries(cfg.actionSchemaByType?.[type] ?? {})) {
             actionMap[`${type}.${actionName}`] = blockPrefix
           }
+
+          knownConditionTypes.push(...(cfg.conditions[type] ?? []).map(name => `${type}.${name}`))
+          knownActionTypes.push(...(cfg.actions[type] ?? []).map(name => `${type}.${name}`))
         }
 
-        registerSchemaComponentsFromMaps(conditionRegistry, actionRegistry, conditionMap, actionMap, cfg.schemas)
+        registerSchemaComponentsFromMaps(
+          conditionRegistry,
+          actionRegistry,
+          conditionMap,
+          actionMap,
+          cfg.schemas,
+          { knownConditionTypes, knownActionTypes },
+        )
         setConfig(cfg)
       })
       .catch(err => {

--- a/src/CoreShop/Bundle/OrderBundle/Resources/assets/pimcore-studio/src/modules/cart-price-rules/CartPriceRuleManager.tsx
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/assets/pimcore-studio/src/modules/cart-price-rules/CartPriceRuleManager.tsx
@@ -57,6 +57,10 @@ export const CartPriceRuleManager: React.FC = () => {
           cfg.itemConditionSchemaByType,
           cfg.itemActionSchemaByType,
           cfg.schemas,
+          {
+            knownConditionTypes: cfg.itemConditions,
+            knownActionTypes: cfg.itemActions,
+          },
         )
 
         setConfig(cfg)

--- a/src/CoreShop/Bundle/ProductBundle/Resources/assets/pimcore-studio/src/modules/product-specific-price-rules/components/ProductSpecificPriceRulesPanel.tsx
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/assets/pimcore-studio/src/modules/product-specific-price-rules/components/ProductSpecificPriceRulesPanel.tsx
@@ -86,11 +86,18 @@ export const ProductSpecificPriceRulesPanel: React.FC<Props> = ({
         actionRegistry,
         value.conditionSchemaByType,
         value.actionSchemaByType,
+        undefined,
+        {
+          knownConditionTypes: value.conditions,
+          knownActionTypes: value.actions,
+        },
       )
     } catch (e) {
       console.warn('Product specific price rules registries not available:', e)
     }
   }, [
+    value.conditions,
+    value.actions,
     value.conditionSchemaByType,
     value.actionSchemaByType,
   ])

--- a/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/assets/pimcore-studio/src/modules/quantity-price-rules/components/ProductQuantityPriceRulesPanel.tsx
+++ b/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/assets/pimcore-studio/src/modules/quantity-price-rules/components/ProductQuantityPriceRulesPanel.tsx
@@ -17,7 +17,7 @@ import { container } from '@pimcore/studio-ui-bundle'
 import { useGlobalDataObjectContext } from '@pimcore/studio-ui-bundle/modules/data-object'
 import { ConditionsPanel } from '@coreshop/rule/src/rules/components/ConditionsPanel'
 import { ConditionRegistry } from '@coreshop/rule/src/rules/registry'
-import { createSchemaCondition } from '@coreshop/rule/src/rules/components'
+import { createSchemaCondition, EmptyCondition } from '@coreshop/rule/src/rules/components'
 import type { RuleCondition } from '@coreshop/rule/src/rules/types'
 import { useTranslation } from 'react-i18next'
 import type { QuantityPriceRule, QuantityPriceRulesFieldData, CalculationBehaviour, QuantityRange } from '../types'
@@ -112,7 +112,15 @@ export const ProductQuantityPriceRulesPanel: React.FC<Props> = ({
         conditionRegistry.register(type, createSchemaCondition(blockPrefix))
       }
     }
-  }, [hasConditionRegistry, value.conditionSchemaByType])
+
+    // Known types without a schema mapping have no configuration form at all. They are
+    // still valid, so render a neutral placeholder instead of "Unknown condition type".
+    for (const type of availableConditionTypes) {
+      if (!conditionRegistry.has(type)) {
+        conditionRegistry.register(type, EmptyCondition)
+      }
+    }
+  }, [hasConditionRegistry, value.conditionSchemaByType, availableConditionTypes])
 
   // Get calculation behaviour options
   const calculationBehaviourOptions = (value.stores?.calculationBehaviourTypes ?? DEFAULT_CALCULATION_BEHAVIOURS)

--- a/src/CoreShop/Bundle/RuleBundle/Resources/assets/pimcore-studio/src/rules/components/EmptyAction.tsx
+++ b/src/CoreShop/Bundle/RuleBundle/Resources/assets/pimcore-studio/src/rules/components/EmptyAction.tsx
@@ -12,19 +12,23 @@
 
 import React from 'react'
 import { Alert } from 'antd'
+import { useTranslation } from 'react-i18next'
 import type { ActionComponentProps } from '../types'
 
 /**
  * EmptyAction component for actions that don't require configuration
- * Use this for actions that just need to exist without any settings
+ * Registered automatically for action types that ship without a configuration form type
  */
 export const EmptyAction: React.FC<ActionComponentProps> = () => {
+  const { t } = useTranslation()
+
   return (
     <Alert
-      message="This action has no configuration options."
+      message={t('coreshop_action_no_configuration', { defaultValue: 'This action has no configuration.' })}
       type="info"
       showIcon
       style={{ marginTop: 8 }}
     />
   )
 }
+EmptyAction.displayName = 'EmptyAction'

--- a/src/CoreShop/Bundle/RuleBundle/Resources/assets/pimcore-studio/src/rules/components/EmptyCondition.tsx
+++ b/src/CoreShop/Bundle/RuleBundle/Resources/assets/pimcore-studio/src/rules/components/EmptyCondition.tsx
@@ -12,19 +12,23 @@
 
 import React from 'react'
 import { Alert } from 'antd'
+import { useTranslation } from 'react-i18next'
 import type { ConditionComponentProps } from '../types'
 
 /**
  * EmptyCondition component for conditions that don't require configuration
- * Use this for conditions that just need to exist without any settings
+ * Registered automatically for condition types that ship without a configuration form type
  */
 export const EmptyCondition: React.FC<ConditionComponentProps> = () => {
+  const { t } = useTranslation()
+
   return (
     <Alert
-      message="This condition has no configuration options."
+      message={t('coreshop_condition_no_configuration', { defaultValue: 'This condition has no configuration.' })}
       type="info"
       showIcon
       style={{ marginTop: 8 }}
     />
   )
 }
+EmptyCondition.displayName = 'EmptyCondition'

--- a/src/CoreShop/Bundle/RuleBundle/Resources/assets/pimcore-studio/src/rules/registry/registerSchemaComponents.ts
+++ b/src/CoreShop/Bundle/RuleBundle/Resources/assets/pimcore-studio/src/rules/registry/registerSchemaComponents.ts
@@ -3,12 +3,22 @@
  */
 
 import type { RuleConfig } from '../types'
-import { createSchemaAction, createSchemaCondition } from '../components'
+import { createSchemaAction, createSchemaCondition, EmptyAction, EmptyCondition } from '../components'
 import { ActionRegistry } from './ActionRegistry'
 import { ConditionRegistry } from './ConditionRegistry'
 
 export interface SchemaRegistrationOptions {
   overwriteExisting?: boolean
+  /**
+   * All condition types the backend knows about. Types without a schema mapping are valid,
+   * they just ship without a configuration form and get an EmptyCondition placeholder.
+   */
+  knownConditionTypes?: string[]
+  /**
+   * All action types the backend knows about. Types without a schema mapping are valid,
+   * they just ship without a configuration form and get an EmptyAction placeholder.
+   */
+  knownActionTypes?: string[]
 }
 
 const isSchemaConditionComponent = (component: unknown): boolean => {
@@ -121,6 +131,21 @@ export const registerSchemaComponentsFromMaps = (
       actionRegistry.register(type, createSchemaAction(blockPrefix))
     }
   }
+
+  // Known types without a schema mapping have no configuration form at all
+  // (e.g. the voucherCredit cart price rule action). They are still valid, so render a
+  // neutral placeholder instead of leaving them to the "Unknown type" fallback.
+  for (const type of options.knownConditionTypes ?? []) {
+    if (!conditionRegistry.has(type)) {
+      conditionRegistry.register(type, EmptyCondition)
+    }
+  }
+
+  for (const type of options.knownActionTypes ?? []) {
+    if (!actionRegistry.has(type)) {
+      actionRegistry.register(type, EmptyAction)
+    }
+  }
 }
 
 export const registerSchemaComponentsFromConfig = (
@@ -135,6 +160,10 @@ export const registerSchemaComponentsFromConfig = (
     config.conditionSchemaByType,
     config.actionSchemaByType,
     config.schemas,
-    options,
+    {
+      knownConditionTypes: config.conditions,
+      knownActionTypes: config.actions,
+      ...options,
+    },
   )
 }

--- a/src/CoreShop/Bundle/RuleBundle/Resources/translations/studio.de.yaml
+++ b/src/CoreShop/Bundle/RuleBundle/Resources/translations/studio.de.yaml
@@ -1,7 +1,8 @@
 ---
 coreshop_conditions: 'Bedingungen'
 coreshop_actions: 'Aktionen'
-coreshop_condition_no_configuration: 'Kein Konfiguration verfügbar'
+coreshop_condition_no_configuration: 'Diese Bedingung hat keine Konfiguration.'
+coreshop_action_no_configuration: 'Diese Aktion hat keine Konfiguration.'
 coreshop_condition_conditions_operator_and: 'Und'
 coreshop_condition_conditions_operator_or: 'Oder'
 coreshop_condition_conditions_operator_not: 'Nicht'

--- a/src/CoreShop/Bundle/RuleBundle/Resources/translations/studio.en.yaml
+++ b/src/CoreShop/Bundle/RuleBundle/Resources/translations/studio.en.yaml
@@ -1,7 +1,8 @@
 ---
 coreshop_conditions: 'Conditions'
 coreshop_actions: 'Actions'
-coreshop_condition_no_configuration: 'No Configuration available'
+coreshop_condition_no_configuration: 'This condition has no configuration.'
+coreshop_action_no_configuration: 'This action has no configuration.'
 coreshop_condition_conditions_operator_and: 'And'
 coreshop_condition_conditions_operator_or: 'Or'
 coreshop_condition_conditions_operator_not: 'Not'


### PR DESCRIPTION
Fixes #3137

Rule conditions and actions registered without a configuration form type (e.g. the `voucherCredit` cart price rule action) rendered as "Unknown action type: X" in Studio. They are valid types, they just have no configuration.

### Changes

* `RuleBundle` `registerSchemaComponents.ts`: `SchemaRegistrationOptions` gained `knownConditionTypes` / `knownActionTypes`. Every known type that has no schema mapping and no component registered yet gets the existing `EmptyCondition` / `EmptyAction` placeholder. Existing hand-written and schema components are untouched.
* `registerSchemaComponentsFromConfig()` derives the known type lists from `config.conditions` / `config.actions`, so all of its callers (`ShippingBundle`, `PaymentBundle`, `ProductBundle` product price rules, `OrderBundle` cart price rules) are fixed without further changes.
* Callers using `registerSchemaComponentsFromMaps()` directly now pass the type lists: `OrderBundle` cart-item rules (`itemConditions` / `itemActions`), `ProductBundle` product specific price rules, `NotificationBundle` (composing the `type.name` keys the same way as the schema maps).
* `ProductQuantityPriceRulesBundle` registers its conditions inline, so the same fallback was added there.
* `EmptyCondition` / `EmptyAction` now translate their message via `coreshop_condition_no_configuration` / the new `coreshop_action_no_configuration` instead of hardcoding English. Keys added to `RuleBundle/Resources/translations/studio.en.yaml` and `studio.de.yaml`.

"Unknown type" stays in place for genuinely unknown types, i.e. types stored in a saved rule but absent from the backend config lists.

### Checks

* `npm run check-types` passes across all Studio workspaces.
* `npm run build` passes; the rebuilt Rule, Core, Order, Payment, Shipping, Notification, Product and ProductQuantityPriceRules bundles (the dependency closure of the RuleBundle change) contain the new translation keys.
* No built assets are committed here: per `.gitignore` and `.github/workflows/frontend-build.yaml` they are built by CI and committed only on the push to `5.1`, so this diff stays limited to the source change.
* No PHP was changed, so ecs/phpstan were not run.
