### PR TITLE
Make TestBundle pages compatible with page-object-extension ^0.3 and ^0.4

### DIFF
--- a/src/CoreShop/Behat/Page/Pimcore/AbstractPimcorePage.php
+++ b/src/CoreShop/Behat/Page/Pimcore/AbstractPimcorePage.php
@@ -24,8 +24,6 @@ use CoreShop\Bundle\TestBundle\Page\SymfonyPage;
 
 abstract class AbstractPimcorePage extends SymfonyPage implements PimcorePageInterface
 {
-    protected static array $additionalParameters = ['_locale' => 'en'];
-
     protected function findOrThrow($selector, $locator): NodeElement
     {
         $element = $this->getDocument()->find($selector, $locator);

--- a/src/CoreShop/Bundle/TestBundle/Page/Frontend/AbstractFrontendPage.php
+++ b/src/CoreShop/Bundle/TestBundle/Page/Frontend/AbstractFrontendPage.php
@@ -21,8 +21,6 @@ use CoreShop\Bundle\TestBundle\Page\SymfonyPage;
 
 abstract class AbstractFrontendPage extends SymfonyPage implements FrontendPageInterface
 {
-    protected static array $additionalParameters = ['_locale' => 'en'];
-
     public function isOpenWithUri(string $uri): bool
     {
         return $this->getSession()->getCurrentUrl() !== $uri;

--- a/src/CoreShop/Bundle/TestBundle/Page/SymfonyPage.php
+++ b/src/CoreShop/Bundle/TestBundle/Page/SymfonyPage.php
@@ -24,6 +24,30 @@ use FriendsOfBehat\PageObjectExtension\Page\UnexpectedPageException;
 
 abstract class SymfonyPage extends BaseSymfonyPage implements SymfonyPageInterface
 {
+    /**
+     * Default parameters added to every generated URL.
+     *
+     * Deliberately a constant instead of an override of the parent's static $additionalParameters
+     * property: that property is untyped in friends-of-behat/page-object-extension ^0.3 and typed
+     * in ^0.4, so a redeclaration here is a compile error against one of the two versions.
+     */
+    protected const array DEFAULT_URL_PARAMETERS = ['_locale' => 'en'];
+
+    protected function getUrl(array $urlParameters = []): string
+    {
+        $url = parent::getUrl(array_merge(static::DEFAULT_URL_PARAMETERS, $urlParameters));
+
+        $replace = [];
+
+        foreach (static::DEFAULT_URL_PARAMETERS as $key => $value) {
+            $replace[sprintf('&%s=%s', $key, $value)] = '';
+            $replace[sprintf('?%s=%s&', $key, $value)] = '?';
+            $replace[sprintf('?%s=%s', $key, $value)] = '';
+        }
+
+        return str_replace(array_keys($replace), array_values($replace), $url);
+    }
+
     protected function getElement(string $name, array $parameters = []): NodeElement
     {
         DriverHelper::waitForPageToLoad($this->getSession());


### PR DESCRIPTION
Fixes #3149

## Problem

`AbstractFrontendPage` and `AbstractPimcorePage` redeclare the parent's static property as `protected static array $additionalParameters = ['_locale' => 'en'];`. That type only matches `friends-of-behat/page-object-extension` **^0.4**; in **^0.3** the parent property is untyped, and PHP refuses the redeclaration:

```
PHP Fatal error:  Type of CoreShop\Bundle\TestBundle\Page\Frontend\AbstractFrontendPage::$additionalParameters
must be omitted to match the parent definition in class FriendsOfBehat\PageObjectExtension\Page\SymfonyPage
```

Core's own CI is green because the root `composer.json` requires `^0.4.0` — but only in `require-dev`, which Composer ignores for dependencies. External bundles get the package through `coreshop/test-setup` (`^0.3.2`), resolve v0.3.2, and every console invocation dies, `assets:install` included.

Fixing this by juggling constraints does not work: 5.1 declares the same property **untyped**, so bumping `coreshop/test-setup` to `^0.4` just moves the fatal onto the 5.1 line, and `^0.3.2 || ^0.4` resolves differently under the highest/lowest dependency matrix.

## Change

Drop both static property overrides and move the default into CoreShop's own `TestBundle\Page\SymfonyPage::getUrl()` — the shared parent of both classes — as a `DEFAULT_URL_PARAMETERS` constant. `getUrl()` prepends the defaults (so explicit parameters and `getAdditionalParameters()` still win) and strips them from the query string exactly as the upstream implementation does for its own defaults, which keeps URLs identical for routes where `_locale` is not a path parameter.

Both v0.3.2 and v0.4.0 implement `getUrl()` as `$urlParameters + static::$additionalParameters`, so explicitly passed parameters take precedence over the parent's static defaults in either version.

## Verification

`php -l`, ECS and PHPStan (level 3, `phpstan.neon`) are clean on the touched files.

Mechanical both-versions check: a scratch project that class-loads the patched pages against each parent version and generates URLs through a real Symfony router — one route with `_locale` in the path (`/{_locale}/shop/`, as the FrontendBundle routes are defined) and one without (`/admin/`, like `pimcore_admin_index`).

| | v0.3.2 (parent untyped) | v0.4.0 (parent typed) |
| --- | --- | --- |
| before this PR | fatal on class load | OK |
| after this PR | OK | OK |

Generated URLs after the change, identical on both versions and identical to what v0.4.0 produced before it:

| case | URL |
| --- | --- |
| frontend, no params | `http://localhost/en/shop/` |
| frontend, explicit `_locale=de` | `http://localhost/de/shop/` |
| frontend, extra param | `http://localhost/en/shop/?foo=bar` |
| admin route without `_locale` path parameter | `http://localhost/admin/` |
