### PR TITLE
[TestBundle] fix standalone PHPStan: add studio packages to require-dev

### DIFF
--- a/src/CoreShop/Bundle/TestBundle/InstallProfile/CoreShopTestInstallProfile.php
+++ b/src/CoreShop/Bundle/TestBundle/InstallProfile/CoreShopTestInstallProfile.php
@@ -227,10 +227,9 @@ final readonly class CoreShopTestInstallProfile implements InstallProfileInterfa
 
     private function readValue(string $name): ?string
     {
-        /** @var string|false|null $value */
         $value = $_ENV[$name] ?? $_SERVER[$name] ?? getenv($name);
 
-        if ($value === false || $value === null || trim($value) === '') {
+        if (!\is_string($value) || trim($value) === '') {
             return null;
         }
 

--- a/src/CoreShop/Bundle/TestBundle/composer.json
+++ b/src/CoreShop/Bundle/TestBundle/composer.json
@@ -43,7 +43,10 @@
     "require-dev": {
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",
-        "phpstan/phpstan-webmozart-assert": "^2.0"
+        "phpstan/phpstan-webmozart-assert": "^2.0",
+        "pimcore/generic-data-index-bundle": "^2026.1",
+        "pimcore/studio-backend-bundle": "^2026.1",
+        "pimcore/studio-ui-bundle": "^2026.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The "Packages Bundles" check for TestBundle has been failing on `2026.x` (pre-existing, e.g. on the 2026-08-15 push run — not related to the upmerge PRs):

```
Class Pimcore\Bundle\GenericDataIndexBundle\PimcoreGenericDataIndexBundle not found (CoreShopTestInstallProfile.php:97)
```

`CoreShopTestInstallProfile` references the studio bundle classes directly, but TestBundle's standalone composer.json didn't install them, so PHPStan can't discover the symbols.

This adds `pimcore/generic-data-index-bundle`, `pimcore/studio-backend-bundle` and `pimcore/studio-ui-bundle` (^2026.1, matching the root composer.json) to `require-dev`. `PimcoreGenericExecutionEngineBundle` needs nothing — it ships inside `pimcore/pimcore`.