### PR TITLE
[RuleBundle] Add missing coreshop_settings key to Studio translation catalogue

### DIFF
--- a/src/CoreShop/Bundle/RuleBundle/Resources/translations/studio.de.yaml
+++ b/src/CoreShop/Bundle/RuleBundle/Resources/translations/studio.de.yaml
@@ -1,4 +1,5 @@
 ---
+coreshop_settings: 'Einstellungen'
 coreshop_conditions: 'Bedingungen'
 coreshop_actions: 'Aktionen'
 coreshop_condition_no_configuration: 'Diese Bedingung hat keine Konfiguration.'

--- a/src/CoreShop/Bundle/RuleBundle/Resources/translations/studio.en.yaml
+++ b/src/CoreShop/Bundle/RuleBundle/Resources/translations/studio.en.yaml
@@ -1,4 +1,5 @@
 ---
+coreshop_settings: 'Settings'
 coreshop_conditions: 'Conditions'
 coreshop_actions: 'Actions'
 coreshop_condition_no_configuration: 'This condition has no configuration.'


### PR DESCRIPTION
Fixes #3165

Same fix as #3163, applied to the `5.1` line, where Studio is already in productive use so the untranslated key hits real installations.

## Problem

`RuleForm.tsx` labels its first tab with the translation key `coreshop_settings`:

```
src/CoreShop/Bundle/RuleBundle/Resources/assets/pimcore-studio/src/rules/components/RuleForm.tsx:85
label: t('coreshop_settings', { defaultValue: 'Settings' }),
```

RuleBundle's own `Resources/translations/studio.{en,de}.yaml` never defined that key — it was only shipped by IndexBundle and CoreBundle, which use it for their own components. Installations that render rule forms without those bundles showed the raw key.

## Change

Added `coreshop_settings` to RuleBundle's `studio.en.yaml` (`Settings`) and `studio.de.yaml` (`Einstellungen`), as the first entry so the catalogue order matches the tab order in the form. The wording matches the entries already present in this branch's IndexBundle and CoreBundle catalogues.

## Audit of the other keys

The audit was re-run against `5.1` rather than carried over from `2026.x`, and the key set here does differ: on this branch `EmptyAction.tsx` and `EmptyCondition.tsx` also use `useTranslation`, so RuleBundle references six keys rather than four.

| Key | Referenced in | Shipped by RuleBundle before this PR |
| --- | --- | --- |
| `coreshop_settings` | `RuleForm.tsx` | no — added here |
| `coreshop_conditions` | `RuleForm.tsx` | yes |
| `coreshop_actions` | `RuleForm.tsx` | yes |
| `coreshop_save` | `RuleForm.tsx` | yes |
| `coreshop_condition_no_configuration` | `EmptyCondition.tsx` | yes |
| `coreshop_action_no_configuration` | `EmptyAction.tsx` | yes |

So `coreshop_settings` remains the only genuine gap on this branch too. The other `coreshop_*` identifiers in the bundle's assets (`coreshop_rule*`, `coreshop_timestamp_date`, `coreshop_cart_price_rule_*`) are icon names, form-widget registry ids and doc-comment examples, not translation keys.

## IndexBundle's copy

Kept, as in #3163. IndexBundle uses `coreshop_settings` in its own `FilterDetail.tsx` and `IndexDetail.tsx`, and CoreBundle in `SettingsManager.tsx`, so the key legitimately belongs to those catalogues as well. Each bundle should be self-contained rather than relying on a sibling being installed, and Symfony merges translation catalogues per domain, so the duplicate values are harmless.

## Notes

Source-only change; no Studio build artifacts are committed. Both catalogues were verified to parse.
