### PR TITLE
Fix typo in coreshop.security.frontend_regex breaking the pimcore-studio exclusion

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -1,5 +1,5 @@
 parameters:
-    coreshop.security.frontend_regex: "^/(?!admin|!pimcore-studio)[^/]*"
+    coreshop.security.frontend_regex: "^/(?!admin|pimcore-studio)[^/]*"
 
 pimcore:
     security:

--- a/docs/01_Getting_Started/00_Installation.md
+++ b/docs/01_Getting_Started/00_Installation.md
@@ -27,7 +27,7 @@ CoreShop:
     - Add the CoreShop Frontend parameter at the very top of your `security.yaml` (before `security`):
       ```yaml
       parameters:
-          coreshop.security.frontend_regex: "^/(?!admin)[^/]*"
+          coreshop.security.frontend_regex: "^/(?!admin|pimcore-studio)[^/]*"
 
       security:
           ...
@@ -39,7 +39,8 @@ CoreShop:
          coreshop_user:
              id: CoreShop\Bundle\CoreBundle\Security\ObjectUserProvider
       ```
-    - Add the Firewall Config. Find your existing `firewalls` entry and add the `coreshop_frontend` entry after the other entries:
+    - Add the Firewall Config. Find your existing `firewalls` entry and add the `coreshop_frontend` entry after the other
+      entries - in particular after `pimcore_studio`, since Symfony uses the first firewall whose pattern matches:
       ```yaml
        firewalls:
          coreshop_frontend:


### PR DESCRIPTION
Fixes #3145

Targets `5.1`, the oldest affected branch — `2026.x` carries the identical typo and picks the fix up through the normal upmerge, so there is no second PR.

## Problem

`config/packages/security.yaml` defines the frontend firewall pattern as:

```yaml
coreshop.security.frontend_regex: "^/(?!admin|!pimcore-studio)[^/]*"
```

The second `!` is a typo. Inside a negative lookahead the alternation `admin|!pimcore-studio` matches the *literal* string `!pimcore-studio`, so `/pimcore-studio` was never excluded from the CoreShop frontend firewall pattern.

The symptom is subtle: logging into Pimcore Studio appears to work, but every subsequent `/pimcore-studio/api` request is anonymous ("No pimcore user found"), because the request can be picked up by the shop firewall with its own (`context: shop`) session context instead of the Studio one.

## Fix

```yaml
coreshop.security.frontend_regex: "^/(?!admin|pimcore-studio)[^/]*"
```

## Firewall order

Checked as part of the same failure mode, on this branch: `pimcore_studio` is declared before `coreshop_frontend` (the classic `pimcore_admin` firewall above it is commented out), which is correct — Symfony uses the first firewall whose pattern matches. No change needed.

The installation docs only said to add `coreshop_frontend` "after the other entries", which is now made explicit.

## Verification

Mechanical check of both patterns against the relevant paths. The two patterns are read out of the real `config/packages/security.yaml` — `before` from `5.1` as it stands, `after` from this branch — and matched with `preg_match`, answering "does this path fall into the CoreShop frontend firewall?":

```
before (5.1 today)  ^/(?!admin|!pimcore-studio)[^/]*
  FAIL  /pimcore-studio/api/login  frontend firewall: yes (expected no)
  FAIL  /pimcore-studio            frontend firewall: yes (expected no)
  OK    /admin/login               frontend firewall: no  (expected no)
  OK    /en/shop/                  frontend firewall: yes (expected yes)
  OK    /                          frontend firewall: yes (expected yes)

after  (this PR)    ^/(?!admin|pimcore-studio)[^/]*
  OK    /pimcore-studio/api/login  frontend firewall: no  (expected no)
  OK    /pimcore-studio            frontend firewall: no  (expected no)
  OK    /admin/login               frontend firewall: no  (expected no)
  OK    /en/shop/                  frontend firewall: yes (expected yes)
  OK    /                          frontend firewall: yes (expected yes)
```

Shop paths are unaffected; only `/pimcore-studio*` changes classification, which is the intent.

## Blast radius

Grepped both `5.1` and `2026.x` for `frontend_regex` and for the spelled-out pattern:

| Location | State |
| --- | --- |
| `config/packages/security.yaml` | had the typo on both branches — fixed here on `5.1` |
| `docs/01_Getting_Started/00_Installation.md` | had `^/(?!admin)[^/]*`, no Studio exclusion at all, identical on both branches — updated, so anyone following the install guide does not reproduce this bug |
| `src/CoreShop/Bundle/CoreBundle/Resources/config/pimcore/security.yml` | has the old `^/(?!admin)[^/]*` on both branches; this file is stale Symfony-4-era config (`anonymous: ~`, `encoder_factories`) that nothing imports. Deliberately left alone — it is a separate cleanup, not part of this fix |
| `CHANGELOG-3.0.x.md` | historical, untouched |

No occurrences in app skeletons, install templates, demo/test app configs, or external-bundle docs.
