### PR TITLE
[Docs] document OpenSearch index worker (available since 4.1.3)

### DIFF
--- a/docs/03_Development/08_Index_and_Filters/01_Index/index.md
+++ b/docs/03_Development/08_Index_and_Filters/01_Index/index.md
@@ -8,7 +8,36 @@ This index plays a crucial role in enhancing search and filter capabilities with
 CoreShop currently supports the following types of indexes:
 
 - **MySQL**: Utilizes a MySQL database for indexing.
-- ~~Elasticsearch~~: Currently not supported.
+- **OpenSearch** (since 4.1.3): Utilizes an [OpenSearch](https://opensearch.org/) cluster for indexing.
+- ~~Elasticsearch~~: Currently not supported. Use the OpenSearch worker instead.
+
+### OpenSearch
+
+The OpenSearch worker is available since CoreShop 4.1.3 and requires the `pimcore/opensearch-client` package:
+
+```bash
+composer require pimcore/opensearch-client
+```
+
+Configure one or more OpenSearch clients via the `pimcore_open_search_client` configuration:
+
+```yaml
+pimcore_open_search_client:
+    clients:
+        default:
+            hosts: ['https://opensearch:9200']
+            username: 'admin'
+            password: 'somethingsecret'
+```
+
+Every configured client is automatically registered and can be selected when creating an index with the type
+**OpenSearch**. The worker itself provides the following options:
+
+| Option             | Description                                                    |
+|--------------------|----------------------------------------------------------------|
+| Client             | The OpenSearch client to use (from the configuration above).   |
+| Number of Shards   | Number of shards for the created index (default `1`).          |
+| Number of Replicas | Number of replicas for the created index (default `1`).        |
 
 ### Adding Fields to the Index
 


### PR DESCRIPTION
The docs still stated that only MySQL is supported and Elasticsearch is not. Since 4.1.3 the IndexBundle ships an OpenSearch worker (#10248b92f0 "feat: add OpenSearch index worker").

This documents the OpenSearch index type: required `pimcore/opensearch-client` package, client configuration via `pimcore_open_search_client`, and the worker options (client, number of shards/replicas).

Targets `4.1` so it gets upmerged to 5.0/5.1.