### PR TITLE
[CI] Use pull_request_target so fork PRs get the CI secrets

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -9,7 +9,7 @@ on:
       - '*.php'
       - 'src/**'
       - '.github/workflows/behat.yml'
-  pull_request:
+  pull_request_target:
     branches: [ '2026.x' ]
     paths:
       - 'composer.json'

--- a/.github/workflows/behat_ui.yml
+++ b/.github/workflows/behat_ui.yml
@@ -9,7 +9,7 @@ on:
       - '*.php'
       - 'src/**'
       - '.github/workflows/behat_ui.yml'
-  pull_request:
+  pull_request_target:
     branches: [ '2026.x' ]
     paths:
       - 'composer.json'

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -11,7 +11,7 @@ on:
       - '*.xml'
       - 'composer.json'
       - '.github/workflows/static.yml'
-  pull_request:
+  pull_request_target:
     branches: [ '2026.x' ]
     paths:
       - 'features/**'


### PR DESCRIPTION
Fork PRs (e.g. #3160) currently fail in CI because `pull_request` runs from forks don't get repository secrets — `PIMCORE_SECRET` ends up empty and `bin/console cache:clear` aborts with "`pimcore.encryption.secret` is not set".

This switches the PR trigger in `behat.yml`, `behat_ui.yml` and `static.yml` to `pull_request_target` (same approach as pimcore/pimcore):

- The workflow definition is always taken from the base branch, so a fork PR cannot modify it to reference additional secrets — only `PIMCORE_SECRET`, `PIMCORE_INSTANCE_IDENTIFIER` and `PIMCORE_PRODUCT_KEY` are exposed.
- The checkout steps already use `github.event.pull_request.head.sha` / `head.repo.full_name`, so the fork code is checked out correctly.
- `permissions: contents: read` is already set in all three workflows, so the `GITHUB_TOKEN` cannot write.

Note: unlike `pull_request`, there is no first-time-contributor approval gate with `pull_request_target` — a malicious fork PR could exfiltrate the three secrets (e.g. via composer scripts). Consider using dedicated, rotatable CI-only keys for these secrets, analogous to pimcore's `PIMCORE_CI_*`.