### PR TITLE
Treat PHP deprecations the way Pimcore does and drop the react/promise conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -127,7 +127,6 @@
   },
   "conflict": {
     "ezimuel/ringphp": "<1.4",
-    "react/promise": "<3",
     "symfony/error-handler": "<6.4.14"
   },
   "require-dev": {

--- a/src/CoreShop/Behat/Resources/config/profiles/default.yml
+++ b/src/CoreShop/Behat/Resources/config/profiles/default.yml
@@ -13,6 +13,13 @@ default:
                 class: BehatKernel
                 environment: test
 
+    calls:
+        # Deprecations must never fail a scenario: Behat's runtime call handler turns every
+        # reported error into a failing step, while Pimcore's own test setup (Codeception's
+        # default error_level) reports deprecations without escalating them. 8191 is
+        # E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED.
+        error_reporting: 8191
+
     gherkin:
         filters:
             tags: '@domain&&~@wip'

--- a/src/CoreShop/Behat/Resources/config/profiles/ui.yml
+++ b/src/CoreShop/Behat/Resources/config/profiles/ui.yml
@@ -56,6 +56,13 @@ ui:
 
         Robertfausk\Behat\PantherExtension: ~
 
+    calls:
+        # Deprecations must never fail a scenario: Behat's runtime call handler turns every
+        # reported error into a failing step, while Pimcore's own test setup (Codeception's
+        # default error_level) reports deprecations without escalating them. 8191 is
+        # E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED.
+        error_reporting: 8191
+
     gherkin:
         filters:
             tags: '@ui&&~@ui_precision&&~@ui_pimcore&&~@wip'

--- a/src/CoreShop/Behat/Resources/config/profiles/ui_pimcore.yml
+++ b/src/CoreShop/Behat/Resources/config/profiles/ui_pimcore.yml
@@ -55,6 +55,13 @@ ui_pimcore:
 
         Robertfausk\Behat\PantherExtension: ~
 
+    calls:
+        # Deprecations must never fail a scenario: Behat's runtime call handler turns every
+        # reported error into a failing step, while Pimcore's own test setup (Codeception's
+        # default error_level) reports deprecations without escalating them. 8191 is
+        # E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED.
+        error_reporting: 8191
+
     gherkin:
         filters:
             tags: '@ui_pimcore&&~@wip'

--- a/src/CoreShop/Behat/Resources/config/profiles/ui_precision.yml
+++ b/src/CoreShop/Behat/Resources/config/profiles/ui_precision.yml
@@ -29,6 +29,13 @@ ui_precision:
 
         Robertfausk\Behat\PantherExtension: ~
 
+    calls:
+        # Deprecations must never fail a scenario: Behat's runtime call handler turns every
+        # reported error into a failing step, while Pimcore's own test setup (Codeception's
+        # default error_level) reports deprecations without escalating them. 8191 is
+        # E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED.
+        error_reporting: 8191
+
     gherkin:
         filters:
             tags: '@ui_precision&&~@wip'


### PR DESCRIPTION
Fixes #3146

## What made deprecations fatal

Behat's `Behat\Testwork\Call\Handler\RuntimeCallHandler` installs its own error handler around **every** step and hook call and throws a `CallErrorException` (an `ErrorException`) for any error matching its configured level. That level defaults to whatever `error_reporting()` returns while the Behat container is built, which in CI is `error_reporting=32767` (`E_ALL`) — so `E_DEPRECATED` was included and a single deprecation raised inside a step aborted the scenario. The message format `Deprecated: … in … line …` in #3146 comes straight from `CallErrorException`.

## How Pimcore handles it

Pimcore's CI uses the same `display_errors=On, error_reporting=32767` ini values (`pimcore/workflows-collection-public/.github/workflows/reusable-codeception-public.yaml`), but its test runner does not escalate deprecations: Codeception's `ErrorHandler` defaults to `E_ALL & ~E_DEPRECATED` and `convert_deprecations_to_exceptions` is off, so deprecations are reported as notifications and never become failures. `codeception.dist.yml` does not override that.

## Change

Configure Behat's call error reporting to `E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED` (`8191`, the same mask Symfony's `ErrorHandler` uses for `thrownErrors`) in all four Behat profiles. Every other error level still fails a step exactly as before; deprecations raised outside step scope are still printed.

With that in place the `"react/promise": "<3"` conflict is no longer needed and is removed. It only existed to keep react/promise 2.11 — whose implicitly nullable parameters raise `E_DEPRECATED` on PHP 8.4+ — out of the tree, at the cost of capping `pimcore/opensearch-client` at v2026.1.0.

## Resolved versions after the change

`composer update` on PHP 8.5 now reaches:

| package | before | after |
| --- | --- | --- |
| pimcore/pimcore | v2026.1.x | v2026.2.8 |
| pimcore/opensearch-client | v2026.1.0 | v2026.2.0 |
| pimcore/generic-data-index-bundle | v2026.1.0 | v2026.2.4 |
| pimcore/studio-backend-bundle | v2026.1.4 | v2026.2.5 |
| pimcore/studio-ui-bundle | v2026.1.4 | v2026.2.5 |
| react/promise | (blocked) | v2.11.0 |

## Verification

- `composer update` in a clean worktree on PHP 8.5 resolves the versions above.
- The handler semantics were checked directly against `RuntimeCallHandler(8191)`: `E_DEPRECATED` and `E_USER_DEPRECATED` pass through to PHP without throwing, while e.g. `E_USER_WARNING` still throws `CallErrorException`.
- A full local Behat run was not possible (no MySQL/Pimcore install available on this machine), so the Behat CI on this PR is the real gate.