### PR TITLE
Studio: make plugin registry lookups independent of plugin init order

### DIFF
--- a/src/CoreShop/Bundle/IndexBundle/Resources/assets/pimcore-studio/src/main.ts
+++ b/src/CoreShop/Bundle/IndexBundle/Resources/assets/pimcore-studio/src/main.ts
@@ -11,23 +11,14 @@
  */
 
 import { type IAbstractPlugin, container } from '@pimcore/studio-ui-bundle'
-import { serviceIds as pimcoreServiceIds } from '@pimcore/studio-ui-bundle/app'
-import type { WidgetRegistry as PimcoreWidgetRegistry } from '@pimcore/studio-ui-bundle/modules/widget-manager'
-import { DynamicTypeObjectDataRegistry } from '@pimcore/studio-ui-bundle/modules/element'
-import { widgetRegistryServiceId, type WidgetRegistry } from '@coreshop/studio-form'
 // Deep import (bundled, not a shared remote) so the document editable registration also works
 // inside the reduced document editor iframe app.
 import { registerCoreShopDocumentEditableSelects } from '@coreshop/resource/src/dynamic-types/DynamicTypeDocumentEditableCoreShopSelect'
-import { Input } from 'antd'
 import { IndexBundleIconModule } from './modules/icon-library'
-import { DynamicTypeObjectDataCoreShopFilter } from './dynamic-types'
 import { ConditionRegistry, NestedCondition } from './modules/filters/conditions'
 import { serviceIds } from './modules/filters/service-ids'
-import { FilterFieldSelect, FilterFieldsMultiSelect, FilterValueSelect, FilterValueMultiSelect } from './modules/filters/widgets'
-import { FilterManager } from './modules/filters/FilterManager'
-import { IndexManager } from './modules/indexes/IndexManager'
-import { InterpreterWidget } from './modules/indexes/widgets/InterpreterWidget'
-import { InterpreterCollectionWidget } from './modules/indexes/widgets/InterpreterCollectionWidget'
+import { FiltersModule } from './modules/filters/module'
+import { IndexesModule } from './modules/indexes/module'
 
 const plugin: IAbstractPlugin = {
     name: 'coreshop-index',
@@ -37,38 +28,12 @@ const plugin: IAbstractPlugin = {
         // document editor iframe; only depends on the core DocumentEditableRegistry.
         registerCoreShopDocumentEditableSelects(['coreshop_filter', 'coreshop_index'])
 
-        try {
-        // Register Dynamic Types
-        const objectDataRegistry = container.get<DynamicTypeObjectDataRegistry>(
-            pimcoreServiceIds['DynamicTypes/ObjectDataRegistry']
-        )
-        objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopFilter())
-
-        // Register Pimcore widgets
-        const widgetManager = container.get<PimcoreWidgetRegistry>(pimcoreServiceIds.widgetManager)
-
-        widgetManager.registerWidget({
-            name: 'coreshop-index-filter',
-            component: FilterManager
-        })
-
-        widgetManager.registerWidget({
-            name: 'coreshop-index-index',
-            component: IndexManager
-        })
-
-        // Register custom schema widgets for filter conditions
-        const schemaWidgetRegistry = container.get<WidgetRegistry>(widgetRegistryServiceId)
-        schemaWidgetRegistry.register('coreshop_filter_index_field', () => ({ component: FilterFieldSelect }))
-        schemaWidgetRegistry.register('coreshop_filter_index_fields', () => ({ component: FilterFieldsMultiSelect }))
-        schemaWidgetRegistry.register('coreshop_filter_value_select', () => ({ component: FilterValueSelect }))
-        schemaWidgetRegistry.register('coreshop_filter_value_multiselect', () => ({ component: FilterValueMultiSelect }))
-
-        // Create and bind separate registries for pre-conditions and user-conditions
+        // Create and bind separate registries for pre-conditions and user-conditions. These
+        // are this bundle's own services, so binding them here makes them available to every
+        // other plugin from its onStartup onwards.
         container.bind(serviceIds.preConditionRegistry).to(ConditionRegistry).inSingletonScope()
         container.bind(serviceIds.userConditionRegistry).to(ConditionRegistry).inSingletonScope()
 
-        // Get registries
         const preConditionRegistry = container.get<ConditionRegistry>(serviceIds.preConditionRegistry)
         const userConditionRegistry = container.get<ConditionRegistry>(serviceIds.userConditionRegistry)
 
@@ -76,39 +41,15 @@ const plugin: IAbstractPlugin = {
         // Other conditions are registered dynamically from schema config in FilterManager
         preConditionRegistry.register('nested', NestedCondition)
         userConditionRegistry.register('nested', NestedCondition)
-
-        // Register interpreter widget for dynamic schema loading (no prototypes needed)
-        schemaWidgetRegistry.register('coreshop_index_column_interpreter', (field) => ({
-            component: InterpreterWidget,
-            props: { field },
-        }))
-
-        // Register interpreter collection widget (nested interpreter lists)
-        schemaWidgetRegistry.register('interpreter_collection', (field) => ({
-            component: InterpreterCollectionWidget,
-            props: { field },
-        }))
-        } catch {
-            // Everything above targets the main Studio app (object editor, widgets, schema
-            // forms). Those services are absent in the reduced document editor iframe app —
-            // skip them there; the document editables are already registered above.
-        }
     },
 
     onStartup({ moduleSystem }) {
-        try {
-            // Hide IndexBundle-owned rule collection prefixes from generic schema forms
-            const formWidgetRegistry = container.get<WidgetRegistry>(widgetRegistryServiceId)
-            const hiddenWidget = () => ({ component: Input, extra: { hidden: true } })
-            ;[
-              'coreshop_filter_pre_condition_collection',
-              'coreshop_filter_user_condition_collection',
-            ].forEach((prefix) => formWidgetRegistry.register(prefix, hiddenWidget))
-        } catch {
-            // Main Studio app only — StudioForm registry absent in the document editor iframe.
-        }
-
+        // Widget, object data and schema widget registrations live in these modules: modules
+        // are initialised after every plugin's onInit, so the registries other plugins bind
+        // in their own onInit are guaranteed to exist by then.
         moduleSystem.registerModule(IndexBundleIconModule)
+        moduleSystem.registerModule(FiltersModule)
+        moduleSystem.registerModule(IndexesModule)
     }
 }
 

--- a/src/CoreShop/Bundle/IndexBundle/Resources/assets/pimcore-studio/src/modules/filters/module.ts
+++ b/src/CoreShop/Bundle/IndexBundle/Resources/assets/pimcore-studio/src/modules/filters/module.ts
@@ -1,0 +1,62 @@
+/**
+ * CoreShop IndexBundle Studio Plugin — filter registrations.
+ *
+ * Registers the filter manager widget, the coreshop_filter object data type and the schema
+ * widgets the filter condition forms need. Registered as a module (not from the plugin's
+ * onInit) because the StudioForm widget registry is bound by the StudioFormBundle plugin's
+ * own onInit and plugin order is not guaranteed; modules are initialised after every
+ * plugin's onInit.
+ *
+ * This source file is available under the terms of the
+ * CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    CoreShop Commercial License (CCL)
+ */
+
+import { type AbstractModule, container } from '@pimcore/studio-ui-bundle'
+import { serviceIds as pimcoreServiceIds } from '@pimcore/studio-ui-bundle/app'
+import type { WidgetRegistry as PimcoreWidgetRegistry } from '@pimcore/studio-ui-bundle/modules/widget-manager'
+import { DynamicTypeObjectDataRegistry } from '@pimcore/studio-ui-bundle/modules/element'
+import { widgetRegistryServiceId, type WidgetRegistry } from '@coreshop/studio-form'
+import { Input } from 'antd'
+import { DynamicTypeObjectDataCoreShopFilter } from '../../dynamic-types'
+import { FilterFieldSelect, FilterFieldsMultiSelect, FilterValueSelect, FilterValueMultiSelect } from './widgets'
+import { FilterManager } from './FilterManager'
+
+export const FiltersModule: AbstractModule = {
+    onInit(): void {
+        try {
+            const objectDataRegistry = container.get<DynamicTypeObjectDataRegistry>(
+                pimcoreServiceIds['DynamicTypes/ObjectDataRegistry']
+            )
+            objectDataRegistry.registerDynamicType(new DynamicTypeObjectDataCoreShopFilter())
+
+            const widgetManager = container.get<PimcoreWidgetRegistry>(pimcoreServiceIds.widgetManager)
+
+            widgetManager.registerWidget({
+                name: 'coreshop-index-filter',
+                component: FilterManager
+            })
+
+            // Custom schema widgets for filter conditions
+            const schemaWidgetRegistry = container.get<WidgetRegistry>(widgetRegistryServiceId)
+            schemaWidgetRegistry.register('coreshop_filter_index_field', () => ({ component: FilterFieldSelect }))
+            schemaWidgetRegistry.register('coreshop_filter_index_fields', () => ({ component: FilterFieldsMultiSelect }))
+            schemaWidgetRegistry.register('coreshop_filter_value_select', () => ({ component: FilterValueSelect }))
+            schemaWidgetRegistry.register('coreshop_filter_value_multiselect', () => ({ component: FilterValueMultiSelect }))
+
+            // Hide IndexBundle-owned rule collection prefixes from generic schema forms
+            const hiddenWidget = () => ({ component: Input, extra: { hidden: true } })
+            ;[
+                'coreshop_filter_pre_condition_collection',
+                'coreshop_filter_user_condition_collection',
+            ].forEach((prefix) => schemaWidgetRegistry.register(prefix, hiddenWidget))
+        } catch {
+            // Everything above targets the main Studio app (object editor, widgets, schema
+            // forms). Those services are absent in the reduced document editor iframe app.
+        }
+    }
+}

--- a/src/CoreShop/Bundle/IndexBundle/Resources/assets/pimcore-studio/src/modules/indexes/module.ts
+++ b/src/CoreShop/Bundle/IndexBundle/Resources/assets/pimcore-studio/src/modules/indexes/module.ts
@@ -1,0 +1,54 @@
+/**
+ * CoreShop IndexBundle Studio Plugin — index registrations.
+ *
+ * Registers the index manager widget and the interpreter schema widgets. Registered as a
+ * module (not from the plugin's onInit) because the StudioForm widget registry is bound by
+ * the StudioFormBundle plugin's own onInit and plugin order is not guaranteed; modules are
+ * initialised after every plugin's onInit.
+ *
+ * This source file is available under the terms of the
+ * CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    CoreShop Commercial License (CCL)
+ */
+
+import { type AbstractModule, container } from '@pimcore/studio-ui-bundle'
+import { serviceIds as pimcoreServiceIds } from '@pimcore/studio-ui-bundle/app'
+import type { WidgetRegistry as PimcoreWidgetRegistry } from '@pimcore/studio-ui-bundle/modules/widget-manager'
+import { widgetRegistryServiceId, type WidgetRegistry } from '@coreshop/studio-form'
+import { IndexManager } from './IndexManager'
+import { InterpreterWidget } from './widgets/InterpreterWidget'
+import { InterpreterCollectionWidget } from './widgets/InterpreterCollectionWidget'
+
+export const IndexesModule: AbstractModule = {
+    onInit(): void {
+        try {
+            const widgetManager = container.get<PimcoreWidgetRegistry>(pimcoreServiceIds.widgetManager)
+
+            widgetManager.registerWidget({
+                name: 'coreshop-index-index',
+                component: IndexManager
+            })
+
+            const schemaWidgetRegistry = container.get<WidgetRegistry>(widgetRegistryServiceId)
+
+            // Interpreter widget for dynamic schema loading (no prototypes needed)
+            schemaWidgetRegistry.register('coreshop_index_column_interpreter', (field) => ({
+                component: InterpreterWidget,
+                props: { field },
+            }))
+
+            // Interpreter collection widget (nested interpreter lists)
+            schemaWidgetRegistry.register('interpreter_collection', (field) => ({
+                component: InterpreterCollectionWidget,
+                props: { field },
+            }))
+        } catch {
+            // Main Studio app only — widget manager and StudioForm services are absent in
+            // the reduced document editor iframe app.
+        }
+    }
+}

--- a/src/CoreShop/Bundle/PimcoreBundle/Resources/assets/pimcore-studio/src/main.ts
+++ b/src/CoreShop/Bundle/PimcoreBundle/Resources/assets/pimcore-studio/src/main.ts
@@ -25,6 +25,12 @@ import {
 const plugin: IAbstractPlugin = {
     name: 'coreshop-pimcore',
 
+    // Base plugin of the CoreShop Studio stack: it registers the dynamic types the other
+    // CoreShop plugins build on. Plugins are initialised in ascending priority order
+    // (default 0), so this runs before coreshop-resource, coreshop-studio-form-plugin and
+    // every feature bundle.
+    priority: -1200,
+
     onInit() {
         const objectDataRegistry = container.get<DynamicTypeObjectDataRegistry>(
             serviceIds['DynamicTypes/ObjectDataRegistry']

--- a/src/CoreShop/Bundle/ResourceBundle/Resources/assets/pimcore-studio/src/main.ts
+++ b/src/CoreShop/Bundle/ResourceBundle/Resources/assets/pimcore-studio/src/main.ts
@@ -39,6 +39,11 @@ import { ResourceConfigProvider, coreshopResourceServiceIds } from './config'
 const plugin: IAbstractPlugin = {
     name: 'coreshop-resource',
 
+    // This plugin provides the entity extension registries that the feature bundles resolve.
+    // Plugins are initialised in ascending priority order (default 0), so a negative value
+    // guarantees the binds below happen before any consumer's onInit runs.
+    priority: -1100,
+
     onInit() {
         // Register CoreShop Dynamic Types for Data Objects
         const objectDataRegistry = container.get<DynamicTypeObjectDataRegistry>(

--- a/src/CoreShop/Bundle/StudioFormBundle/Resources/assets/pimcore-studio/src/main.ts
+++ b/src/CoreShop/Bundle/StudioFormBundle/Resources/assets/pimcore-studio/src/main.ts
@@ -24,6 +24,7 @@ const plugin: IAbstractPlugin = {
   // Init before the feature bundle plugins (index, address, ...) that resolve the
   // StudioForm WidgetRegistry in their own onInit. Plugins are ordered ascending by
   // priority, so a low value guarantees this plugin binds the registry first.
+  // Provider ladder: coreshop-pimcore (-1200), coreshop-resource (-1100), this (-1000).
   priority: -1000,
 
   onInit() {


### PR DESCRIPTION
Fixes #3141

A user testing the IndexGeoBundle dev instance hit this in the browser console:

```
Uncaught (in promise) Error: No matching bindings found for serviceIdentifier: CoreShop/StudioForm/WidgetRegistry
    at ... Object.onInit (__federation_expose_default_export.2226468a.js)
```

That chunk is the `coreshop-index` plugin remote: IndexBundle resolved the StudioForm widget registry in its plugin `onInit`, while the registry is bound by the StudioFormBundle plugin `onInit`.

## The ordering contract

Verified against `pimcore/studio-ui-bundle` 2025.4.x, `assets/js/src/core/app/plugin-system/plugin-system.ts`:

- `priority?: number` on `IAbstractPlugin` (line 23)
- `getOrderedPlugins()` sorts `(a.priority ?? 0) - (b.priority ?? 0)`, i.e. ascending with default `0`, so negative values run first (lines 97-101)
- `initPlugins()` (line 103) iterates that order, `startupPlugins()` (line 111) iterates it again afterwards
- `assets/js/src/sdk/_internal_/mf-bootstrap.ts` lines 35-37 call `initPlugins()` -> `startupPlugins()` -> `moduleSystem.initModules()`, and `module-system.ts:27` runs each module`s `onInit` from there

So with equal priorities the order is just the remote load order, and anything a module does is guaranteed to see every binding made by any plugin.

## Changes

1. Negative `priority` on the provider plugins so their binds always land before any consumer `onInit`: `coreshop-pimcore` (-1200), `coreshop-resource` (-1100), `coreshop-studio-form-plugin` (-1000, already present, comment extended to document the ladder). Consumers keep the default `0` and need no change.
2. IndexBundle`s widget, object data and schema widget registrations moved out of `onInit` into `FiltersModule` and `IndexesModule`, registered from `onStartup`. Only the bundle`s own container binds stay in `onInit`, where they cannot fail. This also fixes a second-order bug: the `try/catch` that guards the block for the reduced document editor iframe used to swallow the registry failure *and* skip the `preConditionRegistry` / `userConditionRegistry` binds that followed it, breaking the filter UI rather than merely losing widgets.

## Verification

`npm run check-types` clean for IndexBundle, ResourceBundle, PimcoreBundle and StudioFormBundle; local `rsbuild build` succeeds for all four. Build artifacts are deliberately not part of this PR — `.gitignore` excludes `src/CoreShop/Bundle/*/Resources/public/studio/*/` and CI commits them on push to 5.1.

## Follow-up

AddressBundle, CoreBundle, CurrencyBundle, PaymentBundle, StoreBundle and TaxationBundle still resolve the StudioForm registry from their plugin `onInit`. The provider priority makes them safe, but moving them to modules would remove the ordering assumption entirely.