### PR TITLE
[IndexBundle] support Elasticsearch alongside OpenSearch

### DIFF
--- a/docs/03_Development/08_Index_and_Filters/01_Index/index.md
+++ b/docs/03_Development/08_Index_and_Filters/01_Index/index.md
@@ -8,7 +8,53 @@ This index plays a crucial role in enhancing search and filter capabilities with
 CoreShop currently supports the following types of indexes:
 
 - **MySQL**: Utilizes a MySQL database for indexing.
-- ~~Elasticsearch~~: Currently not supported.
+- **OpenSearch** (since 4.1.3): Utilizes an [OpenSearch](https://opensearch.org/) cluster for indexing.
+- **Elasticsearch** (since 5.0): Utilizes an [Elasticsearch](https://www.elastic.co/elasticsearch) cluster for indexing, using the same worker as OpenSearch.
+
+### OpenSearch / Elasticsearch
+
+The OpenSearch worker supports both OpenSearch and Elasticsearch clusters. Depending on your engine, install one of
+the Pimcore client packages:
+
+```bash
+# For OpenSearch
+composer require pimcore/opensearch-client
+
+# For Elasticsearch
+composer require pimcore/elasticsearch-client
+```
+
+Configure one or more clients via the corresponding configuration tree:
+
+```yaml
+# OpenSearch
+pimcore_open_search_client:
+    clients:
+        default:
+            hosts: ['https://opensearch:9200']
+            username: 'admin'
+            password: 'somethingsecret'
+
+# Elasticsearch
+pimcore_elasticsearch_client:
+    clients:
+        default:
+            hosts: ['https://elasticsearch:9200']
+            username: 'elastic'
+            password: 'somethingsecret'
+```
+
+Every configured client is automatically registered and can be selected when creating an index with the type
+**OpenSearch**. If both packages are installed and a client name exists in both configurations, the OpenSearch client
+keeps the plain name and the Elasticsearch client is available as `elasticsearch_<name>`.
+
+The worker provides the following options:
+
+| Option             | Description                                                    |
+|--------------------|----------------------------------------------------------------|
+| Client             | The search client to use (from the configuration above).       |
+| Number of Shards   | Number of shards for the created index (default `1`).          |
+| Number of Replicas | Number of replicas for the created index (default `1`).        |
 
 ### Adding Fields to the Index
 

--- a/src/CoreShop/Bundle/IndexBundle/DependencyInjection/Compiler/RegisterOpenSearchClientPass.php
+++ b/src/CoreShop/Bundle/IndexBundle/DependencyInjection/Compiler/RegisterOpenSearchClientPass.php
@@ -23,7 +23,16 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class RegisterOpenSearchClientPass implements CompilerPassInterface
 {
-    private const string CLIENT_SERVICE_PREFIX = 'pimcore.open_search_client.';
+    /**
+     * Wrapper clients implementing Pimcore\SearchClient\SearchClientInterface,
+     * registered by pimcore/opensearch-client and pimcore/elasticsearch-client.
+     * OpenSearch is scanned first so its clients keep their bare identifier on
+     * a name collision (BC with configurations created before Elasticsearch support).
+     */
+    private const array CLIENT_SERVICE_PREFIXES = [
+        'opensearch' => 'pimcore.openSearch.custom_client.',
+        'elasticsearch' => 'pimcore.elasticsearch.custom_client.',
+    ];
 
     /**
      * @inheritDoc
@@ -31,10 +40,21 @@ class RegisterOpenSearchClientPass implements CompilerPassInterface
     public function process(ContainerBuilder $container): void
     {
         $registry = $container->getDefinition('coreshop.registry.index.opensearch_client');
+        $registered = [];
 
-        foreach ($container->getDefinitions() as $id => $definition) {
-            if (\str_starts_with($id, self::CLIENT_SERVICE_PREFIX)) {
-                $identifier = \str_replace(self::CLIENT_SERVICE_PREFIX, '', $id);
+        foreach (self::CLIENT_SERVICE_PREFIXES as $engine => $prefix) {
+            foreach ($container->getDefinitions() as $id => $definition) {
+                if (!\str_starts_with($id, $prefix)) {
+                    continue;
+                }
+
+                $identifier = \substr($id, \strlen($prefix));
+
+                if (isset($registered[$identifier])) {
+                    $identifier = $engine . '_' . $identifier;
+                }
+
+                $registered[$identifier] = true;
                 $registry->addMethodCall('register', [$identifier, new Reference($id)]);
             }
         }

--- a/src/CoreShop/Bundle/IndexBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/IndexBundle/Resources/config/services.yml
@@ -108,12 +108,12 @@ services:
     coreshop.form_registry.index.interpreter:
         class: CoreShop\Bundle\ResourceBundle\Form\Registry\FormTypeRegistry
 
-    # OpenSearch Client Registry
+    # Search Client Registry (OpenSearch and Elasticsearch clients)
     coreshop.registry.index.opensearch_client:
         class: CoreShop\Component\Registry\ServiceRegistry
         arguments:
-            - OpenSearch\Client
-            - opensearch-clients
+            - Pimcore\SearchClient\SearchClientInterface
+            - search-clients
         tags:
             - { name: coreshop.registry, type_hint: opensearchClients }
 

--- a/src/CoreShop/Bundle/IndexBundle/Worker/OpenSearchWorker.php
+++ b/src/CoreShop/Bundle/IndexBundle/Worker/OpenSearchWorker.php
@@ -32,8 +32,7 @@ use CoreShop\Component\Index\Worker\FilterGroupHelperInterface;
 use CoreShop\Component\Index\Worker\OpenSearchWorkerInterface;
 use CoreShop\Component\Index\Worker\WorkerDeleteableByIdInterface;
 use CoreShop\Component\Registry\ServiceRegistryInterface;
-use OpenSearch\Client;
-use OpenSearch\Common\Exceptions\Missing404Exception;
+use Pimcore\SearchClient\SearchClientInterface;
 use Pimcore\Tool;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\String\Slugger\SluggerInterface;
@@ -73,7 +72,7 @@ class OpenSearchWorker extends AbstractWorker implements OpenSearchWorkerInterfa
         $client = $this->getClient($index);
         $indexName = $this->getIndexName($index->getName());
 
-        if ($client->indices()->exists(['index' => $indexName])) {
+        if ($client->existsIndex(['index' => $indexName])) {
             $this->deleteIndexStructures($index);
         }
 
@@ -104,13 +103,10 @@ class OpenSearchWorker extends AbstractWorker implements OpenSearchWorkerInterfa
 
         $this->eventDispatcher->dispatch($event, 'coreshop.index.create_or_update_index_structures');
 
-        $client
-            ->indices()
-            ->create([
-                'index' => $event->getArgument('index'),
-                'body' => $event->getArgument('body'),
-            ])
-        ;
+        $client->createIndex([
+            'index' => $event->getArgument('index'),
+            'body' => $event->getArgument('body'),
+        ]);
     }
 
     /**
@@ -120,38 +116,62 @@ class OpenSearchWorker extends AbstractWorker implements OpenSearchWorkerInterfa
      */
     public function deleteIndexStructures(IndexInterface $index): void
     {
-        try {
-            $this->getClient($index)
-                ->indices()
-                ->delete([
-                    'index' => $this->getIndexName($index->getName()),
-                ])
-            ;
-        } catch (Missing404Exception) {
-            // If the index does not exist, we can ignore the exception
+        $client = $this->getClient($index);
+        $indexName = $this->getIndexName($index->getName());
+
+        if (!$client->existsIndex(['index' => $indexName])) {
+            return;
         }
+
+        $client->deleteIndex([
+            'index' => $indexName,
+        ]);
     }
 
     public function renameIndexStructures(IndexInterface $index, string $oldName, string $newName): void
     {
-        $indices = $this->getClient($index)->indices();
+        $client = $this->getClient($index);
         $oldIndex = $this->getIndexName($oldName);
         $newIndex = $this->getIndexName($newName);
 
         // First, check if the old index exists
-        if (!$indices->exists(['index' => $oldIndex])) {
+        if (!$client->existsIndex(['index' => $oldIndex])) {
             return;
         }
 
-        // Then, clone the whole index with the new name
-        $indices->clone([
-            'index' => $oldIndex,
-            'target' => $newIndex,
+        // Re-create the index under the new name with the settings and mappings of the old
+        // one. The generic search client abstraction has no "clone" operation, so settings
+        // and mappings are copied explicitly and the documents are re-indexed.
+        $mappings = $client->getIndexMapping(['index' => $oldIndex])[$oldIndex]['mappings'] ?? [];
+        $settings = $client->getIndexSettings(['index' => $oldIndex])[$oldIndex]['settings']['index'] ?? [];
+
+        // Remove internal settings which cannot be set on index creation
+        unset(
+            $settings['creation_date'],
+            $settings['provided_name'],
+            $settings['uuid'],
+            $settings['version'],
+        );
+
+        $client->createIndex([
+            'index' => $newIndex,
+            'body' => [
+                'settings' => ['index' => $settings],
+                'mappings' => $mappings,
+            ],
+        ]);
+
+        $client->reIndex([
             'wait_for_completion' => true,
+            'refresh' => true,
+            'body' => [
+                'source' => ['index' => $oldIndex],
+                'dest' => ['index' => $newIndex],
+            ],
         ]);
 
         // Finally, delete the old index
-        $indices->delete([
+        $client->deleteIndex([
             'index' => $oldIndex,
         ]);
     }
@@ -201,15 +221,11 @@ class OpenSearchWorker extends AbstractWorker implements OpenSearchWorkerInterfa
 
         // Delete the document from the index if it is not indexable
         if (!$object->getIndexable($index)) {
-            try {
-                $client
-                    ->delete([
-                        'index' => $indexName,
-                        'id' => $objectId,
-                    ])
-                ;
-            } catch (Missing404Exception) {
-                // If the document does not exist, we can ignore the exception
+            if ($client->exists(['index' => $indexName, 'id' => $objectId])) {
+                $client->delete([
+                    'index' => $indexName,
+                    'id' => $objectId,
+                ]);
             }
 
             return;
@@ -253,7 +269,7 @@ class OpenSearchWorker extends AbstractWorker implements OpenSearchWorkerInterfa
         );
     }
 
-    public function getClient(IndexInterface $index): Client
+    public function getClient(IndexInterface $index): SearchClientInterface
     {
         $config = $index->getConfiguration();
 
@@ -263,10 +279,10 @@ class OpenSearchWorker extends AbstractWorker implements OpenSearchWorkerInterfa
 
         $client = $this->clientRegistry->get($config['client']);
 
-        if (!$client instanceof Client) {
+        if (!$client instanceof SearchClientInterface) {
             throw new \RuntimeException(
                 \sprintf(
-                    'OpenSearch client "%s" could not be found. Available clients: "%s"',
+                    'Search client "%s" could not be found. Available clients: "%s"',
                     $config['client'],
                     \implode(', ', \array_keys($this->clientRegistry->all())),
                 ),

--- a/src/CoreShop/Bundle/IndexBundle/Worker/OpenSearchWorker/Listing.php
+++ b/src/CoreShop/Bundle/IndexBundle/Worker/OpenSearchWorker/Listing.php
@@ -325,7 +325,7 @@ class Listing extends AbstractListing
             $aggregations[$columnName] = [
                 'terms' => [
                     'field' => $columnName,
-                    'order' => ['_term' => 'asc'],
+                    'order' => ['_key' => 'asc'],
                 ],
             ];
         }


### PR DESCRIPTION
## What

The OpenSearch index worker now works with both **OpenSearch** and **Elasticsearch** clusters. The worker codes against `Pimcore\SearchClient\SearchClientInterface` (shipped with pimcore/pimcore ^12) instead of the concrete `OpenSearch\Client`. Both `pimcore/opensearch-client` and `pimcore/elasticsearch-client` register wrapper services implementing that interface, so every configured client of either bundle shows up in the worker's client dropdown.

## Changes

- `RegisterOpenSearchClientPass` scans both wrapper prefixes (`pimcore.openSearch.custom_client.*`, `pimcore.elasticsearch.custom_client.*`). On a client-name collision the Elasticsearch client is registered as `elasticsearch_<name>` — OpenSearch keeps the bare name, so existing index configurations keep working.
- Client registry now types against `SearchClientInterface`.
- `renameIndexStructures` no longer uses the client-specific `indices()->clone()` API (not part of the abstraction): it copies settings/mappings to the new index, runs `_reindex` and deletes the old index.
- 404 handling switched from OpenSearch's `Missing404Exception` to portable `exists`/`existsIndex` guards (the ES wrapper maps 404s to `false`/`[]`, the OpenSearch wrapper throws wrapped `ClientException`s — guards work for both).
- Fixed terms aggregation sort: `_term` was removed in ES 7 / never valid in OpenSearch 2 — now `_key`.
- Docs updated (`docs/03_Development/08_Index_and_Filters/01_Index/index.md`), builds on top of the OpenSearch docs from #3155.

## BC notes

- Existing OpenSearch index configurations (`client: <name>`) keep working unchanged; the index name prefix (`coreshop_index_os_*`) is untouched.
- Anyone fetching clients directly from `coreshop.registry.index.opensearch_client` now gets the Pimcore wrapper (`SearchClientInterface`) instead of the raw `OpenSearch\Client`; the raw client is reachable via `getOriginalClient()`.