### PR TITLE
Restore the backend half of pimcore_admin that the classic admin removal took with it

### DIFF
--- a/CHANGELOG-2026.1.x.md
+++ b/CHANGELOG-2026.1.x.md
@@ -23,8 +23,11 @@ Removed:
   listeners, the Pimcore Grid Config Installer).
 - All `classic_admin.yml` service files and the conditional `PimcoreAdminBundle` loading blocks in
   bundle extensions.
-- `pimcore_admin` configuration section from `CoreShopPimcoreExtension` and all bundle `Configuration`
-  classes, plus the `registerPimcoreResources()` helper on `AbstractPimcoreExtension`.
+- The classic-admin asset keys of the `pimcore_admin` configuration section (`js`, `css`, `editmode_js`,
+  `editmode_css`), along with the installers behind the `grid_config` and `routes` install types. The
+  section itself and the `registerPimcoreResources()` helper on `AbstractPimcoreExtension` remain, and
+  still carry the backend-relevant `permissions` and `install` declarations — see "Backend declarations
+  kept" below.
 - `CoreShop\Component\Pimcore\DataObject\Grid\GridFilterInterface`, `AsGridFilter` attribute,
   `RegisterGridFilterPass` compiler pass, `GridConfigInstaller` / `GridConfigInstallerInterface`.
 - `CoreShop\Bundle\PimcoreBundle\Controller\Admin\*` controllers. Studio-facing actions were moved to
@@ -36,6 +39,27 @@ Removed:
 
 If you have project code referencing any of these symbols, see the migration notes in the
 upgrade guide.
+
+### Backend declarations kept: `pimcore_admin` and `registerPimcoreResources()`
+
+Despite its name, the `pimcore_admin` configuration section was never only about the classic admin. Besides
+the ExtJS asset keys it carries the declarations that drive the resource installers, and those are unrelated
+to the admin UI:
+
+- `permissions` — the Pimcore user-permission definitions installed by `PimcorePermissionInstaller`.
+- `install.documents` / `install.image_thumbnails` / `install.sql` — installed by
+  `PimcoreDocumentsInstaller`, `PimcoreImageThumbnailsInstaller` and `SqlInstaller`.
+
+The section and the `registerPimcoreResources()` helper therefore stay. Only the classic-admin keys are gone,
+and they are *ignored* rather than rejected, so a bundle that still declares `js` / `css` alongside its
+`permissions` keeps working on 2026.x with no changes to its `Configuration` class or its extension.
+
+The section name is kept as `pimcore_admin` for backwards compatibility, even though it is now a purely
+historical name. This is deliberate and permanent: there is no rename, no alias and no deprecation, because
+bundles outside the core declare `pimcore_admin: { permissions: [...] }` and call `registerPimcoreResources()`
+verbatim and must keep working. The same goes for the method name.
+
+See `docs/03_Bundles/Resource_Bundle/06_User_Permissions.md`.
 
 ### Studio extension points unchanged
 

--- a/config/reference.php
+++ b/config/reference.php
@@ -470,7 +470,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         datetime?: array{
  *             default_format?: scalar|Param|null, // Default: "Y-m-d\\TH:i:sP"
  *             default_deserialization_formats?: list<scalar|Param|null>,
- *             default_timezone?: scalar|Param|null, // Default: "Europe/Berlin"
+ *             default_timezone?: scalar|Param|null, // Default: "UTC"
  *             cdata?: scalar|Param|null, // Default: true
  *         },
  *         array_collection?: array{
@@ -570,7 +570,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             datetime?: array{
  *                 default_format?: scalar|Param|null, // Default: "Y-m-d\\TH:i:sP"
  *                 default_deserialization_formats?: list<scalar|Param|null>,
- *                 default_timezone?: scalar|Param|null, // Default: "Europe/Berlin"
+ *                 default_timezone?: scalar|Param|null, // Default: "UTC"
  *                 cdata?: scalar|Param|null, // Default: true
  *             },
  *             array_collection?: array{
@@ -716,6 +716,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     translation?: bool|array{
  *         enabled?: bool|Param, // Default: true
  *         locale_provider?: scalar|Param|null, // Default: "CoreShop\\Component\\Resource\\Translation\\Provider\\TranslationLocaleProviderInterface"
+ *         locale_column_length?: int|Param, // Length of the `locale` column mapped onto every `*_translation` database table. The default of 5 fits plain language/region codes like "de_AT" but is too short for locales with a script subtag, e.g. "zh_Hans" / "zh_Hant" (7 chars) - MySQL silently truncates them, which then collides with the unique (translatable_id, locale) constraint. IMPORTANT: changing this value only updates Doctrine's mapping metadata for newly created schemas - it does NOT alter any already-created database column. You must ship your own migration that runs `ALTER TABLE ... MODIFY locale VARCHAR(<n>)` on every existing `*_translation` table, or inserts will keep failing/truncating against the old column width. // Default: 5
  *     },
  *     drivers?: list<"doctrine/orm"|Param>,
  *     orm_cascade_merge_associations?: array<string, array{ // Default: []
@@ -765,6 +766,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     doctrine?: array{
  *         table_name?: scalar|Param|null, // Default: null
  *         connection?: scalar|Param|null, // Default: null
+ *     },
+ *     pimcore_admin?: array{
+ *         permissions?: scalar|Param|null, // Default: ["messenger"]
  *     },
  * }
  * @psalm-type CoreShopRuleConfig = array{
@@ -1006,6 +1010,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         order_shipment?: scalar|Param|null, // Default: "CoreShop\\Component\\Order\\Model\\OrderShipmentInterface"
  *         order_shipment_item?: scalar|Param|null, // Default: "CoreShop\\Component\\Order\\Model\\OrderShipmentItemInterface"
  *     },
+ *     pimcore_admin?: array{
+ *         permissions?: scalar|Param|null, // Default: ["cart_price_rule","order_list","order_detail","order_create","quote_list","quote_detail","quote_create","cart_list","cart_detail","cart_create"]
+ *     },
  * }
  * @psalm-type CoreShopCustomerConfig = array{
  *     login_identifier?: "email"|"username"|Param, // Default: "email"
@@ -1058,6 +1065,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 type?: scalar|Param|null, // Default: "object"
  *             },
  *         },
+ *     },
+ *     pimcore_admin?: array{
+ *         permissions?: scalar|Param|null, // Default: ["customer_list","customer_group_list"]
  *     },
  * }
  * @psalm-type CoreShopUserConfig = array{
@@ -1298,6 +1308,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         category?: scalar|Param|null, // Default: "CoreShop\\Component\\Product\\Model\\CategoryInterface"
  *         manufacturer?: scalar|Param|null, // Default: "CoreShop\\Component\\Product\\Model\\ManufacturerInterface"
  *     },
+ *     pimcore_admin?: array{
+ *         permissions?: scalar|Param|null, // Default: ["product_price_rule","product_unit"]
+ *     },
  * }
  * @psalm-type CoreShopThemeConfig = array{
  *     autoconfigure_with_attributes?: scalar|Param|null, // Default: false
@@ -1411,6 +1424,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             },
  *         },
  *     },
+ *     pimcore_admin?: array{
+ *         permissions?: scalar|Param|null, // Default: ["country","state","zone"]
+ *     },
  * }
  * @psalm-type CoreShopCurrencyConfig = array{
  *     money_decimal_factor?: int|Param, // Default: 100
@@ -1444,6 +1460,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 form?: scalar|Param|null, // Default: "CoreShop\\Bundle\\CurrencyBundle\\Form\\Type\\ExchangeRateType"
  *             },
  *         },
+ *     },
+ *     pimcore_admin?: array{
+ *         permissions?: scalar|Param|null, // Default: ["currency","exchange_rate"]
  *     },
  * }
  * @psalm-type CoreShopTaxationConfig = array{
@@ -1509,6 +1528,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             },
  *         },
  *     },
+ *     pimcore_admin?: array{
+ *         permissions?: scalar|Param|null, // Default: ["tax_rate","tax_rule_group"]
+ *     },
  * }
  * @psalm-type CoreShopStoreConfig = array{
  *     autoconfigure_with_attributes?: scalar|Param|null, // Default: false
@@ -1528,6 +1550,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 form?: scalar|Param|null, // Default: "CoreShop\\Bundle\\StoreBundle\\Form\\Type\\StoreType"
  *             },
  *         },
+ *     },
+ *     pimcore_admin?: array{
+ *         permissions?: scalar|Param|null, // Default: ["store"]
  *     },
  * }
  * @psalm-type CoreShopIndexConfig = array{
@@ -1584,6 +1609,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     mapping_types?: array<string, scalar|Param|null>,
  *     worker_mapping_types?: array<string, array<string, scalar|Param|null>>,
+ *     pimcore_admin?: array{
+ *         permissions?: scalar|Param|null, // Default: ["index","filter"]
+ *     },
  * }
  * @psalm-type CoreShopShippingConfig = array{
  *     autoconfigure_with_attributes?: scalar|Param|null, // Default: false
@@ -1639,6 +1667,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 form?: scalar|Param|null, // Default: "CoreShop\\Bundle\\ShippingBundle\\Form\\Type\\ShippingRuleGroupType"
  *             },
  *         },
+ *     },
+ *     pimcore_admin?: array{
+ *         permissions?: scalar|Param|null, // Default: ["carrier","shipping_rule"]
  *     },
  * }
  * @psalm-type CoreShopPaymentConfig = array{
@@ -1719,6 +1750,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             },
  *         },
  *     },
+ *     pimcore_admin?: array{
+ *         permissions?: scalar|Param|null, // Default: ["payment_provider","payment_provider_rule"]
+ *     },
  * }
  * @psalm-type CoreShopSequenceConfig = array{
  *     resources?: array{
@@ -1770,6 +1804,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             },
  *         },
  *     },
+ *     pimcore_admin?: array{
+ *         permissions?: scalar|Param|null, // Default: ["notification"]
+ *     },
  * }
  * @psalm-type CoreShopTrackingConfig = array{
  *     autoconfigure_with_attributes?: scalar|Param|null, // Default: false
@@ -1801,6 +1838,12 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         security?: scalar|Param|null, // Default: "CoreShop\\Bundle\\FrontendBundle\\Controller\\SecurityController"
  *         payment?: scalar|Param|null, // Default: "CoreShop\\Bundle\\PayumBundle\\Controller\\PaymentController"
  *         mail?: scalar|Param|null, // Default: "CoreShop\\Bundle\\FrontendBundle\\Controller\\MailController"
+ *     },
+ *     pimcore_admin?: array{
+ *         install?: array{
+ *             documents?: list<scalar|Param|null>,
+ *             image_thumbnails?: list<scalar|Param|null>,
+ *         },
  *     },
  * }
  * @psalm-type CoreShopPayumConfig = array{
@@ -2883,7 +2926,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             domain?: scalar|Param|null, // Default: null
  *             secure?: true|false|"auto"|Param, // Default: null
  *             httponly?: bool|Param, // Default: true
- *             samesite?: null|"lax"|"strict"|"none"|Param, // Default: "lax"
+ *             samesite?: null|"lax"|"strict"|"none"|Param, // Default: "strict"
  *             always_remember_me?: bool|Param, // Default: false
  *             remember_me_parameter?: scalar|Param|null, // Default: "_remember_me"
  *         },
@@ -3678,6 +3721,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             priority?: int|Param,
  *         }>,
  *     }>,
+ *     pimcore_admin?: array{
+ *         permissions?: scalar|Param|null, // Default: ["settings","ctc_assign_to_new","ctc_assign_to_existing"]
+ *     },
  * }
  * @psalm-type CoreShopStorageListConfig = array{
  *     list?: array<string, array{ // Default: []

--- a/docs/03_Bundles/Resource_Bundle/06_User_Permissions.md
+++ b/docs/03_Bundles/Resource_Bundle/06_User_Permissions.md
@@ -1,0 +1,102 @@
+# User Permissions
+
+CoreShop gates menu entries, Studio widgets and controllers behind Pimcore user permissions, for example
+`coreshop_permission_order_list`. A permission can only be granted to a Pimcore user or role once a
+`Pimcore\Model\User\Permission\Definition` row exists for it, so every permission a bundle checks has to be
+*declared* first. `coreshop:resources:install` then writes the declarations into Pimcore.
+
+## Declaring permissions
+
+Declare them in the `pimcore_admin` section of your bundle's configuration and register that section from your
+DI extension. This is the same mechanism CoreShop has used since 4.x — it is unchanged on 2026.x.
+
+```php
+<?php
+// YourBundle/DependencyInjection/Configuration.php
+
+private function addPimcoreResourcesSection(ArrayNodeDefinition $node): void
+{
+    $node->children()
+        ->arrayNode('pimcore_admin')
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->scalarNode('permissions')
+                    ->cannotBeOverwritten()
+                    ->defaultValue(['dashboard', 'settings'])
+                ->end()
+            ->end()
+        ->end()
+    ->end()
+    ;
+}
+```
+
+```php
+<?php
+// YourBundle/DependencyInjection/CoreShopYourBundleExtension.php
+
+public function load(array $configs, ContainerBuilder $container): void
+{
+    // ...
+
+    if (array_key_exists('pimcore_admin', $configs)) {
+        $this->registerPimcoreResources('coreshop_your_bundle', $configs['pimcore_admin'], $container);
+    }
+}
+```
+
+The first argument to `registerPimcoreResources()` is your application name, and every permission entry is
+prefixed with it. The example above declares `coreshop_your_bundle_permission_dashboard` and
+`coreshop_your_bundle_permission_settings`, both installed into the permission group
+`coreshop_permission_group_coreshop_your_bundle`.
+
+Use the same identifier when you check the permission:
+
+```php
+$menuItem->setAttribute('permission', 'coreshop_your_bundle_permission_dashboard');
+```
+
+```php
+$user->isAllowed('coreshop_your_bundle_permission_dashboard');
+```
+
+## Classic admin keys are ignored, not rejected
+
+The `pimcore_admin` section used to carry the classic ExtJS admin's asset registration as well (`js`, `css`,
+`editmode_js`, `editmode_css`). Those keys no longer do anything on 2026.x, but `registerPimcoreResources()`
+never looks at them rather than rejecting them, so a bundle that still declares them keeps working without
+changes. Only the backend-relevant keys are read:
+
+| Key | Purpose |
+| --- | --- |
+| `permissions` | Pimcore user-permission definitions |
+| `install.documents` | Documents installed by `PimcoreDocumentsInstaller` |
+| `install.image_thumbnails` | Thumbnail configs installed by `PimcoreImageThumbnailsInstaller` |
+| `install.sql` | SQL files run by `SqlInstaller` |
+
+Install types are not validated. A type whose installer no longer exists — `grid_config` and `routes` were
+the two the classic admin removal took — is written to a container parameter that nobody reads, so declaring
+one is inert rather than an error.
+
+The section name stays `pimcore_admin`, deliberately and permanently. It is a historical name — the section
+configures backend resources, not the classic admin UI — but bundles outside the core declare
+`pimcore_admin: { permissions: [...] }` and call `registerPimcoreResources()` verbatim, so neither the key
+nor the method is renamed, aliased or deprecated. Please do not "clean it up".
+
+## Installing the declarations
+
+Declarations are written to Pimcore by the installers behind:
+
+```bash
+$ bin/console coreshop:resources:install
+```
+
+Restricting the run to a single application installs only that application's declarations:
+
+```bash
+$ bin/console coreshop:resources:install -a coreshop_your_bundle
+```
+
+The permission installer is idempotent — permissions that already exist are skipped, so it is safe to run on
+every deployment. It never removes permission definitions; if you drop a permission from your bundle, ship a
+migration that deletes the row from `users_permission_definitions`.

--- a/src/CoreShop/Bundle/AddressBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/AddressBundle/DependencyInjection/Configuration.php
@@ -66,6 +66,8 @@ final class Configuration implements ConfigurationInterface
         $this->addStack($rootNode);
         $this->addModelsSection($rootNode);
 
+        $this->addPimcoreResourcesSection($rootNode);
+
         return $treeBuilder;
     }
 
@@ -253,4 +255,19 @@ final class Configuration implements ConfigurationInterface
         ;
     }
 
+    private function addPimcoreResourcesSection(ArrayNodeDefinition $node): void
+    {
+        $node->children()
+            ->arrayNode('pimcore_admin')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->scalarNode('permissions')
+                        ->cannotBeOverwritten()
+                        ->defaultValue(['country', 'state', 'zone'])
+                    ->end()
+                ->end()
+            ->end()
+        ->end()
+        ;
+    }
 }

--- a/src/CoreShop/Bundle/AddressBundle/DependencyInjection/CoreShopAddressExtension.php
+++ b/src/CoreShop/Bundle/AddressBundle/DependencyInjection/CoreShopAddressExtension.php
@@ -66,6 +66,10 @@ final class CoreShopAddressExtension extends AbstractModelExtension implements P
         );
         $this->registerPimcoreModels('coreshop', $configs['pimcore'], $container);
 
+        if (array_key_exists('pimcore_admin', $configs)) {
+            $this->registerPimcoreResources('coreshop', $configs['pimcore_admin'], $container);
+        }
+
         if (array_key_exists('stack', $configs)) {
             $this->registerStack('coreshop', $configs['stack'], $container);
         }

--- a/src/CoreShop/Bundle/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/CoreBundle/DependencyInjection/Configuration.php
@@ -44,6 +44,8 @@ final class Configuration implements ConfigurationInterface
         $this->addModelsSection($rootNode);
         $this->addCheckoutConfigurationSection($rootNode);
 
+        $this->addPimcoreResourcesSection($rootNode);
+
         return $treeBuilder;
     }
 
@@ -116,6 +118,22 @@ final class Configuration implements ConfigurationInterface
                             ->end()
                         ->end()
 
+                    ->end()
+                ->end()
+            ->end()
+        ->end()
+        ;
+    }
+
+    private function addPimcoreResourcesSection(ArrayNodeDefinition $node): void
+    {
+        $node->children()
+            ->arrayNode('pimcore_admin')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->scalarNode('permissions')
+                        ->cannotBeOverwritten()
+                        ->defaultValue(['settings', 'ctc_assign_to_new', 'ctc_assign_to_existing'])
                     ->end()
                 ->end()
             ->end()

--- a/src/CoreShop/Bundle/CoreBundle/DependencyInjection/CoreShopCoreExtension.php
+++ b/src/CoreShop/Bundle/CoreBundle/DependencyInjection/CoreShopCoreExtension.php
@@ -72,6 +72,10 @@ final class CoreShopCoreExtension extends AbstractModelExtension implements Prep
          */
         $this->registerDependantBundles('coreshop', [PimcoreCustomReportsBundle::class], $container);
 
+        if (array_key_exists('pimcore_admin', $configs)) {
+            $this->registerPimcoreResources('coreshop', $configs['pimcore_admin'], $container);
+        }
+
         $container->setParameter('coreshop.after_logout_redirect_route', $configs['after_logout_redirect_route']);
 
         $bundles = $container->getParameter('kernel.bundles');

--- a/src/CoreShop/Bundle/CurrencyBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/CurrencyBundle/DependencyInjection/Configuration.php
@@ -49,6 +49,8 @@ final class Configuration implements ConfigurationInterface
         ;
         $this->addModelsSection($rootNode);
 
+        $this->addPimcoreResourcesSection($rootNode);
+
         return $treeBuilder;
     }
 
@@ -107,4 +109,19 @@ final class Configuration implements ConfigurationInterface
         ;
     }
 
+    private function addPimcoreResourcesSection(ArrayNodeDefinition $node): void
+    {
+        $node->children()
+            ->arrayNode('pimcore_admin')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->scalarNode('permissions')
+                        ->cannotBeOverwritten()
+                        ->defaultValue(['currency', 'exchange_rate'])
+                    ->end()
+                ->end()
+            ->end()
+        ->end()
+        ;
+    }
 }

--- a/src/CoreShop/Bundle/CurrencyBundle/DependencyInjection/CoreShopCurrencyExtension.php
+++ b/src/CoreShop/Bundle/CurrencyBundle/DependencyInjection/CoreShopCurrencyExtension.php
@@ -55,6 +55,10 @@ final class CoreShopCurrencyExtension extends AbstractModelExtension implements 
 
         $this->registerResources('coreshop', CoreShopResourceBundle::DRIVER_DOCTRINE_ORM, $configs['resources'], $container);
 
+        if (array_key_exists('pimcore_admin', $configs)) {
+            $this->registerPimcoreResources('coreshop', $configs['pimcore_admin'], $container);
+        }
+
         $bundles = $container->getParameter('kernel.bundles');
 
         if (array_key_exists('PimcoreDataHubBundle', $bundles)) {

--- a/src/CoreShop/Bundle/CustomerBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/CustomerBundle/DependencyInjection/Configuration.php
@@ -47,6 +47,8 @@ final class Configuration implements ConfigurationInterface
         $this->addStack($rootNode);
         $this->addModelsSection($rootNode);
 
+        $this->addPimcoreResourcesSection($rootNode);
+
         return $treeBuilder;
     }
 
@@ -140,4 +142,19 @@ final class Configuration implements ConfigurationInterface
         ;
     }
 
+    private function addPimcoreResourcesSection(ArrayNodeDefinition $node): void
+    {
+        $node->children()
+            ->arrayNode('pimcore_admin')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->scalarNode('permissions')
+                        ->cannotBeOverwritten()
+                        ->defaultValue(['customer_list', 'customer_group_list'])
+                    ->end()
+                ->end()
+            ->end()
+        ->end()
+        ;
+    }
 }

--- a/src/CoreShop/Bundle/CustomerBundle/DependencyInjection/CoreShopCustomerExtension.php
+++ b/src/CoreShop/Bundle/CustomerBundle/DependencyInjection/CoreShopCustomerExtension.php
@@ -39,6 +39,10 @@ final class CoreShopCustomerExtension extends AbstractModelExtension
         $this->registerPimcoreModels('coreshop', $configs['pimcore'], $container);
         $this->registerStack('coreshop', $configs['stack'], $container);
 
+        if (array_key_exists('pimcore_admin', $configs)) {
+            $this->registerPimcoreResources('coreshop', $configs['pimcore_admin'], $container);
+        }
+
         $container->setParameter('coreshop.customer.security.login_identifier', $configs['login_identifier']);
 
         $loader->load('services.yml');

--- a/src/CoreShop/Bundle/FrontendBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/FrontendBundle/DependencyInjection/Configuration.php
@@ -53,6 +53,7 @@ final class Configuration implements ConfigurationInterface
 
         $this->addCategorySection($rootNode);
         $this->addControllerSection($rootNode);
+        $this->addPimcoreResourcesSection($rootNode);
 
         return $treeBuilder;
     }
@@ -105,4 +106,30 @@ final class Configuration implements ConfigurationInterface
         ;
     }
 
+    private function addPimcoreResourcesSection(ArrayNodeDefinition $node): void
+    {
+        $node->children()
+            ->arrayNode('pimcore_admin')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->arrayNode('install')
+                        ->addDefaultsIfNotSet()
+                        ->children()
+                            ->arrayNode('documents')
+                                ->treatNullLike([])
+                                ->scalarPrototype()->end()
+                                ->defaultValue(['@CoreShopFrontendBundle/Resources/install/pimcore/documents.yml'])
+                            ->end()
+                            ->arrayNode('image_thumbnails')
+                                ->treatNullLike([])
+                                ->scalarPrototype()->end()
+                                ->defaultValue(['@CoreShopFrontendBundle/Resources/install/pimcore/image-thumbnails.yml'])
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ->end()
+        ;
+    }
 }

--- a/src/CoreShop/Bundle/FrontendBundle/DependencyInjection/CoreShopFrontendExtension.php
+++ b/src/CoreShop/Bundle/FrontendBundle/DependencyInjection/CoreShopFrontendExtension.php
@@ -48,6 +48,10 @@ final class CoreShopFrontendExtension extends AbstractModelExtension
         $container->setParameter('coreshop.frontend.category.default_sort_name', $configs['category']['default_sort_name']);
         $container->setParameter('coreshop.frontend.category.default_sort_direction', $configs['category']['default_sort_direction']);
 
+        if (array_key_exists('pimcore_admin', $configs)) {
+            $this->registerPimcoreResources('coreshop', $configs['pimcore_admin'], $container);
+        }
+
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
     }

--- a/src/CoreShop/Bundle/IndexBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/IndexBundle/DependencyInjection/Configuration.php
@@ -54,6 +54,8 @@ final class Configuration implements ConfigurationInterface
         $this->addModelsSection($rootNode);
         $this->addIndexColumnsTypeSection($rootNode);
 
+        $this->addPimcoreResourcesSection($rootNode);
+
         return $treeBuilder;
     }
 
@@ -161,6 +163,22 @@ final class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
             ->end()
+        ;
+    }
+
+    private function addPimcoreResourcesSection(ArrayNodeDefinition $node): void
+    {
+        $node->children()
+            ->arrayNode('pimcore_admin')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->scalarNode('permissions')
+                        ->cannotBeOverwritten()
+                        ->defaultValue(['index', 'filter'])
+                    ->end()
+                ->end()
+            ->end()
+        ->end()
         ;
     }
 }

--- a/src/CoreShop/Bundle/IndexBundle/DependencyInjection/CoreShopIndexExtension.php
+++ b/src/CoreShop/Bundle/IndexBundle/DependencyInjection/CoreShopIndexExtension.php
@@ -77,6 +77,10 @@ final class CoreShopIndexExtension extends AbstractModelExtension implements Pre
 
         $this->registerResources('coreshop', CoreShopResourceBundle::DRIVER_DOCTRINE_ORM, $configs['resources'], $container);
 
+        if (array_key_exists('pimcore_admin', $configs)) {
+            $this->registerPimcoreResources('coreshop', $configs['pimcore_admin'], $container);
+        }
+
         $bundles = $container->getParameter('kernel.bundles');
 
         if (isset($configs['mapping_types'])) {

--- a/src/CoreShop/Bundle/MessengerBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/MessengerBundle/DependencyInjection/Configuration.php
@@ -45,7 +45,24 @@ final class Configuration implements ConfigurationInterface
             ->end()
         ;
 
+        $this->addPimcoreResourcesSection($rootNode);
+
         return $treeBuilder;
     }
 
+    private function addPimcoreResourcesSection(ArrayNodeDefinition $node): void
+    {
+        $node->children()
+            ->arrayNode('pimcore_admin')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->scalarNode('permissions')
+                        ->cannotBeOverwritten()
+                        ->defaultValue(['messenger'])
+                    ->end()
+                ->end()
+            ->end()
+        ->end()
+        ;
+    }
 }

--- a/src/CoreShop/Bundle/MessengerBundle/DependencyInjection/CoreShopMessengerExtension.php
+++ b/src/CoreShop/Bundle/MessengerBundle/DependencyInjection/CoreShopMessengerExtension.php
@@ -32,6 +32,10 @@ final class CoreShopMessengerExtension extends AbstractPimcoreExtension
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
+        if (array_key_exists('pimcore_admin', $config)) {
+            $this->registerPimcoreResources('coreshop', $config['pimcore_admin'], $container);
+        }
+
         $bundles = $container->getParameter('kernel.bundles');
 
         if (!array_key_exists('CoreShopCoreBundle', $bundles)) {

--- a/src/CoreShop/Bundle/NotificationBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/NotificationBundle/DependencyInjection/Configuration.php
@@ -37,6 +37,8 @@ final class Configuration implements ConfigurationInterface
 
         $this->addModelsSection($rootNode);
 
+        $this->addPimcoreResourcesSection($rootNode);
+
         return $treeBuilder;
     }
 
@@ -71,4 +73,19 @@ final class Configuration implements ConfigurationInterface
         ;
     }
 
+    private function addPimcoreResourcesSection(ArrayNodeDefinition $node): void
+    {
+        $node->children()
+            ->arrayNode('pimcore_admin')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->scalarNode('permissions')
+                        ->cannotBeOverwritten()
+                        ->defaultValue(['notification'])
+                    ->end()
+                ->end()
+            ->end()
+        ->end()
+        ;
+    }
 }

--- a/src/CoreShop/Bundle/NotificationBundle/DependencyInjection/CoreShopNotificationExtension.php
+++ b/src/CoreShop/Bundle/NotificationBundle/DependencyInjection/CoreShopNotificationExtension.php
@@ -39,6 +39,10 @@ final class CoreShopNotificationExtension extends AbstractModelExtension
 
         $this->registerResources('coreshop', CoreShopResourceBundle::DRIVER_DOCTRINE_ORM, $configs['resources'], $container);
 
+        if (array_key_exists('pimcore_admin', $configs)) {
+            $this->registerPimcoreResources('coreshop', $configs['pimcore_admin'], $container);
+        }
+
         $bundles = $container->getParameter('kernel.bundles');
 
         if (array_key_exists('PimcoreStudioUiBundle', $bundles)) {

--- a/src/CoreShop/Bundle/OrderBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/OrderBundle/DependencyInjection/Configuration.php
@@ -80,6 +80,8 @@ final class Configuration implements ConfigurationInterface
         $this->addModelsSection($rootNode);
         $this->addStack($rootNode);
 
+        $this->addPimcoreResourcesSection($rootNode);
+
         return $treeBuilder;
     }
 
@@ -400,4 +402,30 @@ final class Configuration implements ConfigurationInterface
         ;
     }
 
+    private function addPimcoreResourcesSection(ArrayNodeDefinition $node): void
+    {
+        $node->children()
+            ->arrayNode('pimcore_admin')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->scalarNode('permissions')
+                        ->cannotBeOverwritten()
+                        ->defaultValue([
+                            'cart_price_rule',
+                            'order_list',
+                            'order_detail',
+                            'order_create',
+                            'quote_list',
+                            'quote_detail',
+                            'quote_create',
+                            'cart_list',
+                            'cart_detail',
+                            'cart_create',
+                        ])
+                    ->end()
+                ->end()
+            ->end()
+        ->end()
+        ;
+    }
 }

--- a/src/CoreShop/Bundle/OrderBundle/DependencyInjection/CoreShopOrderExtension.php
+++ b/src/CoreShop/Bundle/OrderBundle/DependencyInjection/CoreShopOrderExtension.php
@@ -78,6 +78,10 @@ final class CoreShopOrderExtension extends AbstractModelExtension implements Pre
         $this->registerResources('coreshop', CoreShopResourceBundle::DRIVER_DOCTRINE_ORM, $configs['resources'], $container);
         $this->registerPimcoreModels('coreshop', $configs['pimcore'], $container);
 
+        if (array_key_exists('pimcore_admin', $configs)) {
+            $this->registerPimcoreResources('coreshop', $configs['pimcore_admin'], $container);
+        }
+
         if (array_key_exists('stack', $configs)) {
             $this->registerStack('coreshop', $configs['stack'], $container);
         }

--- a/src/CoreShop/Bundle/PaymentBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/PaymentBundle/DependencyInjection/Configuration.php
@@ -62,6 +62,8 @@ final class Configuration implements ConfigurationInterface
         ;
         $this->addModelsSection($rootNode);
 
+        $this->addPimcoreResourcesSection($rootNode);
+
         return $treeBuilder;
     }
 
@@ -196,4 +198,19 @@ final class Configuration implements ConfigurationInterface
         ;
     }
 
+    private function addPimcoreResourcesSection(ArrayNodeDefinition $node): void
+    {
+        $node->children()
+            ->arrayNode('pimcore_admin')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->scalarNode('permissions')
+                        ->cannotBeOverwritten()
+                        ->defaultValue(['payment_provider', 'payment_provider_rule'])
+                    ->end()
+                ->end()
+            ->end()
+        ->end()
+        ;
+    }
 }

--- a/src/CoreShop/Bundle/PaymentBundle/DependencyInjection/CoreShopPaymentExtension.php
+++ b/src/CoreShop/Bundle/PaymentBundle/DependencyInjection/CoreShopPaymentExtension.php
@@ -60,6 +60,10 @@ final class CoreShopPaymentExtension extends AbstractModelExtension implements P
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
 
         $this->registerResources('coreshop', CoreShopResourceBundle::DRIVER_DOCTRINE_ORM, $configs['resources'], $container);
+
+        if (array_key_exists('pimcore_admin', $configs)) {
+            $this->registerPimcoreResources('coreshop', $configs['pimcore_admin'], $container);
+        }
         //$this->registerPimcoreModels('coreshop', $configs['pimcore'], $container);
 
         $bundles = $container->getParameter('kernel.bundles');

--- a/src/CoreShop/Bundle/PimcoreBundle/DependencyInjection/Extension/AbstractPimcoreExtension.php
+++ b/src/CoreShop/Bundle/PimcoreBundle/DependencyInjection/Extension/AbstractPimcoreExtension.php
@@ -17,8 +17,78 @@ declare(strict_types=1);
 
 namespace CoreShop\Bundle\PimcoreBundle\DependencyInjection\Extension;
 
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 
 abstract class AbstractPimcoreExtension extends Extension
 {
+    /**
+     * Registers a bundle's `pimcore_admin` configuration section.
+     *
+     * Two kinds of declaration are read, both consumed by the installers behind
+     * `coreshop:resources:install`:
+     *
+     *  - `permissions`: Pimcore user-permission definitions. Every entry is prefixed with the
+     *    application name, so `permissions: [order_list]` under the application `coreshop` declares
+     *    `coreshop_permission_order_list`, installed into the group `coreshop_permission_group_coreshop`.
+     *  - `install`: resources to install, keyed by installer type (`documents`, `image_thumbnails`,
+     *    `sql`). Each type maps to a list of file references. Types are not validated here - a type with
+     *    no installer behind it simply ends up in a container parameter nobody reads.
+     *
+     * The classic ExtJS admin's asset keys (`js`, `css`, `editmode_js`, `editmode_css`) are not read at
+     * all, so bundles that still carry their pre-2026 configuration keep working unchanged.
+     *
+     * The section is named `pimcore_admin` for historical reasons only - it configures backend resources,
+     * not the classic admin UI. Do not rename it and do not rename this method: bundles outside this
+     * repository declare `pimcore_admin: { permissions: [...] }` and call `registerPimcoreResources()`
+     * verbatim, and both names are kept deliberately so that code keeps working.
+     */
+    protected function registerPimcoreResources(string $applicationName, array $bundleResources, ContainerBuilder $container): void
+    {
+        if (array_key_exists('install', $bundleResources)) {
+            foreach ($bundleResources['install'] as $type => $value) {
+                $applicationParameter = sprintf('%s.pimcore.admin.install.%s', $applicationName, $type);
+                $globalParameter = sprintf('coreshop.all.pimcore.admin.install.%s', $type);
+
+                foreach ([$applicationParameter, $globalParameter] as $containerParameter) {
+                    /**
+                     * @var array $resources
+                     */
+                    $resources = $container->hasParameter($containerParameter) ? $container->getParameter($containerParameter) : [];
+
+                    $container->setParameter($containerParameter, array_merge($resources, array_values($value)));
+                }
+            }
+        }
+
+        if (array_key_exists('permissions', $bundleResources)) {
+            $applicationParameter = sprintf('%s.permissions', $applicationName);
+            $globalParameter = 'coreshop.all.permissions';
+
+            /**
+             * @var string[] $applicationPermissions
+             */
+            $applicationPermissions = $container->hasParameter($applicationParameter) ? $container->getParameter($applicationParameter) : [];
+
+            /**
+             * @var array<string, string[]> $globalPermissions
+             */
+            $globalPermissions = $container->hasParameter($globalParameter) ? $container->getParameter($globalParameter) : [];
+
+            $identifiers = [];
+
+            foreach ($bundleResources['permissions'] as $permission) {
+                $identifiers[] = sprintf('%s_permission_%s', $applicationName, $permission);
+            }
+
+            $globalPermissions[$applicationName] = array_values(array_unique(
+                array_merge($globalPermissions[$applicationName] ?? [], $identifiers),
+            ));
+
+            $container->setParameter($globalParameter, $globalPermissions);
+            $container->setParameter($applicationParameter, array_values(array_unique(
+                array_merge($applicationPermissions, $identifiers),
+            )));
+        }
+    }
 }

--- a/src/CoreShop/Bundle/ProductBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/ProductBundle/DependencyInjection/Configuration.php
@@ -78,6 +78,8 @@ final class Configuration implements ConfigurationInterface
         $this->addModelsSection($rootNode);
         $this->addStack($rootNode);
 
+        $this->addPimcoreResourcesSection($rootNode);
+
         return $treeBuilder;
     }
 
@@ -376,4 +378,19 @@ final class Configuration implements ConfigurationInterface
         ;
     }
 
+    private function addPimcoreResourcesSection(ArrayNodeDefinition $node): void
+    {
+        $node->children()
+            ->arrayNode('pimcore_admin')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->scalarNode('permissions')
+                        ->cannotBeOverwritten()
+                        ->defaultValue(['product_price_rule', 'product_unit'])
+                    ->end()
+                ->end()
+            ->end()
+        ->end()
+        ;
+    }
 }

--- a/src/CoreShop/Bundle/ProductBundle/DependencyInjection/CoreShopProductExtension.php
+++ b/src/CoreShop/Bundle/ProductBundle/DependencyInjection/CoreShopProductExtension.php
@@ -61,6 +61,10 @@ final class CoreShopProductExtension extends AbstractModelExtension implements P
         $this->registerResources('coreshop', CoreShopResourceBundle::DRIVER_DOCTRINE_ORM, $configs['resources'], $container);
         $this->registerPimcoreModels('coreshop', $configs['pimcore'], $container);
 
+        if (array_key_exists('pimcore_admin', $configs)) {
+            $this->registerPimcoreResources('coreshop', $configs['pimcore_admin'], $container);
+        }
+
         if (array_key_exists('stack', $configs)) {
             $this->registerStack('coreshop', $configs['stack'], $container);
         }

--- a/src/CoreShop/Bundle/ShippingBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/ShippingBundle/DependencyInjection/Configuration.php
@@ -55,6 +55,8 @@ final class Configuration implements ConfigurationInterface
 
         $this->addModelsSection($rootNode);
 
+        $this->addPimcoreResourcesSection($rootNode);
+
         return $treeBuilder;
     }
 
@@ -151,4 +153,19 @@ final class Configuration implements ConfigurationInterface
         ;
     }
 
+    private function addPimcoreResourcesSection(ArrayNodeDefinition $node): void
+    {
+        $node->children()
+            ->arrayNode('pimcore_admin')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->scalarNode('permissions')
+                        ->cannotBeOverwritten()
+                        ->defaultValue(['carrier', 'shipping_rule'])
+                    ->end()
+                ->end()
+            ->end()
+        ->end()
+        ;
+    }
 }

--- a/src/CoreShop/Bundle/ShippingBundle/DependencyInjection/CoreShopShippingExtension.php
+++ b/src/CoreShop/Bundle/ShippingBundle/DependencyInjection/CoreShopShippingExtension.php
@@ -69,6 +69,10 @@ final class CoreShopShippingExtension extends AbstractModelExtension implements 
 
         $this->registerResources('coreshop', CoreShopResourceBundle::DRIVER_DOCTRINE_ORM, $configs['resources'], $container);
 
+        if (array_key_exists('pimcore_admin', $configs)) {
+            $this->registerPimcoreResources('coreshop', $configs['pimcore_admin'], $container);
+        }
+
         $alias = new Alias($configs['default_resolver']);
         $alias->setPublic(true);
 

--- a/src/CoreShop/Bundle/StoreBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/StoreBundle/DependencyInjection/Configuration.php
@@ -41,6 +41,8 @@ final class Configuration implements ConfigurationInterface
         ;
         $this->addModelsSection($rootNode);
 
+        $this->addPimcoreResourcesSection($rootNode);
+
         return $treeBuilder;
     }
 
@@ -81,4 +83,19 @@ final class Configuration implements ConfigurationInterface
         ;
     }
 
+    private function addPimcoreResourcesSection(ArrayNodeDefinition $node): void
+    {
+        $node->children()
+            ->arrayNode('pimcore_admin')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->scalarNode('permissions')
+                        ->cannotBeOverwritten()
+                        ->defaultValue(['store'])
+                    ->end()
+                ->end()
+            ->end()
+        ->end()
+        ;
+    }
 }

--- a/src/CoreShop/Bundle/StoreBundle/DependencyInjection/CoreShopStoreExtension.php
+++ b/src/CoreShop/Bundle/StoreBundle/DependencyInjection/CoreShopStoreExtension.php
@@ -59,6 +59,10 @@ final class CoreShopStoreExtension extends AbstractModelExtension implements Pre
 
         $this->registerResources('coreshop', CoreShopResourceBundle::DRIVER_DOCTRINE_ORM, $configs['resources'], $container);
 
+        if (array_key_exists('pimcore_admin', $configs)) {
+            $this->registerPimcoreResources('coreshop', $configs['pimcore_admin'], $container);
+        }
+
         $bundles = $container->getParameter('kernel.bundles');
 
         if (array_key_exists('PimcoreDataHubBundle', $bundles)) {

--- a/src/CoreShop/Bundle/TaxationBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/TaxationBundle/DependencyInjection/Configuration.php
@@ -52,6 +52,8 @@ final class Configuration implements ConfigurationInterface
 
         $this->addModelsSection($rootNode);
 
+        $this->addPimcoreResourcesSection($rootNode);
+
         return $treeBuilder;
     }
 
@@ -164,4 +166,19 @@ final class Configuration implements ConfigurationInterface
         ;
     }
 
+    private function addPimcoreResourcesSection(ArrayNodeDefinition $node): void
+    {
+        $node->children()
+            ->arrayNode('pimcore_admin')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->scalarNode('permissions')
+                        ->cannotBeOverwritten()
+                        ->defaultValue(['tax_rate', 'tax_rule_group'])
+                    ->end()
+                ->end()
+            ->end()
+        ->end()
+        ;
+    }
 }

--- a/src/CoreShop/Bundle/TaxationBundle/DependencyInjection/CoreShopTaxationExtension.php
+++ b/src/CoreShop/Bundle/TaxationBundle/DependencyInjection/CoreShopTaxationExtension.php
@@ -50,6 +50,10 @@ final class CoreShopTaxationExtension extends AbstractModelExtension implements 
         $this->registerResources('coreshop', CoreShopResourceBundle::DRIVER_DOCTRINE_ORM, $configs['resources'], $container);
         $this->registerPimcoreModels('coreshop', $configs['pimcore'], $container);
 
+        if (array_key_exists('pimcore_admin', $configs)) {
+            $this->registerPimcoreResources('coreshop', $configs['pimcore_admin'], $container);
+        }
+
         $bundles = $container->getParameter('kernel.bundles');
 
         if (array_key_exists('PimcoreDataHubBundle', $bundles)) {


### PR DESCRIPTION
Fixes #3144

## What this is

Commit 720355156f (classic admin removal) removed more than the classic admin. It deleted the whole `pimcore_admin` configuration section and the `registerPimcoreResources()` helper that read it — but despite the name, that section was never only about the ExtJS admin. Alongside the asset keys it carries the declarations that drive CoreShop's resource installers.

This PR restores the section and the helper with the classic-admin parts left out, rather than inventing a replacement API. The permission regression in #3144 is the visible symptom; it is not the only one.

## Four installers were starved, not one

All four are still registered as `coreshop.resource.installer` and still read their container parameters. Nothing writes those parameters anymore, and every installer body sits behind a `hasParameter()` check, so they fail silently — `coreshop:resources:install` does not even print their success lines.

| Installer | Parameter | Effect on 2026.x |
| --- | --- | --- |
| `PimcorePermissionInstaller` | `coreshop.all.permissions` | No `coreshop_permission_*` rows. Non-admin users cannot be granted any CoreShop permission; every `isAllowed('coreshop_permission_*')` gate fails. `MainMenuBuilder` alone checks 32 of them, plus `MessageController`, `ListMessagesController`, `OrderCreationController`. |
| `PimcoreDocumentsInstaller` | `coreshop.all.pimcore.admin.install.documents` | The frontend's email and page documents are never created, although `FrontendBundle/Resources/install/pimcore/documents.yml` still ships. |
| `PimcoreImageThumbnailsInstaller` | `coreshop.all.pimcore.admin.install.image_thumbnails` | The 12 `coreshop_*` thumbnail configs are never written, although `image-thumbnails.yml` still ships. |
| `SqlInstaller` | `coreshop.all.pimcore.admin.install.sql` | The `install.sql` declaration path is gone for bundles that used it. |

## What is restored, what stays gone

`registerPimcoreResources(string $applicationName, array $bundleResources, ContainerBuilder $container)` returns to `AbstractPimcoreExtension` with the same name, signature and visibility, and reads:

- `permissions` — prefixed with the application name, so `permissions: [order_list]` under `coreshop` declares `coreshop_permission_order_list` in group `coreshop_permission_group_coreshop`.
- `install.<type>` — `documents`, `image_thumbnails`, `sql`.

The classic ExtJS admin's asset keys — `js`, `css`, `editmode_js`, `editmode_css` — are not read at all. They are **not rejected either**: the method simply never looks at any key other than `permissions` and `install`, which is what makes old bundle code work untouched.

Install types are not validated. `grid_config` and `routes` lost their installers with the classic admin removal (`PimcoreGridConfigInstaller`, and `PimcoreRoutesInstaller` which static routes no longer need now that the frontend ships native Symfony routes), so a bundle still declaring them writes a container parameter that nobody reads — inert, not an error. There is deliberately no list of obsolete type names in the code: nothing on 2026.x consumes them, so there is nothing to tolerate and no reason to name them.

One difference from 5.1: the helper now lives entirely on `AbstractPimcoreExtension` instead of being split across it and an `AbstractModelExtension` override. Bundles that do not extend `AbstractModelExtension` can therefore declare permissions too — `CoreShopMessengerExtension` is exactly such a case, which is why its permission previously needed the hand-written migration `Version20240421093216`.

## Do untouched 5.1-era bundles work on 2026.x?

Yes — verified concretely, not assumed. This is the maintainer's implicit goal and it means the 14 migrated bundles can simply **restore what they removed** rather than adopt anything new.

I added a throwaway probe bundle carrying the verbatim 5.1-era shape — a `pimcore_admin` node declaring `js` and `css` *alongside* `permissions`, and an extension with the unmodified `if (array_key_exists('pimcore_admin', $configs)) { $this->registerPimcoreResources(...); }` call site — registered it in the kernel, and:

- the container compiled and booted with no config or type errors;
- `debug:container --parameter=coreshop_legacy_probe.permissions` returned `["coreshop_legacy_probe_permission_legacy_dashboard", "coreshop_legacy_probe_permission_legacy_settings"]`;
- `coreshop:resources:install -a coreshop_legacy_probe` installed both, categorised `coreshop_permission_group_coreshop_legacy_probe`;
- the `js` / `css` declarations were ignored without complaint;
- the obsolete `install: { grid_config: ..., routes: ... }` declarations produced only the orphan parameters `coreshop_legacy_probe.pimcore.admin.install.grid_config` / `...routes`, which no installer reads — no config error, and no attempt to resolve their (deliberately non-existent) file references.

A full `coreshop:resources:install` with the probe bundle registered still installed everything: 33 core permissions, 2 probe permissions, 31 documents, 12 thumbnail configs.

The probe bundle was removed again and is not part of this PR.

## Naming: `pimcore_admin` is kept, deliberately and permanently

The key is a misnomer now that the classic admin is gone — the section configures backend resources, not the admin UI. It is kept anyway, and this is a decision rather than an oversight: **no rename, no alias, no deprecation.**

The reason is the whole point of this PR. Bundles outside this repository declare

```yaml
core_shop_your_bundle:
    pimcore_admin:
        permissions: ['dashboard']
```

and call `$this->registerPimcoreResources(...)` verbatim. Renaming either the config key or the method — even with an alias and a deprecation — would put those bundles back in the position this PR is fixing, and would mean every bundle needs an edit just to silence a warning. So both names stay as they are.

To keep a future reader from "cleaning this up", the reasoning is recorded in three places that a cleanup would pass through: the `registerPimcoreResources()` docblock, the changelog section below, and `docs/03_Bundles/Resource_Bundle/06_User_Permissions.md`.

## Verification

Real install against a real database — MySQL 8, OpenSearch 2.11, Pimcore installed with `vendor/bin/pimcore-install --install-profile 'CoreShop\Bundle\CoreBundle\InstallProfile\CoreShopInstallProfile'`. Before/after measured on the *same* database, differing only by this branch being stashed or applied.

| | before | after |
| --- | --- | --- |
| `coreshop_permission_*` rows | 0 | 33 |
| `documents` rows | 1 | 31 |
| `var/config/image_thumbnails/*.yaml` | 0 | 12 |

Installer output before: only `Classes` and `Dependant Bundles have been installed successfully`. After: those two plus `Documents`, `Image Thumbnails` and `Permissions have been installed successfully`.

Idempotence: a second full run changed nothing — 31 documents, 12 thumbnails, 33 permission rows / 33 distinct keys.

Static analysis: `vendor/bin/phpstan` no errors; `vendor/bin/psalm` no errors; `vendor/bin/ecs check` clean on all 29 changed PHP files and the docs; `bin/console lint:container` OK.

## Also in here

- The 33 core permission declarations, restored to their owning bundles' `Configuration` classes with identifiers and group categories unchanged from 5.1.
- `ProductQuantityPriceRulesBundle`'s declaration is deliberately **not** restored: it declared `notification`, i.e. `coreshop_permission_notification`, which is `NotificationBundle`'s permission and is still declared there. That looks like a 5.1 copy-paste bug.
- `CHANGELOG-2026.1.x.md`: the "Removed" list said the `pimcore_admin` section and `registerPimcoreResources()` were removed outright. Corrected to name only the classic-admin keys, with a new section explaining what stays and why.
- New doc page `docs/03_Bundles/Resource_Bundle/06_User_Permissions.md`.
- `config/reference.php` regenerated for the restored nodes (only the additions; unrelated environment drift such as `default_timezone` was kept out).

## Branch choice: 2026.x only

5.1 is not affected, including installs that skip the classic admin bundle, which 5.1 only *suggests*. Verified three ways: no call site on 5.1 is gated on `PimcoreAdminBundle` (the guard is `array_key_exists('pimcore_admin', $configs)`, a check on CoreShop's own config); the installers are registered in the plain `installer.yml`, not in any `classic_admin.yml`; and running 5.1's `registerPimcoreResources()` against a `ContainerBuilder` whose `kernel.bundles` deliberately contained no `PimcoreAdminBundle`, fed by 5.1's Order/Address/Taxation/Currency `Configuration` classes processed from empty user config, produced the full `coreshop.all.permissions` map from the node defaults alone.

So there is nothing to fix on 5.1 and nothing to upmerge — the regression is specific to what 2026.x removed.
