### PR TITLE
Allow react/promise 2.11 so the Pimcore 2026.2 line resolves

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -127,7 +127,7 @@
   },
   "conflict": {
     "ezimuel/ringphp": "<1.4",
-    "react/promise": "<3",
+    "react/promise": "<2.11",
     "symfony/error-handler": "<6.4.14"
   },
   "require-dev": {


### PR DESCRIPTION
Fixes #3146.

The `react/promise: <3` conflict (ccadb487e2, added for the PHP 8.4 implicit-nullable deprecations) is broader than the problem it guards against: react/promise v2.11.0 is the v2 release that fixed those deprecations. Meanwhile `pimcore/opensearch-client` v2026.1.1+ requires `react/promise ^2.11`, so the conflict transitively caps studio-backend/studio-ui at the 2026.1 line for every monolith install, while split-package installs (no conflict section in split packages) already run v2.11 unaffected.

Narrowing the conflict to `<2.11` keeps the deprecation protection and unblocks the whole Pimcore 2026.2 line.