### PR TITLE
[CoreBundle] migrate the doctrine json columns from LONGTEXT to the platform json type

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Migrations/Version20260821090100.php
+++ b/src/CoreShop/Bundle/CoreBundle/Migrations/Version20260821090100.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CoreShop
+ *
+ * This source file is available under the terms of the
+ * CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    CoreShop Commercial License (CCL)
+ *
+ */
+
+namespace CoreShop\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Companion of Version20260807000000: that migration converted the values of the columns that were
+ * mapped as doctrine "array"/"object" before Pimcore 12 / DBAL 4 to JSON, but it did not touch the
+ * column definitions. On databases created before the mapping change those columns are still
+ * LONGTEXT while the mapping now says "json", which keeps showing up as a schema diff.
+ *
+ * Kept separate from the fieldName migration (Version20260821090000) because it is unrelated drift:
+ * it is cosmetic (both column types read and write the same values through DBAL), it must run after
+ * the value conversion of Version20260807000000, and it is skipped per column whenever the data
+ * cannot be converted, which should not hold back the fix for a broken installation.
+ *
+ * Idempotent: columns that already have the platform's json type are skipped, and a column whose
+ * values are not all valid JSON is left alone with a warning instead of failing the migration
+ * (MySQL rejects invalid JSON on ALTER TABLE). On platforms whose json declaration is LONGTEXT
+ * (MariaDB) the whole migration is a no-op.
+ */
+final class Version20260821090100 extends AbstractMigration
+{
+    /**
+     * table => columns
+     *
+     * @var array<string, list<string>>
+     */
+    private const COLUMNS = [
+        'coreshop_configuration' => ['data'],
+        'coreshop_index' => ['configuration'],
+        'coreshop_index_column' => ['getterConfig', 'interpreterConfig', 'configuration'],
+        'coreshop_filter_condition' => ['configuration'],
+        'coreshop_rule_action' => ['configuration'],
+        'coreshop_rule_condition' => ['configuration'],
+    ];
+
+    public function getDescription(): string
+    {
+        return 'Change the columns mapped as doctrine "json" (Configuration, Index, Rule, ...) from '
+            . 'the legacy LONGTEXT definition to the platform json type.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('SELECT 1'); // the conversion happens in postUp()
+    }
+
+    public function postUp(Schema $schema): void
+    {
+        $jsonDeclaration = $this->platform->getJsonTypeDeclarationSQL([]);
+
+        if (str_contains(strtoupper($jsonDeclaration), 'TEXT')) {
+            $this->write(sprintf('nothing to do, this platform declares json columns as %s', $jsonDeclaration));
+
+            return;
+        }
+
+        $schemaManager = $this->connection->createSchemaManager();
+
+        foreach (self::COLUMNS as $table => $columns) {
+            if (!$schemaManager->tablesExist([$table])) {
+                $this->write(sprintf('skipping %s — table does not exist', $table));
+
+                continue;
+            }
+
+            $tableColumns = $schemaManager->listTableColumns($table);
+
+            foreach ($columns as $column) {
+                $tableColumn = $tableColumns[strtolower($column)] ?? null;
+
+                if (null === $tableColumn) {
+                    $this->write(sprintf('skipping %s.%s — column does not exist', $table, $column));
+
+                    continue;
+                }
+
+                if (!$this->isConvertible($table, $column)) {
+                    continue;
+                }
+
+                $this->connection->executeStatement(sprintf(
+                    'ALTER TABLE `%s` MODIFY `%s` %s %s',
+                    $table,
+                    $column,
+                    $jsonDeclaration,
+                    $tableColumn->getNotnull() ? 'NOT NULL' : 'DEFAULT NULL',
+                ));
+
+                $this->write(sprintf('%s.%s converted to %s', $table, $column, $jsonDeclaration));
+            }
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        // The mapping expects json columns; there is nothing to roll back to.
+        $this->addSql('SELECT 1');
+    }
+
+    private function isConvertible(string $table, string $column): bool
+    {
+        $currentType = $this->connection->fetchOne(
+            'SELECT DATA_TYPE FROM information_schema.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = :table AND COLUMN_NAME = :column',
+            ['table' => $table, 'column' => $column],
+        );
+
+        if (is_string($currentType) && strtolower($currentType) === 'json') {
+            return false;
+        }
+
+        $values = $this->connection->fetchFirstColumn(
+            sprintf('SELECT `%s` FROM `%s` WHERE `%s` IS NOT NULL', $column, $table, $column),
+        );
+
+        foreach ($values as $value) {
+            json_decode((string) $value);
+
+            if (json_last_error() !== \JSON_ERROR_NONE) {
+                $this->write(sprintf(
+                    'skipping %s.%s — it still contains values that are not valid JSON, run the value '
+                    . 'conversion (Version20260807000000) first',
+                    $table,
+                    $column,
+                ));
+
+                return false;
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
Refs #3142 (see below — the main claim of that issue does not hold, this PR only covers the second half of it).

## Why the original scope was dropped

This PR first also contained a migration re-adding `coreshop_product_store_values.fieldName`. That was wrong and has been removed.

`fieldName` was added in 2528a853ec ("[Core] allow multiple store-values") **together with** migration `Version20241105123053`, and that migration shipped in released tags from **4.0.12 through 4.1.12**. Every database that was upgraded through the latest 4.1 release therefore already has the column, and pruning the migration in c561e2e34c only removed the file from later branches — it did not un-apply anything.

The only databases without the column are ones installed before 4.0.12 that jumped straight to 5.x without going through the last 4.1 release. `docs/01_Getting_Started/02_Upgrade_Guide.md` covers exactly that case: migrations are deliberately removed between majors, you must update to the latest minor of the previous major first, and if you skipped it the documented remedy is `bin/console doctrine:schema:update --dump-sql` plus a manual review. Re-adding one of the twenty pruned migrations would contradict that policy, and the same argument would apply to all the others.

## What remains: the LONGTEXT → JSON column definitions

This one is a genuine gap on a **supported** path. On 4.1 those columns were mapped as doctrine `array`/`object` (`Configuration.data` was `type="object"`, `Action.configuration` was `type="array"`, …), which DBAL creates as LONGTEXT. On 5.0 they are `type="json"`, which DBAL creates as JSON. `Version20260807000000` converts the stored *values* from PHP-serialized to JSON, but nothing ever converts the *column definitions*. A correctly upgraded 4.1.12 database keeps LONGTEXT while a fresh 5.0 install gets JSON — nothing was skipped by the user, the migration simply was never written.

`Version20260821090100` closes that gap for `coreshop_configuration`, `coreshop_index`, `coreshop_index_column`, `coreshop_filter_condition`, `coreshop_rule_action` and `coreshop_rule_condition`. It:

* uses the platform's own json declaration, so it is a no-op where that is LONGTEXT
* preserves each column's nullability rather than aligning it to the mapping, so it cannot fail on existing NULLs
* skips missing tables (bundles that are not installed) and columns that already have the json type
* skips a column whose values are not all valid JSON, with a warning pointing at `Version20260807000000`, instead of failing the migration — MySQL rejects invalid JSON on `ALTER TABLE`

The effect is cosmetic in the sense that both column types round-trip the same values through DBAL; the point is that `doctrine:schema:update --dump-sql` stops reporting a diff that no migration can resolve.

## Verification

ECS passes; phpstan and psalm exclude `**/Migrations/Version*.php` by config, so `php -l` is the static check that applies there.

The migration was **actually executed** against a MySQL 8.0 container, on tables rebuilt with the 4.1-era LONGTEXT definitions:

* `coreshop_configuration.data` (NOT NULL) and `coreshop_rule_action.configuration` (nullable) end up as `json` with their nullability preserved and the stored values still readable
* absent tables are skipped with a message
* a re-run performs no further changes
* a table still holding PHP-serialized data (`a:1:{s:1:"a";i:1;}`) is skipped with the warning and stays LONGTEXT instead of aborting the migration
