### PR TITLE
[5.1][RuleBundle] Add missing coreshop_settings key to Studio translation catalogue

### DIFF
--- a/src/CoreShop/Bundle/RuleBundle/Resources/translations/studio.de.yaml
+++ b/src/CoreShop/Bundle/RuleBundle/Resources/translations/studio.de.yaml
@@ -1,4 +1,5 @@
 ---
+coreshop_settings: 'Einstellungen'
 coreshop_conditions: 'Bedingungen'
 coreshop_actions: 'Aktionen'
 coreshop_condition_no_configuration: 'Diese Bedingung hat keine Konfiguration.'

--- a/src/CoreShop/Bundle/RuleBundle/Resources/translations/studio.en.yaml
+++ b/src/CoreShop/Bundle/RuleBundle/Resources/translations/studio.en.yaml
@@ -1,4 +1,5 @@
 ---
+coreshop_settings: 'Settings'
 coreshop_conditions: 'Conditions'
 coreshop_actions: 'Actions'
 coreshop_condition_no_configuration: 'This condition has no configuration.'


### PR DESCRIPTION
Fixes #3140

Targets `5.1`, the oldest affected branch, where Studio is already in productive use so the untranslated key hits real installations. `2026.x` is affected identically and picks the fix up through the normal upmerge flow.

## Problem

`RuleForm.tsx` labels its first tab with the translation key `coreshop_settings`:

```
src/CoreShop/Bundle/RuleBundle/Resources/assets/pimcore-studio/src/rules/components/RuleForm.tsx:85
label: t('coreshop_settings', { defaultValue: 'Settings' }),
```

But RuleBundle's own `Resources/translations/studio.{en,de}.yaml` never defined that key. It was only shipped by IndexBundle and CoreBundle, which use it for their own components. Any installation that renders rule forms without those bundles being present therefore showed the raw key instead of a label.

## Change

Added `coreshop_settings` to RuleBundle's `studio.en.yaml` (`Settings`) and `studio.de.yaml` (`Einstellungen`), as the first entry so the catalogue order matches the tab order in the form. The wording matches the entries already present in this branch's IndexBundle and CoreBundle catalogues.

## Audit of the other keys

The audit was run against `5.1` itself rather than carried over. On this branch RuleBundle references six translation keys — `RuleForm.tsx`, `EmptyCondition.tsx` and `EmptyAction.tsx` are the files using `useTranslation`:

| Key | Referenced in | Shipped by RuleBundle before this PR |
| --- | --- | --- |
| `coreshop_settings` | `RuleForm.tsx` | no — added here |
| `coreshop_conditions` | `RuleForm.tsx` | yes |
| `coreshop_actions` | `RuleForm.tsx` | yes |
| `coreshop_save` | `RuleForm.tsx` | yes |
| `coreshop_condition_no_configuration` | `EmptyCondition.tsx` | yes |
| `coreshop_action_no_configuration` | `EmptyAction.tsx` | yes |

`coreshop_settings` is the only genuine gap. The other `coreshop_*` identifiers in the bundle's assets (`coreshop_rule*`, `coreshop_timestamp_date`, `coreshop_cart_price_rule_*`) are icon names, form-widget registry ids and doc-comment examples, not translation keys, so they need no catalogue entries.

## IndexBundle's copy

Kept. IndexBundle uses `coreshop_settings` in its own `FilterDetail.tsx` and `IndexDetail.tsx`, and CoreBundle in `SettingsManager.tsx`, so the key legitimately belongs to those catalogues as well. Every bundle should be self-contained rather than relying on a sibling bundle being installed, and Symfony merges translation catalogues per domain, so the duplicate values are harmless.

## Notes

Source-only change; no Studio build artifacts are committed. Both catalogues were verified to parse.
