### PR TITLE
Make Studio shipment/invoice creation modals fully schema-driven

### DIFF
--- a/docs/03_Development/14_Studio/06_OrderBundle/01_Order_Cart_Quote_System.md
+++ b/docs/03_Development/14_Studio/06_OrderBundle/01_Order_Cart_Quote_System.md
@@ -201,77 +201,91 @@ export const CustomTab: React.FC<SaleTabProps> = () => {
 }
 ```
 
-## Modal Field Extensions
+## Extending the Creation Modals
 
-Modal Field Extensions allow bundles to inject additional fields into action modals.
+The shipment, invoice and payment creation modals are rendered entirely from a
+form schema, so they are extended from PHP with plain Symfony **form type
+extensions** — no JavaScript and no frontend registry involved.
 
-### Architecture
+### Modals and their form types
 
-```typescript
-export interface ModalFieldExtension {
-  (props: any): React.ReactNode
-}
+| Modal | Block prefix | Form type | Per-item entry type |
+|-------|--------------|-----------|---------------------|
+| CreateShipmentModal | `coreshop_order_shipment_creation` | `Form\Type\Studio\OrderShipmentCreationType` | `Form\Type\Studio\OrderShipmentCreationItemsType` |
+| CreateInvoiceModal | `coreshop_order_invoice_creation` | `Form\Type\Studio\OrderInvoiceCreationType` | `Form\Type\Studio\OrderInvoiceCreationItemsType` |
+| CreatePaymentModal | `coreshop_order_payment_creation` | `Form\Type\Studio\OrderPaymentCreationType` | — |
 
-export class ModalFieldExtensionRegistry {
-  register(modalKey: string, extension: ModalFieldExtension): void
-  getFields(modalKey: string, props: any): React.ReactNode[]
-  hasExtensions(modalKey: string): boolean
-}
-```
+> Note the `Studio` namespace. The types without it back the classic ExtJS
+> wizards; extending those has no effect in Studio, and vice versa.
 
-### Available Modal Keys
+### Adding a modal-level field
 
-| Key | Modal | Description |
-|-----|-------|-------------|
-| `create-shipment` | CreateShipmentModal | Create new shipment |
-| `create-payment` | CreatePaymentModal | Create new payment |
-| `create-invoice` | CreateInvoiceModal | Create new invoice |
+Extend the root type. CoreBundle does exactly this to add the carrier select to
+the shipment modal:
 
-### Adding Modal Fields
+```php
+final class StudioOrderShipmentCreationTypeExtension extends AbstractTypeExtension
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('carrier', CarrierChoiceType::class, [
+            'label' => 'coreshop_carrier',
+            'priority' => 400,
+        ]);
+    }
 
-```typescript
-// src/CoreShop/Bundle/YourBundle/Resources/assets/pimcore-studio/src/modules/sales/extensions/CustomExtension.tsx
-
-import React from 'react'
-import { Form, Input } from 'antd'
-import { container } from '@pimcore/studio-ui-bundle'
-import { ModalFieldExtensionRegistry } from '@coreshop/order/src/modules/sales/extensions'
-import { extensionServiceIds } from '@coreshop/order/src/modules/sales/extensions/service-ids'
-
-// Extension component - receives form instance and onChange
-const TrackingNumberExtension: React.FC<{
-  form: any
-  onChange: (values: any) => void
-}> = ({ form, onChange }) => {
-  return (
-    <Form.Item
-      label="Tracking Number"
-      name="trackingNumber"
-    >
-      <Input
-        placeholder="Enter tracking number"
-        onChange={(e) => onChange({ trackingNumber: e.target.value })}
-      />
-    </Form.Item>
-  )
-}
-
-// Registration
-const plugin: IAbstractPlugin = {
-    name: 'your-bundle',
-
-    onInit() {
-        const registry = container.get<ModalFieldExtensionRegistry>(
-            extensionServiceIds.modalFieldExtensionRegistry
-        )
-
-        // Add field to create-shipment modal
-        registry.register('create-shipment', (props) => (
-            <TrackingNumberExtension {...props} />
-        ))
+    public static function getExtendedTypes(): iterable
+    {
+        return [OrderShipmentCreationType::class];
     }
 }
 ```
+
+### Adding a per-item column
+
+Extend the entry type. The field becomes an extra column in the items grid,
+because `GridCollectionWidget` derives its columns from the collection
+prototype in the generated schema:
+
+```php
+final class OrderShipmentCreationItemsTypeExtension extends AbstractTypeExtension
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('stockItem', StockItemChoiceType::class, [
+            'label' => 'coreshop_stock_item',
+            'constraints' => [new NotBlank()],
+        ]);
+    }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [OrderShipmentCreationItemsType::class];
+    }
+}
+```
+
+**The field must be added in `buildForm()`.** A field added from a `PRE_SUBMIT`
+listener exists only while handling a submit, so it never reaches the generated
+schema and the modal cannot render a column for it.
+
+### Pre-filling per-item values
+
+The `get-ship-able-items` and `get-invoice-able-items` endpoints dispatch a
+`GenericEvent` (`coreshop.order.shipment.prepare_ship_able` and
+`coreshop.order.invoice.prepare_invoice_able`) that lets a bundle add values to
+each item. Any key matching a form field name is used as that column's initial
+value; keys the form does not declare are dropped before the create request, so
+they are safe to use for internal purposes.
+
+### How values survive the round trip
+
+The modals never reduce an item to a fixed key set. On load they pass the API
+item through and only rename the keys the API and the form spell differently.
+On submit `buildCreationItemPayload()` (`modules/sales/utils/creationItems.ts`)
+keeps exactly the fields the entry type declares, skipping disabled ones —
+Symfony ignores submitted values for those and uses the server-side value
+instead.
 
 ## Order Creation Wizard
 
@@ -472,10 +486,8 @@ OrderBundle/Resources/assets/pimcore-studio/src/
 │   │   ├── registry/
 │   │   │   ├── SaleTabRegistry.ts
 │   │   │   └── ComponentRegistry.ts
-│   │   ├── extensions/
-│   │   │   ├── ModalFieldExtensionRegistry.ts
-│   │   │   ├── service-ids.ts
-│   │   │   └── index.ts
+│   │   ├── utils/
+│   │   │   └── creationItems.ts          # Schema-driven per-item mapping
 │   │   ├── context/
 │   │   │   ├── SaleActionsContext.tsx
 │   │   │   └── ButtonRegistry.tsx

--- a/src/CoreShop/Bundle/OrderBundle/Resources/assets/pimcore-studio/src/modules/sales/components/CreateInvoiceModal.tsx
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/assets/pimcore-studio/src/modules/sales/components/CreateInvoiceModal.tsx
@@ -17,6 +17,10 @@ import { useTranslation } from 'react-i18next'
 import { SchemaForm } from '@coreshop/studio-form'
 import { getErrorMessage, renderApiError } from '@coreshop/resource/src/entities'
 import { formatCurrency } from '@coreshop/pimcore/src/utils'
+import { buildCreationItemPayload, loadCreationItemFields } from '../utils/creationItems'
+import type { CreationItemFields } from '../utils/creationItems'
+
+const BLOCK_PREFIX = 'coreshop_order_invoice_creation'
 
 export interface CreateInvoiceModalProps {
   open: boolean
@@ -30,7 +34,9 @@ export interface CreateInvoiceModalProps {
  * Create Invoice Modal
  *
  * Form fields and items grid rendered via SchemaForm.
- * Columns are defined by OrderInvoiceCreationItemsType (configurable via form types).
+ * Columns are defined by OrderInvoiceCreationItemsType, including fields added
+ * by Symfony form type extensions. Per-item values are therefore never reduced
+ * to a fixed key set — they are passed through as the form schema declares them.
  */
 export const CreateInvoiceModal: React.FC<CreateInvoiceModalProps> = ({
   open,
@@ -44,6 +50,7 @@ export const CreateInvoiceModal: React.FC<CreateInvoiceModalProps> = ({
   const [formData, setFormData] = useState<Record<string, unknown>>({})
   const [loading, setLoading] = useState(false)
   const [loadingItems, setLoadingItems] = useState(false)
+  const [itemFields, setItemFields] = useState<CreationItemFields>([])
 
   // Load invoiceable items and populate formData
   useEffect(() => {
@@ -56,15 +63,17 @@ export const CreateInvoiceModal: React.FC<CreateInvoiceModalProps> = ({
         const data = await response.json()
 
         if (data.success && data.items && Object.keys(data.items).length > 0) {
-          // Map API data (keyed by orderItemId) to form field names
+          setItemFields(await loadCreationItemFields(BLOCK_PREFIX))
+
+          // Rename the API's item keys to the form field names. Everything else
+          // is passed through, so values a bundle contributes through the
+          // "coreshop.order.invoice.prepare_invoice_able" event reach the grid.
           const items: Record<string, any> = {}
           for (const [orderItemId, item] of Object.entries(data.items) as Array<[string, any]>) {
             items[orderItemId] = {
-              orderItemId: item.orderItemId,
-              name: item.name,
+              ...item,
               price: formatCurrency(item.price, currencyCode),
               orderedQuantity: item.quantity,
-              quantityInvoiced: item.quantityInvoiced,
               quantity: item.toInvoice,
               maxQuantity: item.maxToInvoice,
             }
@@ -96,11 +105,7 @@ export const CreateInvoiceModal: React.FC<CreateInvoiceModalProps> = ({
       const itemsToInvoice: Record<string, any> = {}
       for (const [key, item] of Object.entries(itemsObj)) {
         if (item.quantity > 0) {
-          itemsToInvoice[key] = {
-            orderItemId: item.orderItemId,
-            quantity: item.quantity,
-            maxQuantity: item.maxQuantity
-          }
+          itemsToInvoice[key] = buildCreationItemPayload(item, itemFields)
         }
       }
 
@@ -149,7 +154,7 @@ export const CreateInvoiceModal: React.FC<CreateInvoiceModalProps> = ({
       destroyOnClose
     >
       <SchemaForm
-        blockPrefix="coreshop_order_invoice_creation"
+        blockPrefix={BLOCK_PREFIX}
         data={formData}
         onChange={(draft) => setFormData((prev) => ({ ...prev, ...draft }))}
       />

--- a/src/CoreShop/Bundle/OrderBundle/Resources/assets/pimcore-studio/src/modules/sales/components/CreateShipmentModal.tsx
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/assets/pimcore-studio/src/modules/sales/components/CreateShipmentModal.tsx
@@ -17,6 +17,10 @@ import { useTranslation } from 'react-i18next'
 import { SchemaForm } from '@coreshop/studio-form'
 import { getErrorMessage, renderApiError } from '@coreshop/resource/src/entities'
 import { formatCurrency } from '@coreshop/pimcore/src/utils'
+import { buildCreationItemPayload, loadCreationItemFields } from '../utils/creationItems'
+import type { CreationItemFields } from '../utils/creationItems'
+
+const BLOCK_PREFIX = 'coreshop_order_shipment_creation'
 
 export interface CreateShipmentModalProps {
   open: boolean
@@ -31,7 +35,9 @@ export interface CreateShipmentModalProps {
  * Create Shipment Modal
  *
  * Form fields and items grid rendered via SchemaForm.
- * Columns are defined by OrderShipmentCreationItemsType (configurable via form types).
+ * Columns are defined by OrderShipmentCreationItemsType, including fields added
+ * by Symfony form type extensions. Per-item values are therefore never reduced
+ * to a fixed key set — they are passed through as the form schema declares them.
  */
 export const CreateShipmentModal: React.FC<CreateShipmentModalProps> = ({
   open,
@@ -46,6 +52,7 @@ export const CreateShipmentModal: React.FC<CreateShipmentModalProps> = ({
   const [formData, setFormData] = useState<Record<string, unknown>>({})
   const [loading, setLoading] = useState(false)
   const [loadingItems, setLoadingItems] = useState(false)
+  const [itemFields, setItemFields] = useState<CreationItemFields>([])
 
   // Set default carrier and load items when modal opens
   useEffect(() => {
@@ -62,15 +69,17 @@ export const CreateShipmentModal: React.FC<CreateShipmentModalProps> = ({
         const data = await response.json()
 
         if (data.success && data.items && Object.keys(data.items).length > 0) {
-          // Map API data (keyed by orderItemId) to form field names
+          setItemFields(await loadCreationItemFields(BLOCK_PREFIX))
+
+          // Rename the API's item keys to the form field names. Everything else
+          // is passed through, so values a bundle contributes through the
+          // "coreshop.order.shipment.prepare_ship_able" event reach the grid.
           const items: Record<string, any> = {}
           for (const [orderItemId, item] of Object.entries(data.items) as Array<[string, any]>) {
             items[orderItemId] = {
-              orderItemId: item.orderItemId,
-              name: item.name,
+              ...item,
               price: formatCurrency(item.price, currencyCode),
               orderedQuantity: item.quantity,
-              quantityShipped: item.quantityShipped,
               quantity: item.toShip,
               maxQuantity: item.maxToShip,
             }
@@ -100,11 +109,7 @@ export const CreateShipmentModal: React.FC<CreateShipmentModalProps> = ({
       const itemsToShip: Record<string, any> = {}
       for (const [key, item] of Object.entries(itemsObj)) {
         if (item.quantity > 0) {
-          itemsToShip[key] = {
-            orderItemId: item.orderItemId,
-            quantity: item.quantity,
-            maxQuantity: item.maxQuantity
-          }
+          itemsToShip[key] = buildCreationItemPayload(item, itemFields)
         }
       }
 
@@ -160,7 +165,7 @@ export const CreateShipmentModal: React.FC<CreateShipmentModalProps> = ({
       destroyOnClose
     >
       <SchemaForm
-        blockPrefix="coreshop_order_shipment_creation"
+        blockPrefix={BLOCK_PREFIX}
         data={formData}
         onChange={(draft) => setFormData((prev) => ({ ...prev, ...draft }))}
       />

--- a/src/CoreShop/Bundle/OrderBundle/Resources/assets/pimcore-studio/src/modules/sales/utils/creationItems.ts
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/assets/pimcore-studio/src/modules/sales/utils/creationItems.ts
@@ -1,0 +1,76 @@
+/**
+ * CoreShop OrderBundle - Document Creation Item Helpers
+ *
+ * Shipment and invoice creation both render a per-item grid from a Symfony
+ * CollectionType. The entry type is extensible via Symfony form type extensions,
+ * so neither the grid columns nor the submitted payload may be limited to a
+ * hard-coded set of keys — the form schema is the single source of truth.
+ *
+ * This source file is available under the terms of the
+ * CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    CoreShop Commercial License (CCL)
+ */
+
+import { fetchFormSchema } from '@coreshop/studio-form/src/schema-adapter/api'
+import type { FormSchemaField } from '@coreshop/studio-form/src/schema-adapter/types'
+
+/**
+ * The per-item fields of a document creation form, as declared by the
+ * collection's entry type (including fields added by form type extensions).
+ */
+export type CreationItemFields = FormSchemaField[]
+
+/**
+ * Read the per-item field definitions out of a document creation form schema.
+ *
+ * Returns an empty list when the schema has no items collection or the
+ * collection carries no prototype, in which case callers fall back to
+ * passing item values through unfiltered.
+ */
+export const loadCreationItemFields = async (
+  blockPrefix: string,
+  collectionField = 'items',
+): Promise<CreationItemFields> => {
+  const schema = await fetchFormSchema(blockPrefix)
+  const collection = schema.fields.find((field) => field.name === collectionField)
+
+  return collection?.prototype?.fields ?? []
+}
+
+/**
+ * Build the payload for a single item row.
+ *
+ * Every field the entry type declares is passed through, which is what keeps
+ * fields contributed by a form type extension (e.g. WarehouseBundle's
+ * `stockItem`) alive from the grid to the create request.
+ *
+ * Disabled fields are omitted: Symfony ignores submitted values for them and
+ * takes the server-side value instead, and some of them hold display-only
+ * values such as a formatted price.
+ */
+export const buildCreationItemPayload = (
+  item: Record<string, unknown>,
+  fields: CreationItemFields,
+): Record<string, unknown> => {
+  if (fields.length === 0) {
+    return { ...item }
+  }
+
+  const payload: Record<string, unknown> = {}
+
+  for (const field of fields) {
+    if (field.disabled === true) {
+      continue
+    }
+
+    if (field.name in item) {
+      payload[field.name] = item[field.name]
+    }
+  }
+
+  return payload
+}


### PR DESCRIPTION
Fixes #3136

## The finding

The hypothesis that this should already be solvable through the StudioForm mechanism **holds**. No new registry was needed — the whole schema pipeline is already extensible, and the only thing blocking third-party form type extensions was the hand-written key mapping inside the modals.

I verified the crux by running it rather than reasoning about it: a bare Symfony form factory wired with `CollectionPrototypeExtension` plus a type extension on the real `Studio\OrderShipmentCreationItemsType`, fed through the real `FormSchemaGenerator`. The extension-added field comes out in the generated collection prototype with its choices and `required` flag, next to the seven built-in item fields:

```
  - items [form,collection,grid_collection]
      prototype fields (= grid columns):
        * orderItemId      [form,hidden]  required=n disabled=n
        * maxQuantity      [form,hidden]  required=n disabled=y
        * name             [form,text]    required=n disabled=y
        * price            [form,number]  required=n disabled=y
        * orderedQuantity  [form,integer] required=n disabled=y
        * quantityShipped  [form,integer] required=n disabled=y
        * quantity         [form,integer] required=n disabled=n
        * stockItem        [form,choice]  required=y disabled=n choices=[...]
```

It works because `CollectionPrototypeExtension` forces `CollectionType` to build a prototype even when `allow_add` is false, and builds it via `$builder->create(...)` — i.e. through the form factory, so type extensions are applied. `FormSchemaGenerator` then serializes that prototype recursively, and `GridCollectionWidget` already derives its columns purely from `prototype.fields` while preserving unknown keys when a cell is edited. CoreBundle's `StudioOrderShipmentCreationTypeExtension` (the `carrier` select) already proves the root-level half of this in production.

## The change

`CreateShipmentModal` reduced each item to `orderItemId` / `quantity` / `maxQuantity` on load *and* on submit, so anything else was silently dropped. Both ends are now driven by the schema:

- **On load** the API item is passed through and only the keys the API and the form spell differently are renamed (`toShip` → `quantity`, `maxToShip` → `maxQuantity`, `quantity` → `orderedQuantity`). Values a bundle contributes through the `coreshop.order.shipment.prepare_ship_able` event now reach the grid.
- **On submit** `buildCreationItemPayload()` keeps exactly the fields the entry type declares. Disabled fields are skipped — Symfony ignores submitted values for them and uses the value seeded from `$allowedData`, and some of them hold display-only values such as a formatted price.
- When no schema is available the helper falls back to passing the item through unchanged, so the modal degrades rather than breaks.

`CreateInvoiceModal` had the identical defect and is fixed through the same helper.

## Docs

`docs/.../06_OrderBundle/01_Order_Cart_Quote_System.md` documented a `ModalFieldExtensionRegistry` with a `create-shipment` modal key. That class does not exist anywhere in the codebase — the section was describing an API that was never implemented, which is likely part of why this looked unsolvable. It now documents the mechanism that actually works: which form type backs which modal, that the `Studio\` namespace is the one to extend, that a field must be added in `buildForm()` rather than in a `PRE_SUBMIT` listener to be schema-visible, and how per-item values survive the round trip. The stale `extensions/` entry in the file-structure listing is corrected too.

## Notes for coreshop/warehouse-bundle#12

Two things fall out of the investigation. The `stockItem` field has to move from the `PRE_SUBMIT` listener into `buildForm()` on the **Studio** entry type — a field that only exists while handling a submit can never appear in the generated schema. And `StockItemChoiceType` already degrades to `findAll()` when no `stockable` option is passed, so a working choice list needs no per-row plumbing on the OrderBundle side.

Passing the grid row record down to cell widgets would enable genuinely per-row choices, but nothing needs it yet, so it is deliberately left out of this PR.

## Verification

- Ran the schema-generation proof described above against the real CoreShop 5.1 classes (from warehouse-bundle's vendor dir), no DB required.
- Ran `buildCreationItemPayload()` against exactly that generated per-item schema plus a realistic grid row: the extension field and `orderItemId`/`quantity` survive, the formatted price and `maxQuantity` are dropped as disabled, non-schema API keys are dropped, and the empty-schema fallback passes everything through.
- `npm run check-types` clean for `@coreshop/order`.
- `rsbuild build` of the OrderBundle Studio plugin succeeds.
- Source-only: no build artifacts are included (the local build overwrites `Resources/public/studio/`; that was restored before committing).
- ESLint was not run — the repo ships no ESLint configuration, so the `lint` script cannot resolve one. No PHP was changed, so ecs/phpstan/psalm are unaffected.
- Not verified end-to-end in a running Studio installation against warehouse-bundle; that needs the warehouse-bundle side of #12 to exist first.

Targets 5.1, the oldest affected branch — 5.0 has neither the modal nor the Studio form types. 2026.x is affected and should get this by upmerge.