### PR TITLE
Make RuleFormSchemaCollector injection optional (split-package installs)

### DIFF
--- a/src/CoreShop/Bundle/IndexBundle/Controller/FilterController.php
+++ b/src/CoreShop/Bundle/IndexBundle/Controller/FilterController.php
@@ -33,31 +33,36 @@ use Symfony\Component\HttpFoundation\Response;
 class FilterController extends ResourceController
 {
     public function getConfigAction(
-        RuleFormSchemaCollector $schemaCollector,
         #[Autowire(service: 'coreshop.form_registry.filter.pre_condition_types')]
         FormTypeRegistryInterface $preConditionFormRegistry,
         #[Autowire(service: 'coreshop.form_registry.filter.user_condition_types')]
         FormTypeRegistryInterface $userConditionFormRegistry,
+        // Provided by CoreShopStudioFormBundle, which is only registered when
+        // Pimcore Studio is installed — null on classic-admin-only setups.
+        ?RuleFormSchemaCollector $schemaCollector = null,
     ): Response {
         $preConditionTypes = array_keys($this->getPreConditionTypes());
         $userConditionTypes = array_keys($this->getUserConditionTypes());
 
-        $preConditionSchemas = $schemaCollector->collectSchemasWithTypeMap($preConditionFormRegistry, $preConditionTypes);
-        $userConditionSchemas = $schemaCollector->collectSchemasWithTypeMap($userConditionFormRegistry, $userConditionTypes);
+        $payload = [
+            'success' => true,
+            'pre_conditions' => $preConditionTypes,
+            'user_conditions' => $userConditionTypes,
+        ];
 
-        return $this->viewHandler->handle(
-            [
-                'success' => true,
-                'pre_conditions' => $preConditionTypes,
-                'user_conditions' => $userConditionTypes,
-                'schemas' => array_merge(
-                    $preConditionSchemas['schemas'],
-                    $userConditionSchemas['schemas'],
-                ),
-                'preConditionSchemaByType' => $preConditionSchemas['schemaByType'],
-                'userConditionSchemaByType' => $userConditionSchemas['schemaByType'],
-            ],
-        );
+        if (null !== $schemaCollector) {
+            $preConditionSchemas = $schemaCollector->collectSchemasWithTypeMap($preConditionFormRegistry, $preConditionTypes);
+            $userConditionSchemas = $schemaCollector->collectSchemasWithTypeMap($userConditionFormRegistry, $userConditionTypes);
+
+            $payload['schemas'] = array_merge(
+                $preConditionSchemas['schemas'],
+                $userConditionSchemas['schemas'],
+            );
+            $payload['preConditionSchemaByType'] = $preConditionSchemas['schemaByType'];
+            $payload['userConditionSchemaByType'] = $userConditionSchemas['schemaByType'];
+        }
+
+        return $this->viewHandler->handle($payload);
     }
 
     public function getFieldsForIndexAction(Request $request, RepositoryInterface $indexRepository): Response

--- a/src/CoreShop/Bundle/IndexBundle/Controller/IndexController.php
+++ b/src/CoreShop/Bundle/IndexBundle/Controller/IndexController.php
@@ -48,7 +48,6 @@ class IndexController extends ResourceController
     }
 
     public function getConfigAction(
-        RuleFormSchemaCollector $schemaCollector,
         IndexableClassesProviderInterface $indexableClassesProvider,
         #[Autowire(service: 'coreshop.form_registry.index.getter')]
         FormTypeRegistryInterface $getterFormTypeRegistry,
@@ -56,6 +55,9 @@ class IndexController extends ResourceController
         FormTypeRegistryInterface $interpreterFormTypeRegistry,
         #[Autowire(service: 'coreshop.form_registry.index.worker')]
         FormTypeRegistryInterface $workerFormTypeRegistry,
+        // Provided by CoreShopStudioFormBundle, which is only registered when
+        // Pimcore Studio is installed — null on classic-admin-only setups.
+        ?RuleFormSchemaCollector $schemaCollector = null,
     ): Response {
         $indexInterpreterRegistry = $this->container->get('coreshop.registry.index.interpreter');
 
@@ -63,9 +65,11 @@ class IndexController extends ResourceController
         $interpreterTypes = $this->getInterpreterTypes();
         $workerTypes = $this->getWorkerTypes();
 
-        $getterSchemas = $schemaCollector->collectSchemasWithTypeMap($getterFormTypeRegistry, $getterTypes);
-        $interpreterSchemas = $schemaCollector->collectSchemasWithTypeMap($interpreterFormTypeRegistry, $interpreterTypes);
-        $workerSchemas = $schemaCollector->collectSchemasWithTypeMap($workerFormTypeRegistry, $workerTypes);
+        $noSchemas = ['schemas' => [], 'schemaByType' => []];
+
+        $getterSchemas = $schemaCollector?->collectSchemasWithTypeMap($getterFormTypeRegistry, $getterTypes) ?? $noSchemas;
+        $interpreterSchemas = $schemaCollector?->collectSchemasWithTypeMap($interpreterFormTypeRegistry, $interpreterTypes) ?? $noSchemas;
+        $workerSchemas = $schemaCollector?->collectSchemasWithTypeMap($workerFormTypeRegistry, $workerTypes) ?? $noSchemas;
 
         $gettersResult = [];
 
@@ -139,25 +143,28 @@ class IndexController extends ResourceController
             $workersResult[] = $entry;
         }
 
-        return $this->viewHandler->handle(
-            [
-                'success' => true,
-                'interpreters' => $interpretersResult,
-                'getters' => $gettersResult,
-                'fieldTypes' => $fieldTypesResult,
-                'classes' => $availableClasses,
-                'workerTypes' => $workerTypes,
-                'workers' => $workersResult,
-                'schemas' => array_merge(
-                    $getterSchemas['schemas'],
-                    $interpreterSchemas['schemas'],
-                    $workerSchemas['schemas'],
-                ),
-                'getterSchemaByType' => $getterSchemas['schemaByType'],
-                'interpreterSchemaByType' => $interpreterSchemas['schemaByType'],
-                'workerSchemaByType' => $workerSchemas['schemaByType'],
-            ],
-        );
+        $payload = [
+            'success' => true,
+            'interpreters' => $interpretersResult,
+            'getters' => $gettersResult,
+            'fieldTypes' => $fieldTypesResult,
+            'classes' => $availableClasses,
+            'workerTypes' => $workerTypes,
+            'workers' => $workersResult,
+        ];
+
+        if (null !== $schemaCollector) {
+            $payload['schemas'] = array_merge(
+                $getterSchemas['schemas'],
+                $interpreterSchemas['schemas'],
+                $workerSchemas['schemas'],
+            );
+            $payload['getterSchemaByType'] = $getterSchemas['schemaByType'];
+            $payload['interpreterSchemaByType'] = $interpreterSchemas['schemaByType'];
+            $payload['workerSchemaByType'] = $workerSchemas['schemaByType'];
+        }
+
+        return $this->viewHandler->handle($payload);
     }
 
     public function getClassDefinitionForFieldSelectionAction(Request $request): Response

--- a/src/CoreShop/Bundle/NotificationBundle/Controller/NotificationRuleController.php
+++ b/src/CoreShop/Bundle/NotificationBundle/Controller/NotificationRuleController.php
@@ -32,11 +32,13 @@ class NotificationRuleController extends ResourceController
 {
     public function getConfigAction(
         Request $request,
-        RuleFormSchemaCollector $schemaCollector,
         #[Autowire(service: 'coreshop.form_registry.notification_rule.conditions')]
         FormTypeRegistryInterface $conditionFormRegistry,
         #[Autowire(service: 'coreshop.form_registry.notification_rule.actions')]
         FormTypeRegistryInterface $actionFormRegistry,
+        // Provided by CoreShopStudioFormBundle, which is only registered when
+        // Pimcore Studio is installed — null on classic-admin-only setups.
+        ?RuleFormSchemaCollector $schemaCollector = null,
     ): Response {
         $conditions = [];
         $actions = [];
@@ -81,15 +83,17 @@ class NotificationRuleController extends ResourceController
                 $typeActions = array_keys($this->getParameter($actionParameter));
                 $actions[$type] = array_merge($actions[$type], $typeActions);
 
-                // Main registry uses compound keys: {notificationType}.{actionName}
-                $compoundKeys = array_map(static fn (string $name) => $type . '.' . $name, $typeActions);
-                $actionSchemas = $schemaCollector->collectSchemasWithTypeMap($actionFormRegistry, $compoundKeys);
-                $schemas = array_merge($schemas, $actionSchemas['schemas']);
+                if (null !== $schemaCollector) {
+                    // Main registry uses compound keys: {notificationType}.{actionName}
+                    $compoundKeys = array_map(static fn (string $name) => $type . '.' . $name, $typeActions);
+                    $actionSchemas = $schemaCollector->collectSchemasWithTypeMap($actionFormRegistry, $compoundKeys);
+                    $schemas = array_merge($schemas, $actionSchemas['schemas']);
 
-                foreach ($typeActions as $actionName) {
-                    $compoundKey = $type . '.' . $actionName;
-                    if (isset($actionSchemas['schemaByType'][$compoundKey])) {
-                        $actionSchemaByType[$type][$actionName] = $actionSchemas['schemaByType'][$compoundKey];
+                    foreach ($typeActions as $actionName) {
+                        $compoundKey = $type . '.' . $actionName;
+                        if (isset($actionSchemas['schemaByType'][$compoundKey])) {
+                            $actionSchemaByType[$type][$actionName] = $actionSchemas['schemaByType'][$compoundKey];
+                        }
                     }
                 }
             }
@@ -102,29 +106,36 @@ class NotificationRuleController extends ResourceController
                 $typeConditions = array_keys($this->getParameter($conditionParameter));
                 $conditions[$type] = array_merge($conditions[$type], $typeConditions);
 
-                // Main registry uses compound keys: {notificationType}.{conditionName}
-                $compoundKeys = array_map(static fn (string $name) => $type . '.' . $name, $typeConditions);
-                $conditionSchemas = $schemaCollector->collectSchemasWithTypeMap($conditionFormRegistry, $compoundKeys);
-                $schemas = array_merge($schemas, $conditionSchemas['schemas']);
+                if (null !== $schemaCollector) {
+                    // Main registry uses compound keys: {notificationType}.{conditionName}
+                    $compoundKeys = array_map(static fn (string $name) => $type . '.' . $name, $typeConditions);
+                    $conditionSchemas = $schemaCollector->collectSchemasWithTypeMap($conditionFormRegistry, $compoundKeys);
+                    $schemas = array_merge($schemas, $conditionSchemas['schemas']);
 
-                foreach ($typeConditions as $conditionName) {
-                    $compoundKey = $type . '.' . $conditionName;
-                    if (isset($conditionSchemas['schemaByType'][$compoundKey])) {
-                        $conditionSchemaByType[$type][$conditionName] = $conditionSchemas['schemaByType'][$compoundKey];
+                    foreach ($typeConditions as $conditionName) {
+                        $compoundKey = $type . '.' . $conditionName;
+                        if (isset($conditionSchemas['schemaByType'][$compoundKey])) {
+                            $conditionSchemaByType[$type][$conditionName] = $conditionSchemas['schemaByType'][$compoundKey];
+                        }
                     }
                 }
             }
         }
 
-        return $this->viewHandler->handle([
+        $payload = [
             'success' => true,
             'types' => $types,
             'actions' => $actions,
             'conditions' => $conditions,
-            'schemas' => $schemas,
-            'conditionSchemaByType' => $conditionSchemaByType,
-            'actionSchemaByType' => $actionSchemaByType,
-        ]);
+        ];
+
+        if (null !== $schemaCollector) {
+            $payload['schemas'] = $schemas;
+            $payload['conditionSchemaByType'] = $conditionSchemaByType;
+            $payload['actionSchemaByType'] = $actionSchemaByType;
+        }
+
+        return $this->viewHandler->handle($payload);
     }
 
     public function sortAction(Request $request): Response

--- a/src/CoreShop/Bundle/OrderBundle/Controller/CartPriceRuleController.php
+++ b/src/CoreShop/Bundle/OrderBundle/Controller/CartPriceRuleController.php
@@ -51,7 +51,6 @@ class CartPriceRuleController extends ResourceController
 
     public function getConfigAction(
         Request $request,
-        RuleFormSchemaCollector $schemaCollector,
         #[Autowire(service: 'coreshop.form_registry.cart_price_rule.conditions')]
         FormTypeRegistryInterface $conditionFormRegistry,
         #[Autowire(service: 'coreshop.form_registry.cart_price_rule.actions')]
@@ -60,6 +59,9 @@ class CartPriceRuleController extends ResourceController
         FormTypeRegistryInterface $itemConditionFormRegistry,
         #[Autowire(service: 'coreshop.form_registry.cart_item_price_rule.actions')]
         FormTypeRegistryInterface $itemActionFormRegistry,
+        // Provided by CoreShopStudioFormBundle, which is only registered when
+        // Pimcore Studio is installed — null on classic-admin-only setups.
+        ?RuleFormSchemaCollector $schemaCollector = null,
     ): JsonResponse {
         $actions = $this->getConfigActions();
         $conditions = $this->getConfigConditions();
@@ -67,27 +69,32 @@ class CartPriceRuleController extends ResourceController
         $itemActions = $this->getCartItemConfigActions();
         $itemConditions = $this->getCartItemConfigConditions();
 
-        $conditionSchemas = $schemaCollector->collectSchemasWithTypeMap($conditionFormRegistry, array_keys($conditions));
-        $actionSchemas = $schemaCollector->collectSchemasWithTypeMap($actionFormRegistry, array_keys($actions));
-        $itemConditionSchemas = $schemaCollector->collectSchemasWithTypeMap($itemConditionFormRegistry, array_keys($itemConditions));
-        $itemActionSchemas = $schemaCollector->collectSchemasWithTypeMap($itemActionFormRegistry, array_keys($itemActions));
-
-        return $this->viewHandler->handle([
+        $payload = [
             'actions' => array_keys($actions),
             'conditions' => array_keys($conditions),
             'itemActions' => array_keys($itemActions),
             'itemConditions' => array_keys($itemConditions),
-            'schemas' => array_merge(
+        ];
+
+        if (null !== $schemaCollector) {
+            $conditionSchemas = $schemaCollector->collectSchemasWithTypeMap($conditionFormRegistry, array_keys($conditions));
+            $actionSchemas = $schemaCollector->collectSchemasWithTypeMap($actionFormRegistry, array_keys($actions));
+            $itemConditionSchemas = $schemaCollector->collectSchemasWithTypeMap($itemConditionFormRegistry, array_keys($itemConditions));
+            $itemActionSchemas = $schemaCollector->collectSchemasWithTypeMap($itemActionFormRegistry, array_keys($itemActions));
+
+            $payload['schemas'] = array_merge(
                 $conditionSchemas['schemas'],
                 $actionSchemas['schemas'],
                 $itemConditionSchemas['schemas'],
                 $itemActionSchemas['schemas'],
-            ),
-            'conditionSchemaByType' => $conditionSchemas['schemaByType'],
-            'actionSchemaByType' => $actionSchemas['schemaByType'],
-            'itemConditionSchemaByType' => $itemConditionSchemas['schemaByType'],
-            'itemActionSchemaByType' => $itemActionSchemas['schemaByType'],
-        ]);
+            );
+            $payload['conditionSchemaByType'] = $conditionSchemas['schemaByType'];
+            $payload['actionSchemaByType'] = $actionSchemas['schemaByType'];
+            $payload['itemConditionSchemaByType'] = $itemConditionSchemas['schemaByType'];
+            $payload['itemActionSchemaByType'] = $itemActionSchemas['schemaByType'];
+        }
+
+        return $this->viewHandler->handle($payload);
     }
 
     public function getCartItemConfigAction(Request $request): JsonResponse

--- a/src/CoreShop/Bundle/PaymentBundle/Controller/PaymentProviderRuleController.php
+++ b/src/CoreShop/Bundle/PaymentBundle/Controller/PaymentProviderRuleController.php
@@ -28,28 +28,35 @@ class PaymentProviderRuleController extends ResourceController
 {
     public function getConfigAction(
         Request $request,
-        RuleFormSchemaCollector $schemaCollector,
         #[Autowire(service: 'coreshop.form_registry.payment_provider_rule.conditions')]
         FormTypeRegistryInterface $conditionFormRegistry,
         #[Autowire(service: 'coreshop.form_registry.payment_provider_rule.actions')]
         FormTypeRegistryInterface $actionFormRegistry,
+        // Provided by CoreShopStudioFormBundle, which is only registered when
+        // Pimcore Studio is installed — null on classic-admin-only setups.
+        ?RuleFormSchemaCollector $schemaCollector = null,
     ): Response {
         $actions = $this->getConfigActions();
         $conditions = $this->getConfigConditions();
 
-        $conditionSchemas = $schemaCollector->collectSchemasWithTypeMap($conditionFormRegistry, array_keys($conditions));
-        $actionSchemas = $schemaCollector->collectSchemasWithTypeMap($actionFormRegistry, array_keys($actions));
-
-        return $this->viewHandler->handle([
+        $payload = [
             'actions' => array_keys($actions),
             'conditions' => array_keys($conditions),
-            'schemas' => array_merge(
+        ];
+
+        if (null !== $schemaCollector) {
+            $conditionSchemas = $schemaCollector->collectSchemasWithTypeMap($conditionFormRegistry, array_keys($conditions));
+            $actionSchemas = $schemaCollector->collectSchemasWithTypeMap($actionFormRegistry, array_keys($actions));
+
+            $payload['schemas'] = array_merge(
                 $conditionSchemas['schemas'],
                 $actionSchemas['schemas'],
-            ),
-            'conditionSchemaByType' => $conditionSchemas['schemaByType'],
-            'actionSchemaByType' => $actionSchemas['schemaByType'],
-        ]);
+            );
+            $payload['conditionSchemaByType'] = $conditionSchemas['schemaByType'];
+            $payload['actionSchemaByType'] = $actionSchemas['schemaByType'];
+        }
+
+        return $this->viewHandler->handle($payload);
     }
 
     /**

--- a/src/CoreShop/Bundle/ProductBundle/Controller/ProductPriceRuleController.php
+++ b/src/CoreShop/Bundle/ProductBundle/Controller/ProductPriceRuleController.php
@@ -28,28 +28,35 @@ class ProductPriceRuleController extends ResourceController
 {
     public function getConfigAction(
         Request $request,
-        RuleFormSchemaCollector $schemaCollector,
         #[Autowire(service: 'coreshop.form_registry.product_price_rule.conditions')]
         FormTypeRegistryInterface $conditionFormRegistry,
         #[Autowire(service: 'coreshop.form_registry.product_price_rule.actions')]
         FormTypeRegistryInterface $actionFormRegistry,
+        // Provided by CoreShopStudioFormBundle, which is only registered when
+        // Pimcore Studio is installed — null on classic-admin-only setups.
+        ?RuleFormSchemaCollector $schemaCollector = null,
     ): Response {
         $actions = $this->getConfigActions();
         $conditions = $this->getConfigConditions();
 
-        $conditionSchemas = $schemaCollector->collectSchemasWithTypeMap($conditionFormRegistry, array_keys($conditions));
-        $actionSchemas = $schemaCollector->collectSchemasWithTypeMap($actionFormRegistry, array_keys($actions));
-
-        return $this->viewHandler->handle([
+        $payload = [
             'actions' => array_keys($actions),
             'conditions' => array_keys($conditions),
-            'schemas' => array_merge(
+        ];
+
+        if (null !== $schemaCollector) {
+            $conditionSchemas = $schemaCollector->collectSchemasWithTypeMap($conditionFormRegistry, array_keys($conditions));
+            $actionSchemas = $schemaCollector->collectSchemasWithTypeMap($actionFormRegistry, array_keys($actions));
+
+            $payload['schemas'] = array_merge(
                 $conditionSchemas['schemas'],
                 $actionSchemas['schemas'],
-            ),
-            'conditionSchemaByType' => $conditionSchemas['schemaByType'],
-            'actionSchemaByType' => $actionSchemas['schemaByType'],
-        ]);
+            );
+            $payload['conditionSchemaByType'] = $conditionSchemas['schemaByType'];
+            $payload['actionSchemaByType'] = $actionSchemas['schemaByType'];
+        }
+
+        return $this->viewHandler->handle($payload);
     }
 
     /**

--- a/src/CoreShop/Bundle/ProductBundle/StudioBackend/DataAdapter/ProductSpecificPriceRulesAdapter.php
+++ b/src/CoreShop/Bundle/ProductBundle/StudioBackend/DataAdapter/ProductSpecificPriceRulesAdapter.php
@@ -37,11 +37,13 @@ final readonly class ProductSpecificPriceRulesAdapter implements SetterDataInter
     public function __construct(
         private ArrayTransformerInterface $serializer,
         private ParameterBagInterface $parameterBag,
-        private RuleFormSchemaCollector $schemaCollector,
         #[Autowire(service: 'coreshop.form_registry.product_specific_price_rule.conditions')]
         private FormTypeRegistryInterface $conditionFormRegistry,
         #[Autowire(service: 'coreshop.form_registry.product_specific_price_rule.actions')]
         private FormTypeRegistryInterface $actionFormRegistry,
+        // Provided by CoreShopStudioFormBundle, which is only registered when
+        // Pimcore Studio is installed — null on classic-admin-only setups.
+        private ?RuleFormSchemaCollector $schemaCollector = null,
     ) {
     }
 
@@ -136,10 +138,10 @@ final readonly class ProductSpecificPriceRulesAdapter implements SetterDataInter
      */
     private function getActionSchemaByType(): array
     {
-        return $this->schemaCollector->collectSchemasWithTypeMap(
+        return $this->schemaCollector?->collectSchemasWithTypeMap(
             $this->actionFormRegistry,
             $this->getConfigActions(),
-        )['schemaByType'];
+        )['schemaByType'] ?? [];
     }
 
     /**
@@ -147,9 +149,9 @@ final readonly class ProductSpecificPriceRulesAdapter implements SetterDataInter
      */
     private function getConditionSchemaByType(): array
     {
-        return $this->schemaCollector->collectSchemasWithTypeMap(
+        return $this->schemaCollector?->collectSchemasWithTypeMap(
             $this->conditionFormRegistry,
             $this->getConfigConditions(),
-        )['schemaByType'];
+        )['schemaByType'] ?? [];
     }
 }

--- a/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/StudioBackend/DataAdapter/ProductQuantityPriceRulesAdapter.php
+++ b/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/StudioBackend/DataAdapter/ProductQuantityPriceRulesAdapter.php
@@ -37,9 +37,11 @@ final readonly class ProductQuantityPriceRulesAdapter implements SetterDataInter
     public function __construct(
         private ArrayTransformerInterface $serializer,
         private ParameterBagInterface $parameterBag,
-        private RuleFormSchemaCollector $schemaCollector,
         #[Autowire(service: 'coreshop.form_registry.product_quantity_price_rules.conditions')]
         private FormTypeRegistryInterface $conditionFormRegistry,
+        // Provided by CoreShopStudioFormBundle, which is only registered when
+        // Pimcore Studio is installed — null on classic-admin-only setups.
+        private ?RuleFormSchemaCollector $schemaCollector = null,
     ) {
     }
 
@@ -153,9 +155,9 @@ final readonly class ProductQuantityPriceRulesAdapter implements SetterDataInter
      */
     private function getConditionSchemaByType(): array
     {
-        return $this->schemaCollector->collectSchemasWithTypeMap(
+        return $this->schemaCollector?->collectSchemasWithTypeMap(
             $this->conditionFormRegistry,
             $this->getConfigConditions(),
-        )['schemaByType'];
+        )['schemaByType'] ?? [];
     }
 }

--- a/src/CoreShop/Bundle/ShippingBundle/Controller/ShippingRuleController.php
+++ b/src/CoreShop/Bundle/ShippingBundle/Controller/ShippingRuleController.php
@@ -28,28 +28,35 @@ class ShippingRuleController extends ResourceController
 {
     public function getConfigAction(
         Request $request,
-        RuleFormSchemaCollector $schemaCollector,
         #[Autowire(service: 'coreshop.form_registry.shipping_rule.conditions')]
         FormTypeRegistryInterface $conditionFormRegistry,
         #[Autowire(service: 'coreshop.form_registry.shipping_rule.actions')]
         FormTypeRegistryInterface $actionFormRegistry,
+        // Provided by CoreShopStudioFormBundle, which is only registered when
+        // Pimcore Studio is installed — null on classic-admin-only setups.
+        ?RuleFormSchemaCollector $schemaCollector = null,
     ): Response {
         $actions = $this->getConfigActions();
         $conditions = $this->getConfigConditions();
 
-        $conditionSchemas = $schemaCollector->collectSchemasWithTypeMap($conditionFormRegistry, array_keys($conditions));
-        $actionSchemas = $schemaCollector->collectSchemasWithTypeMap($actionFormRegistry, array_keys($actions));
-
-        return $this->viewHandler->handle([
+        $payload = [
             'actions' => array_keys($actions),
             'conditions' => array_keys($conditions),
-            'schemas' => array_merge(
+        ];
+
+        if (null !== $schemaCollector) {
+            $conditionSchemas = $schemaCollector->collectSchemasWithTypeMap($conditionFormRegistry, array_keys($conditions));
+            $actionSchemas = $schemaCollector->collectSchemasWithTypeMap($actionFormRegistry, array_keys($actions));
+
+            $payload['schemas'] = array_merge(
                 $conditionSchemas['schemas'],
                 $actionSchemas['schemas'],
-            ),
-            'conditionSchemaByType' => $conditionSchemas['schemaByType'],
-            'actionSchemaByType' => $actionSchemas['schemaByType'],
-        ]);
+            );
+            $payload['conditionSchemaByType'] = $conditionSchemas['schemaByType'];
+            $payload['actionSchemaByType'] = $actionSchemas['schemaByType'];
+        }
+
+        return $this->viewHandler->handle($payload);
     }
 
     /**


### PR DESCRIPTION
Fixes #3135

## Problem

`RuleFormSchemaCollector` lives in `CoreShopStudioFormBundle`, and that bundle is registered by `CoreShopCoreBundle` only — conditionally, when the Pimcore Studio UI is available. Split-package installs (e.g. a project on `coreshop/index-bundle` without the CoreBundle) can have `coreshop/studio-form-bundle` on disk, but nothing registers it, so the *class* exists while the *service* does not.

Everything that injected the collector non-nullably then broke:

* controller actions (`FilterController::getConfigAction()` and siblings) failed at **runtime** — Symfony bakes an errored entry into the controller argument locator: `Cannot autowire service ".service_locator.…": it references class "CoreShop\Bundle\StudioFormBundle\Form\Schema\RuleFormSchemaCollector" but no such service exists.`
* the Studio data adapters are worse: they are constructor-autowired, so the **container no longer compiles at all** as soon as `PimcoreStudioUiBundle` is registered without the StudioFormBundle: `Cannot autowire service "CoreShop\Bundle\ProductBundle\StudioBackend\DataAdapter\ProductSpecificPriceRulesAdapter": argument "$schemaCollector" … but no such service exists.`

## Approach

Nullable injection, i.e. the second option from the issue and the pattern the external bundles (loyalty, inbound-email-rules, index-geo) already follow. The alternative — mirroring CoreBundle's conditional `registerDependentBundles()` in every split bundle — would couple each split bundle to the StudioForm package and still leave the classes broken for anyone who deliberately runs without it.

The collector moved to the end of each signature (an optional parameter cannot precede required ones); controller arguments are resolved by name, so this is not a BC break for callers.

When the collector is absent the schema keys are **omitted** from the JSON rather than emitted as `null`. The Studio frontend already treats them as optional — `RuleConfig.schemas` / `*SchemaByType` are optional in the TS types, `registerSchemaComponentsFromMaps()` and `registerFilterSchemaConditionsFromMap()` guard with `?? {}` / an early return, and known types without a schema fall back to `EmptyCondition` / `EmptyAction`. The two data adapters keep their fixed normalized shape and return an empty map instead, matching what `ProductQuantityPriceRulesAdapter` already did for `actionSchemaByType`.

## Affected classes

| Class | Failure without StudioFormBundle |
| --- | --- |
| `IndexBundle\Controller\FilterController` | runtime (reported) |
| `IndexBundle\Controller\IndexController` | runtime |
| `OrderBundle\Controller\CartPriceRuleController` | runtime |
| `PaymentBundle\Controller\PaymentProviderRuleController` | runtime |
| `NotificationBundle\Controller\NotificationRuleController` | runtime |
| `ProductBundle\Controller\ProductPriceRuleController` | runtime |
| `ShippingBundle\Controller\ShippingRuleController` | runtime |
| `ProductBundle\StudioBackend\DataAdapter\ProductSpecificPriceRulesAdapter` | container compilation |
| `ProductQuantityPriceRulesBundle\StudioBackend\DataAdapter\ProductQuantityPriceRulesAdapter` | container compilation |

## Verification

A split install was simulated by making `CoreShopCoreBundle` skip the StudioFormBundle registration while the package stayed installed.

* Before the fix, `bin/console lint:container` aborts on `ProductSpecificPriceRulesAdapter`; with only the adapters fixed, the compiled container contains the errored `schemaCollector` entry for `coreshop.admin_controller.filter::getConfigAction()` quoted above.
* After the fix, `lint:container` reports OK both with and without the StudioFormBundle registered.
* Invoking `FilterController::getConfigAction()` against the container built *without* the bundle returns HTTP 200 with `success, pre_conditions, user_conditions` and no schema keys; with the bundle registered the payload again carries `schemas, preConditionSchemaByType, userConditionSchemaByType`.
* `vendor/bin/phpstan` and `vendor/bin/psalm` on the changed files: no errors. `vendor/bin/ecs check` flags only import-ordering issues that are already present on `5.1` for the same files (`CartPriceRuleController`, both adapters) — untouched here, the codestyle workflow fixes those on its own.

## Out of scope

The second half of the issue — 5.1 split packages not constraining each other — is confirmed still true on this branch: the split repos' `composer.json` files are hand-maintained inside the monorepo (`src/CoreShop/{Bundle,Component}/*/composer.json`), and 62 of 66 still require their siblings at `^5.0`, with all of them carrying `branch-alias: 5.0-dev`. That is a release-engineering change touching every package and changing how every future 5.1 tag resolves, so it does not belong in this bugfix. Tracked separately in #3172.
