### PR TITLE
[TestBundle] drop pimcore/newsletter-bundle coupling

### DIFF
--- a/phpstan-package.neon
+++ b/phpstan-package.neon
@@ -58,7 +58,7 @@ parameters:
 
         # Optional dependencies
         - identifier: class.notFound
-          message: '/Pimcore\\Bundle\\(AdminBundle|StudioBackendBundle|StudioUiBundle|GoogleMarketingBundle|NewsletterBundle)\\/'
+          message: '/Pimcore\\Bundle\\(AdminBundle|StudioBackendBundle|StudioUiBundle|GoogleMarketingBundle)\\/'
 
 includes:
     - ./vendor/phpstan/phpstan-doctrine/extension.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -52,7 +52,7 @@ parameters:
         - '/Access to undefined constant PackageVersions\\Versions::VERSIONS/'
         # Optional dependencies
         - identifier: class.notFound
-          message: '/Pimcore\\Bundle\\(AdminBundle|StudioBackendBundle|StudioUiBundle|GoogleMarketingBundle|NewsletterBundle)\\/'
+          message: '/Pimcore\\Bundle\\(AdminBundle|StudioBackendBundle|StudioUiBundle|GoogleMarketingBundle)\\/'
 
 includes:
     - vendor/phpstan/phpstan-doctrine/extension.neon

--- a/src/CoreShop/Bundle/CoreBundle/composer.json
+++ b/src/CoreShop/Bundle/CoreBundle/composer.json
@@ -88,7 +88,6 @@
     },
     "suggest": {
         "pimcore/elasticsearch-client": "Allows to use ElasticSearch as your index engine.",
-        "pimcore/newsletter-bundle": "^2.0 - Enables Pimcore Newsletter document type and field integrations",
         "pimcore/opensearch-client": "Allows to use OpenSearch as your index engine."
     }
 }

--- a/src/CoreShop/Bundle/CustomerBundle/composer.json
+++ b/src/CoreShop/Bundle/CustomerBundle/composer.json
@@ -57,7 +57,6 @@
     },
     "suggest": {
         "pimcore/elasticsearch-client": "Allows to use ElasticSearch as your index engine.",
-        "pimcore/newsletter-bundle": "^2.0 - Enables Pimcore Newsletter document type and field integrations",
         "pimcore/opensearch-client": "Allows to use OpenSearch as your index engine."
     }
 }

--- a/src/CoreShop/Bundle/TestBundle/Context/Hook/PimcoreDaoContext.php
+++ b/src/CoreShop/Bundle/TestBundle/Context/Hook/PimcoreDaoContext.php
@@ -101,10 +101,6 @@ class PimcoreDaoContext implements Context
         $this->connection->executeQuery('DELETE FROM documents_page WHERE id <> 1');
         $this->connection->executeQuery('DELETE FROM documents_snippet WHERE id <> 1');
         $this->connection->executeQuery('DELETE FROM documents_translations WHERE id <> 1');
-
-        if ($this->connection->createSchemaManager()->tableExists('documents_newsletter')) {
-            $this->connection->executeQuery('DELETE FROM documents_newsletter WHERE id <> 1');
-        }
     }
 
     /**

--- a/src/CoreShop/Bundle/TestBundle/Context/Setup/DocumentContext.php
+++ b/src/CoreShop/Bundle/TestBundle/Context/Setup/DocumentContext.php
@@ -19,7 +19,6 @@ namespace CoreShop\Bundle\TestBundle\Context\Setup;
 
 use Behat\Behat\Context\Context;
 use CoreShop\Bundle\TestBundle\Service\SharedStorageInterface;
-use Pimcore\Bundle\NewsletterBundle\Model\Document\Newsletter;
 use Pimcore\Model\Document;
 
 final class DocumentContext implements Context
@@ -50,7 +49,6 @@ final class DocumentContext implements Context
             'hardlink' => Document\Hardlink::class,
             'folder' => Document\Folder::class,
             'email' => Document\Email::class,
-            'newsletter' => Newsletter::class,
             default => throw new \InvalidArgumentException($type . ' is not valid')
         };
 

--- a/src/CoreShop/Bundle/TestBundle/Context/Transform/DocumentContext.php
+++ b/src/CoreShop/Bundle/TestBundle/Context/Transform/DocumentContext.php
@@ -19,7 +19,6 @@ namespace CoreShop\Bundle\TestBundle\Context\Transform;
 
 use Behat\Behat\Context\Context;
 use CoreShop\Bundle\TestBundle\Service\SharedStorageInterface;
-use Pimcore\Bundle\NewsletterBundle\Model\Document\Newsletter;
 use Pimcore\Model\Document;
 use Webmozart\Assert\Assert;
 
@@ -127,18 +126,6 @@ final class DocumentContext implements Context
     }
 
     /**
-     * @Transform /^document-newsletter "([^"]+)"$/
-     */
-    public function getDocumentNewsletterByFullPath(string $fullPath): Newsletter
-    {
-        $document = Newsletter::getByPath($fullPath);
-
-        Assert::isInstanceOf($document, Newsletter::class);
-
-        return $document;
-    }
-
-    /**
      * @Transform /^document/
      */
     public function document(): Document
@@ -218,18 +205,6 @@ final class DocumentContext implements Context
         $document = $this->sharedStorage->get('document');
 
         Assert::isInstanceOf($document, Document\Folder::class);
-
-        return $document;
-    }
-
-    /**
-     * @Transform /^document-newsletter/
-     */
-    public function documentNewsletter(): Newsletter
-    {
-        $document = $this->sharedStorage->get('document');
-
-        Assert::isInstanceOf($document, Newsletter::class);
 
         return $document;
     }

--- a/src/CoreShop/Bundle/TestBundle/composer.json
+++ b/src/CoreShop/Bundle/TestBundle/composer.json
@@ -68,8 +68,5 @@
     },
     "config": {
         "sort-packages": true
-    },
-    "suggest": {
-        "pimcore/newsletter-bundle": "^2.0 - Enables Pimcore Newsletter document type and field integrations"
     }
 }


### PR DESCRIPTION
Fixes #3143

## What the investigation found

The premise of the issue does not hold on the current `2026.x` tip: `CoreShopCustomer.json` no longer uses newsletter field types. Commit 38d23f28c6 (`[Studio] make pimcore bundles optional`, Feb 18 2026) already converted them:

* `CustomerBundle/.../CoreShopCustomer.json` — `newsletterActive`, `newsletterConfirmed`: `newsletterActive`/`newsletterConfirmed` fieldtype → `checkbox`
* `CoreBundle/.../CoreShopCustomerBundle/CoreShopCustomer.json` — same, plus `newsletterToken` which was always a plain `input`
* `CustomerBundle/.../grid-config.yml` — 4 column `dataType: newsletterActive|newsletterConfirmed` → `checkbox`

I verified every one of the 29 installable class definitions in `src/CoreShop/Bundle/*/Resources/install/pimcore/classes/`: no `newsletter*` fieldtype remains anywhere. So installing the customer class does not hit unknown field types.

That commit deliberately took the "replace with plain checkboxes so the data survives upgrades" option the issue mentions, which is the right call — the newsletter double-opt-in flow (`CustomerNewsletterConfirmListener`, `CustomerRepository::findByNewsletterToken`, `CustomerController::confirmNewsletterAction`, the registration/settings checkboxes, the `user-newsletter-confirm(ed)` mail documents and notification rules) is CoreShop's own feature and never depended on `pimcore/newsletter-bundle`. Removing the fields would break it, so the fields, model methods and `CustomerInterface` members stay.

## What actually is still broken, and is fixed here

`pimcore/newsletter-bundle` has no 2026.x release — the latest release, v2.3.0, requires `pimcore/pimcore: ^12.3`. It can therefore never be installed alongside Pimcore 2026.1, but three places still assumed it might be:

* `TestBundle/Context/Setup/DocumentContext.php` and `TestBundle/Context/Transform/DocumentContext.php` hard-imported `Pimcore\Bundle\NewsletterBundle\Model\Document\Newsletter` (a `newsletter` arm in `createDocumentByType()` and two `document-newsletter` transforms). No feature file uses them, and any that did would now fatal with a class-not-found.
* `TestBundle/Context/Hook/PimcoreDaoContext.php` purged `documents_newsletter` behind a `tableExists()` guard — a table that can no longer come into existence.
* `CoreBundle`, `CustomerBundle` and `TestBundle` `composer.json` still suggested `pimcore/newsletter-bundle: ^2.0` for "Newsletter document type and field integrations". The field integrations are gone and the document type is uninstallable on 2026.
* `phpstan.neon` / `phpstan-package.neon` carried `NewsletterBundle` in the optional-dependency `class.notFound` exemption, which is now dead. The other alternatives in the pattern (`AdminBundle|StudioBackendBundle|StudioUiBundle|GoogleMarketingBundle`) still match, and `reportUnmatchedIgnoredErrors` is `false` anyway.

## Why this targets `2026.x` and not the oldest affected branch

**In short: this is 2026.x-only. On `5.1` `pimcore/newsletter-bundle` still exists and is installable, so the coupling removed here is valid there and no `5.1` counterpart is needed.**

Fixes normally belong on the oldest affected branch and reach `2026.x` by upmerge. This one is genuinely `2026.x`-only, on two counts.

**The class definition needs no change on either branch.** `5.1` and `2026.x` are already identical here — on both branches `newsletterActive` and `newsletterConfirmed` are `checkbox`, `newsletterToken` is `input`, and all four `grid-config.yml` columns are `dataType: checkbox`. So there is no BC question about removing fields from `5.1` installations: nothing is being removed from any class definition on any branch.

**The `newsletter-bundle` coupling is correct on `5.1` and only wrong on `2026.x`.** `5.1` requires `pimcore/pimcore: ^12.3`, and `pimcore/newsletter-bundle` v2.3.0 requires `pimcore/pimcore: ^12.3` — the bundle is installable there. The `suggest` entries are accurate, the Behat newsletter document type works when a user opts into the bundle, and the PHPStan exemption is still needed because the code referencing `Pimcore\Bundle\NewsletterBundle\*` is still there and the bundle is not in `require-dev`. Applying this diff to `5.1` would delete working optional support rather than fix anything. Every hunk here follows from the single fact "the bundle has no 2026.x release", which is untrue of `5.1`.

**Upmerge note:** `5.1` keeps the newsletter code, so the recurring `upmerge/5.1_2026.x` will carry it toward this branch. As long as those lines are not touched on `5.1` the deletions win silently, but if `TestBundle/Context/{Setup,Transform}/DocumentContext.php` or the PHPStan configs are edited on `5.1`, the upmerge will conflict — resolve in favour of the `2026.x` deletion.

## BC

`Setup\DocumentContext::createDocumentByType()` no longer accepts `'newsletter'`, and the two public `document-newsletter` transform methods are gone from `Transform\DocumentContext`. These are Behat test-infrastructure classes in `TestBundle`, and the removed code could not have run on 2026.x in any case. Nothing on `CustomerInterface` or any other public component API changed.

## Verification

Run against this branch with the vendor tree and container of the local 2026.1 checkout:

* `vendor/bin/ecs check src/CoreShop/Bundle/TestBundle/Context` — no errors
* `vendor/bin/phpstan analyse -c phpstan.neon src/CoreShop/Bundle/TestBundle/Context` — no errors
* `vendor/bin/psalm --no-cache src/CoreShop/Bundle/TestBundle/Context` — no errors
* all three touched `composer.json` files parse as valid JSON
* script-validated all 29 install class definitions for leftover newsletter field types — none
* compared `5.1` and `2026.x` class definitions and grid configs field by field — identical
