### PR TITLE
Make locale column length configurable

### DIFF
--- a/CHANGELOG-2026.1.x.md
+++ b/CHANGELOG-2026.1.x.md
@@ -91,3 +91,55 @@ Additional effects:
 Developer docs covering `rule-engine`, `payment-provider`, `menu-bundle`, `form-extension`, and
 `order-detail` extension have been rewritten to use Studio patterns (StudioFormBundle schema,
 TabExtension / ActionExtension slots). ExtJS code samples were removed.
+
+### Configurable translation `locale` column length
+
+`ORMTranslatableListener` hardcoded the Doctrine ORM mapping for every `*_translation` entity's
+`locale` column to `length: 5`. This is too short for any locale identifier beyond a plain
+`language_REGION` code.
+
+A [BCP 47 / RFC 5646](https://www.rfc-editor.org/rfc/rfc5646.html) language tag (Pimcore/ICU locale
+strings use `_` instead of `-`, but the subtag rules are the same) is built as:
+
+```
+language ["-" script] ["-" region] *("-" variant)
+```
+
+- `language`: 2–3 letters (rarely up to 8 for registered/reserved tags)
+- `script`: **exactly 4 letters** (ISO 15924), e.g. `Hans`, `Hant`, `Cyrl`, `Latn`
+- `region`: 2 letters (ISO 3166-1) or 3 digits (UN M49)
+- `variant`: 5–8 alphanumeric chars, or 1 digit + 3 alphanumeric chars, and — per the `*("-" variant)`
+  grammar in [RFC 5646 §2.2.5](https://www.rfc-editor.org/rfc/rfc5646.html#section-2.2.5) — a tag can
+  carry **any number of them**. There is no fixed maximum tag length; `5` (or any other single value)
+  is only ever a practical choice for the locales a given project actually uses, never a technically
+  correct upper bound.
+
+Real-world examples already longer than 5 characters:
+
+- `zh_Hans` / `zh_Hant` — 7 chars (script only, no region)
+- `zh_Hant_HK`, `zh_Hant_TW`, `zh_Hans_SG` — 10 chars (script + region)
+- `sr_Cyrl_RS` / `sr_Latn_RS` — 10 chars (Serbian, Cyrillic vs. Latin, Serbia)
+- `uz_Cyrl_UZ` / `uz_Latn_UZ` — 10 chars (Uzbek)
+- `pa_Arab_PK` / `pa_Guru_IN` — 10 chars (Punjabi, Shahmukhi vs. Gurmukhi script)
+- `de_DE_1901` — 10 chars (German, traditional 1901 orthography *variant*, not a script)
+
+All of these are real ICU/CLDR locale IDs — the same data source Symfony's
+[Intl component](https://symfony.com/doc/current/components/intl.html) (and by extension Pimcore's
+locale list) draws from, and the identifier grammar itself comes from
+[Unicode UTS #35](https://www.unicode.org/reports/tr35/#Identifiers). `zh_Hans` / `zh_Hant` are only
+the example that was hit in practice — MySQL silently truncated them to `zh_Ha`, which then collided
+with the `(translatable_id, locale)` unique constraint and caused a duplicate-key error on insert.
+
+The column length is now configurable:
+
+```yaml
+core_shop_resource:
+    translation:
+        locale_column_length: 8
+```
+
+**The default stays `5`** — this is opt-in. If you raise it, you are responsible for a migration:
+changing this value only updates Doctrine's *mapping metadata* for newly created schemas. It does
+**not** alter any already-created database column. You must ship your own
+`ALTER TABLE ... MODIFY locale VARCHAR(<n>)` migration for every existing `*_translation` table, or
+inserts will keep failing/truncating against the old column width.

--- a/config/packages/test/config.yaml
+++ b/config/packages/test/config.yaml
@@ -35,3 +35,7 @@ monolog:
             level: error
         console:
             channels: ['!event', '!doctrine', '!console', '!cache']
+
+core_shop_resource:
+    translation:
+        locale_column_length: 8

--- a/features/domain/pimcore/translation_locale_column_length.feature
+++ b/features/domain/pimcore/translation_locale_column_length.feature
@@ -1,0 +1,9 @@
+@domain @pimcore
+Feature: Configurable translation locale column length
+  In order to support locales with a script subtag (e.g. "zh_Hans")
+  As a site administrator
+  I need the ORM mapping for every translation entity's "locale" column to
+  use the length configured via "core_shop_resource.translation.locale_column_length"
+
+  Scenario: The configured locale column length is applied to a translation entity
+    Then the "country" translation entity should map its locale column with a length of 8

--- a/src/CoreShop/Behat/Context/Domain/ResourceContext.php
+++ b/src/CoreShop/Behat/Context/Domain/ResourceContext.php
@@ -19,12 +19,14 @@ namespace CoreShop\Behat\Context\Domain;
 
 use Behat\Behat\Context\Context;
 use CoreShop\Component\Resource\Metadata\Registry;
+use Doctrine\ORM\EntityManagerInterface;
 use Webmozart\Assert\Assert;
 
 final class ResourceContext implements Context
 {
     public function __construct(
         private Registry $metadataRegistry,
+        private EntityManagerInterface $entityManager,
     ) {
     }
 
@@ -36,5 +38,30 @@ final class ResourceContext implements Context
         $car = $this->metadataRegistry->get('app.car');
 
         Assert::eq($car->getClass('model'), 'Pimcore\Model\DataObject\Car');
+    }
+
+    /**
+     * @Then /^the "([^"]+)" translation entity should map its locale column with a length of (\d+)$/
+     */
+    public function theTranslationEntityShouldMapItsLocaleColumnWithALengthOf(
+        string $resourceAlias,
+        int $expectedLength,
+    ): void {
+        $translationMetadata = $this->metadataRegistry->get('coreshop.' . $resourceAlias . '_translation');
+        $translationClass = $translationMetadata->getClass('model');
+
+        $classMetadata = $this->entityManager->getClassMetadata($translationClass);
+        $actualLength = $classMetadata->getFieldMapping('locale')['length'];
+
+        Assert::eq(
+            $actualLength,
+            $expectedLength,
+            sprintf(
+                'Expected the "locale" column of "%s" to be mapped with a length of %d, got %d instead.',
+                $translationClass,
+                $expectedLength,
+                $actualLength,
+            ),
+        );
     }
 }

--- a/src/CoreShop/Behat/Resources/config/services/contexts/domain.yml
+++ b/src/CoreShop/Behat/Resources/config/services/contexts/domain.yml
@@ -250,5 +250,6 @@ services:
         class: CoreShop\Behat\Context\Domain\ResourceContext
         arguments:
             - '@CoreShop\Component\Resource\Metadata\RegistryInterface'
+            - '@Doctrine\ORM\EntityManagerInterface'
         tags:
             - { name: fob.context_service }

--- a/src/CoreShop/Behat/Resources/config/services/contexts/domain.yml
+++ b/src/CoreShop/Behat/Resources/config/services/contexts/domain.yml
@@ -250,6 +250,6 @@ services:
         class: CoreShop\Behat\Context\Domain\ResourceContext
         arguments:
             - '@CoreShop\Component\Resource\Metadata\RegistryInterface'
-            - '@Doctrine\ORM\EntityManagerInterface'
+            - '@doctrine.orm.entity_manager'
         tags:
             - { name: fob.context_service }

--- a/src/CoreShop/Bundle/ResourceBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/ResourceBundle/DependencyInjection/Configuration.php
@@ -143,6 +143,22 @@ final class Configuration implements ConfigurationInterface
                     ->canBeDisabled()
                     ->children()
                         ->scalarNode('locale_provider')->defaultValue(TranslationLocaleProviderInterface::class)->cannotBeEmpty()->end()
+                        ->integerNode('locale_column_length')
+                            ->min(1)
+                            ->defaultValue(5)
+                            ->info(
+                                'Length of the `locale` column mapped onto every `*_translation` database table. ' .
+                                'The default of 5 fits plain language/region codes like "de_AT" but is too short ' .
+                                'for locales with a script subtag, e.g. "zh_Hans" / "zh_Hant" (7 chars) ' .
+                                '- MySQL silently truncates them, which then collides with the unique ' .
+                                '(translatable_id, locale) constraint. IMPORTANT: changing this value only updates ' .
+                                'Doctrine\'s mapping metadata for newly created schemas - it does NOT alter any ' .
+                                'already-created database column. You must ship your own migration that runs ' .
+                                '`ALTER TABLE ... MODIFY locale VARCHAR(<n>)` on every existing `*_translation` ' .
+                                'table, or inserts will keep failing/truncating against the old column width.',
+                            )
+                        ->end()
+                    ->end()
                 ->end()
             ->end()
         ;

--- a/src/CoreShop/Bundle/ResourceBundle/DependencyInjection/CoreShopResourceExtension.php
+++ b/src/CoreShop/Bundle/ResourceBundle/DependencyInjection/CoreShopResourceExtension.php
@@ -72,6 +72,7 @@ final class CoreShopResourceExtension extends AbstractModelExtension implements 
         $container->setParameter('coreshop.resources', []);
         $container->setParameter('coreshop.resource.mapping', $configs['mapping']);
         $container->setParameter('coreshop.orm_cascade_merge', $configs['orm_cascade_merge_associations']);
+        $container->setParameter('coreshop.translation.locale_column_length', $configs['translation']['locale_column_length']);
 
         $this->autoRegisterPimcoreModels($configs, $container);
 

--- a/src/CoreShop/Bundle/ResourceBundle/EventListener/ORMTranslatableListener.php
+++ b/src/CoreShop/Bundle/ResourceBundle/EventListener/ORMTranslatableListener.php
@@ -33,6 +33,7 @@ final class ORMTranslatableListener implements EventSubscriber
     public function __construct(
         private RegistryInterface $resourceMetadataRegistry,
         private TranslatableEntityLocaleAssignerInterface $translatableEntityLocaleAssigner,
+        private int $translationLocaleColumnLength = 5,
     ) {
     }
 
@@ -134,11 +135,13 @@ final class ORMTranslatableListener implements EventSubscriber
         }
 
         if (!$metadata->hasField('locale')) {
+            // Length is configurable (core_shop_resource.translation.locale_column_length) - changing it only
+            // affects newly created schemas, see the option's `info()` in Configuration::addTranslationsSection().
             $metadata->mapField([
                 'fieldName' => 'locale',
                 'type' => 'string',
                 'nullable' => false,
-                'length' => 5,
+                'length' => $this->translationLocaleColumnLength,
             ]);
         }
 

--- a/src/CoreShop/Bundle/ResourceBundle/Resources/config/services/integrations/translation.yml
+++ b/src/CoreShop/Bundle/ResourceBundle/Resources/config/services/integrations/translation.yml
@@ -9,6 +9,7 @@ services:
         arguments:
             - '@CoreShop\Component\Resource\Metadata\RegistryInterface'
             - '@CoreShop\Component\Resource\Translation\TranslatableEntityLocaleAssignerInterface'
+            - '%coreshop.translation.locale_column_length%'
         tags:
             - { name: doctrine.event_listener, connection: default, event: loadClassMetadata, priority: 99 }
             - { name: doctrine.event_listener, connection: default, event: postLoad, priority: 99 }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

### Configurable translation `locale` column length

`ORMTranslatableListener` hardcoded the Doctrine ORM mapping for every `*_translation` entity's `locale` column to `length: 5`. This is too short for any locale identifier beyond a plain `language_REGION` code.

A [BCP 47 / RFC 5646](https://www.rfc-editor.org/rfc/rfc5646.html) language tag (Pimcore/ICU locale strings use `_` instead of `-`, but the subtag rules are the same) is built as:

```
language ["-" script] ["-" region] *("-" variant)
```

- `language`: 2–3 letters (rarely up to 8 for registered/reserved tags)
- `script`: **exactly 4 letters** (ISO 15924), e.g. `Hans`, `Hant`, `Cyrl`, `Latn`
- `region`: 2 letters (ISO 3166-1) or 3 digits (UN M49)
- `variant`: 5–8 alphanumeric chars, or 1 digit + 3 alphanumeric chars, and — per the `*("-" variant)`
  grammar in [RFC 5646 §2.2.5](https://www.rfc-editor.org/rfc/rfc5646.html#section-2.2.5) — a tag can
  carry **any number of them**. There is no fixed maximum tag length; `5` (or any other single value)
  is only ever a practical choice for the locales a given project actually uses, never a technically
  correct upper bound.

Real-world examples already longer than 5 characters:

- `zh_Hans` / `zh_Hant` — 7 chars (script only, no region)
- `zh_Hant_HK`, `zh_Hant_TW`, `zh_Hans_SG` — 10 chars (script + region)
- `sr_Cyrl_RS` / `sr_Latn_RS` — 10 chars (Serbian, Cyrillic vs. Latin, Serbia)
- `uz_Cyrl_UZ` / `uz_Latn_UZ` — 10 chars (Uzbek)
- `pa_Arab_PK` / `pa_Guru_IN` — 10 chars (Punjabi, Shahmukhi vs. Gurmukhi script)
- `de_DE_1901` — 10 chars (German, traditional 1901 orthography *variant*, not a script)

All of these are real ICU/CLDR locale IDs — the same data source Symfony's [Intl component](https://symfony.com/doc/current/components/intl.html) (and by extension Pimcore's locale list) draws from, and the identifier grammar itself comes from [Unicode UTS #35](https://www.unicode.org/reports/tr35/#Identifiers). `zh_Hans` / `zh_Hant` are only the example that was hit in practice — MySQL silently truncated them to `zh_Ha`, which then collided with the `(translatable_id, locale)` unique constraint and caused a duplicate-key error on insert.

The column length is now configurable:

```yaml
core_shop_resource:
    translation:
        locale_column_length: 8
```

**The default stays `5`** — this is opt-in. If you raise it, you are responsible for a migration: changing this value only updates Doctrine's *mapping metadata* for newly created schemas. It does **not** alter any already-created database column. You must ship your own `ALTER TABLE ... MODIFY locale VARCHAR(<n>)` migration for every existing `*_translation` table, or inserts will keep failing/truncating against the old column width.
