### PR TITLE
[CI] Opt in to fork PR checkout for pull_request_target workflows

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -85,6 +85,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          allow-unsafe-pr-checkout: true
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/behat_ui.yml
+++ b/.github/workflows/behat_ui.yml
@@ -86,6 +86,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          allow-unsafe-pr-checkout: true
 
       - uses: browser-actions/setup-chrome@v2
         with:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          allow-unsafe-pr-checkout: true
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
Follow-up to #3161: `actions/checkout@v7` has a built-in guard that refuses to check out fork PR code in `pull_request_target` workflows, so the new runs for #3160 failed at the checkout step. This sets `allow-unsafe-pr-checkout: true` on the checkout steps in `behat.yml`, `behat_ui.yml` and `static.yml` — the explicit opt-in described at https://gh.io/securely-using-pull_request_target. The mitigations from #3161 still apply: the workflow definition comes from the base branch, only the three referenced secrets are exposed, and the `GITHUB_TOKEN` is read-only.