### PR TITLE
Messenger: resolve "Failed At" date for AMQP dead-lettered messages

### DIFF
--- a/docs/03_Bundles/Messenger_Bundle.md
+++ b/docs/03_Bundles/Messenger_Bundle.md
@@ -28,3 +28,26 @@ public function registerBundlesToCollection(BundleCollection $collection)
     ]);
 }
 ```
+
+## The "Failed At" Date
+
+The date shown in the "Failed At" column of the failed messages grid is resolved from the envelope by a
+chain of `CoreShop\Bundle\MessengerBundle\Messenger\FailedAtResolverInterface` implementations. Two are
+shipped out of the box:
+
+* `RedeliveryStampFailedAtResolver` reads Symfony's `RedeliveryStamp`, which Messenger adds when it
+  retries a message or moves it to the failure transport.
+* `AmqpDeathHeaderFailedAtResolver` reads RabbitMQ's `x-death` header. Messages that the broker itself
+  dead-lettered never pass through Messenger's failure handling and therefore carry no `RedeliveryStamp`;
+  the header is the only timestamp available for them. Only `rejected` entries are used, because delayed
+  messages are dead-lettered as well and would otherwise look like failures on their first dispatch.
+
+Additional resolvers can be registered with the `coreshop.messenger.failed_at_resolver` tag. They are
+asked in descending `priority` order and the first one returning a date wins:
+
+```yaml
+services:
+    App\Messenger\MyFailedAtResolver:
+        tags:
+            - { name: coreshop.messenger.failed_at_resolver, priority: 200 }
+```

--- a/src/CoreShop/Bundle/MessengerBundle/CoreShopMessengerBundle.php
+++ b/src/CoreShop/Bundle/MessengerBundle/CoreShopMessengerBundle.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace CoreShop\Bundle\MessengerBundle;
 
 use CoreShop\Bundle\MenuBundle\CoreShopMenuBundle;
+use CoreShop\Bundle\MessengerBundle\DependencyInjection\CompilerPass\FailedAtResolverPass;
 use CoreShop\Bundle\MessengerBundle\DependencyInjection\CompilerPass\FailureReceiverPass;
 use CoreShop\Bundle\MessengerBundle\DependencyInjection\CompilerPass\ReceiverPass;
 use CoreShop\Bundle\PimcoreBundle\CoreShopPimcoreBundle;
@@ -41,5 +42,6 @@ final class CoreShopMessengerBundle extends Bundle implements DependentBundleInt
 
         $container->addCompilerPass(new ReceiverPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -100);
         $container->addCompilerPass(new FailureReceiverPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -100);
+        $container->addCompilerPass(new FailedAtResolverPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -100);
     }
 }

--- a/src/CoreShop/Bundle/MessengerBundle/DependencyInjection/CompilerPass/FailedAtResolverPass.php
+++ b/src/CoreShop/Bundle/MessengerBundle/DependencyInjection/CompilerPass/FailedAtResolverPass.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CoreShop
+ *
+ * This source file is available under the terms of the
+ * CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    CoreShop Commercial License (CCL)
+ *
+ */
+
+namespace CoreShop\Bundle\MessengerBundle\DependencyInjection\CompilerPass;
+
+use CoreShop\Bundle\MessengerBundle\Messenger\ChainFailedAtResolver;
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class FailedAtResolverPass implements CompilerPassInterface
+{
+    use PriorityTaggedServiceTrait;
+
+    public const TAG_NAME = 'coreshop.messenger.failed_at_resolver';
+
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition(ChainFailedAtResolver::class)) {
+            return;
+        }
+
+        $container
+            ->getDefinition(ChainFailedAtResolver::class)
+            ->replaceArgument(0, new IteratorArgument($this->findAndSortTaggedServices(self::TAG_NAME, $container)))
+        ;
+    }
+}

--- a/src/CoreShop/Bundle/MessengerBundle/Messenger/AmqpDeathHeaderFailedAtResolver.php
+++ b/src/CoreShop/Bundle/MessengerBundle/Messenger/AmqpDeathHeaderFailedAtResolver.php
@@ -44,11 +44,30 @@ final class AmqpDeathHeaderFailedAtResolver implements FailedAtResolverInterface
             return $time;
         }
 
-        if (!is_int($time) && !is_string($time)) {
+        // Do not narrow this to int/string: "time" is an AMQP timestamp field, and ext-amqp decodes
+        // it into an AMQPTimestamp value object, not a scalar. AMQPTimestamp is \Stringable and
+        // stringifies to the epoch seconds. Other AMQP clients hand over a plain int instead, so
+        // both have to be accepted here.
+        if ($time instanceof \Stringable) {
+            $time = (string) $time;
+        }
+
+        if (!is_int($time) && !(is_string($time) && is_numeric($time))) {
             return null;
         }
 
-        return \DateTimeImmutable::createFromFormat('U', (string) $time) ?: null;
+        $failedAt = \DateTimeImmutable::createFromFormat('U', (string) (int) $time);
+
+        if (false === $failedAt) {
+            return null;
+        }
+
+        // Keep the setTimezone() call: createFromFormat('U', ...) always returns the date in UTC,
+        // whereas RedeliveryStampFailedAtResolver returns server local time. FailedMessageRepository
+        // formats whatever it gets with a plain format('Y-m-d H:i:s') and no conversion, so without
+        // this normalisation broker dead-letterings would be rendered in a different timezone than
+        // Symfony side failures in the very same grid.
+        return $failedAt->setTimezone(new \DateTimeZone(date_default_timezone_get()));
     }
 
     private function getLastRejectedDeath(Envelope $envelope): ?array

--- a/src/CoreShop/Bundle/MessengerBundle/Messenger/AmqpDeathHeaderFailedAtResolver.php
+++ b/src/CoreShop/Bundle/MessengerBundle/Messenger/AmqpDeathHeaderFailedAtResolver.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CoreShop
+ *
+ * This source file is available under the terms of the
+ * CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    CoreShop Commercial License (CCL)
+ *
+ */
+
+namespace CoreShop\Bundle\MessengerBundle\Messenger;
+
+use Symfony\Component\Messenger\Envelope;
+
+/**
+ * Messages that end up in an AMQP queue because the broker itself dead-lettered them never pass
+ * through Symfony's retry/failure handling, so they carry no RedeliveryStamp. RabbitMQ records the
+ * moment of every dead-lettering in the "x-death" header, which is the only timestamp available for
+ * those messages.
+ *
+ * Only "rejected" entries are considered: delayed messages are dead-lettered as well (that is how
+ * the delay queue works) and would otherwise look like failures on their very first dispatch.
+ */
+final class AmqpDeathHeaderFailedAtResolver implements FailedAtResolverInterface
+{
+    public function resolve(Envelope $envelope): ?\DateTimeInterface
+    {
+        $death = $this->getLastRejectedDeath($envelope);
+
+        if (null === $death) {
+            return null;
+        }
+
+        $time = $death['time'] ?? null;
+
+        if ($time instanceof \DateTimeInterface) {
+            return $time;
+        }
+
+        if (!is_int($time) && !is_string($time)) {
+            return null;
+        }
+
+        return \DateTimeImmutable::createFromFormat('U', (string) $time) ?: null;
+    }
+
+    private function getLastRejectedDeath(Envelope $envelope): ?array
+    {
+        $amqpEnvelope = $this->getAmqpEnvelope($envelope);
+
+        if (null === $amqpEnvelope) {
+            return null;
+        }
+
+        $deaths = $amqpEnvelope->getHeader('x-death');
+
+        if (!is_array($deaths)) {
+            return null;
+        }
+
+        foreach ($deaths as $death) {
+            if (is_array($death) && 'rejected' === ($death['reason'] ?? null)) {
+                return $death;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolved by duck typing so that the bundle keeps working without symfony/amqp-messenger
+     * installed, and with third party AMQP transports that expose their own received stamp.
+     */
+    private function getAmqpEnvelope(Envelope $envelope): ?object
+    {
+        foreach ($envelope->all() as $stamps) {
+            foreach ($stamps as $stamp) {
+                if (!method_exists($stamp, 'getAmqpEnvelope')) {
+                    continue;
+                }
+
+                $amqpEnvelope = $stamp->getAmqpEnvelope();
+
+                if (is_object($amqpEnvelope) && method_exists($amqpEnvelope, 'getHeader')) {
+                    return $amqpEnvelope;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/CoreShop/Bundle/MessengerBundle/Messenger/ChainFailedAtResolver.php
+++ b/src/CoreShop/Bundle/MessengerBundle/Messenger/ChainFailedAtResolver.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CoreShop
+ *
+ * This source file is available under the terms of the
+ * CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    CoreShop Commercial License (CCL)
+ *
+ */
+
+namespace CoreShop\Bundle\MessengerBundle\Messenger;
+
+use Symfony\Component\Messenger\Envelope;
+
+final class ChainFailedAtResolver implements FailedAtResolverInterface
+{
+    /**
+     * @param iterable<FailedAtResolverInterface> $resolvers
+     */
+    public function __construct(
+        private iterable $resolvers,
+    ) {
+    }
+
+    public function resolve(Envelope $envelope): ?\DateTimeInterface
+    {
+        foreach ($this->resolvers as $resolver) {
+            $failedAt = $resolver->resolve($envelope);
+
+            if (null !== $failedAt) {
+                return $failedAt;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/CoreShop/Bundle/MessengerBundle/Messenger/FailedAtResolverInterface.php
+++ b/src/CoreShop/Bundle/MessengerBundle/Messenger/FailedAtResolverInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CoreShop
+ *
+ * This source file is available under the terms of the
+ * CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    CoreShop Commercial License (CCL)
+ *
+ */
+
+namespace CoreShop\Bundle\MessengerBundle\Messenger;
+
+use Symfony\Component\Messenger\Envelope;
+
+interface FailedAtResolverInterface
+{
+    public function resolve(Envelope $envelope): ?\DateTimeInterface;
+}

--- a/src/CoreShop/Bundle/MessengerBundle/Messenger/FailedMessageRepository.php
+++ b/src/CoreShop/Bundle/MessengerBundle/Messenger/FailedMessageRepository.php
@@ -22,16 +22,22 @@ use CoreShop\Bundle\MessengerBundle\Exception\ReceiverNotListableException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Stamp\ErrorDetailsStamp;
-use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
 use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
 use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
 
 final class FailedMessageRepository implements FailedMessageRepositoryInterface
 {
+    private FailedAtResolverInterface $failedAtResolver;
+
     public function __construct(
         private FailureReceiversRepositoryInterface $failureReceivers,
         private EventDispatcherInterface $eventDispatcher,
+        ?FailedAtResolverInterface $failedAtResolver = null,
     ) {
+        $this->failedAtResolver = $failedAtResolver ?? new ChainFailedAtResolver([
+            new RedeliveryStampFailedAtResolver(),
+            new AmqpDeathHeaderFailedAtResolver(),
+        ]);
     }
 
     public function listFailedMessages(string $receiverName, int $limit = 10): array
@@ -46,13 +52,13 @@ final class FailedMessageRepository implements FailedMessageRepositoryInterface
 
         $rows = [];
         foreach ($envelopes as $envelope) {
-            $lastRedeliveryStamp = $envelope->last(RedeliveryStamp::class);
             $lastErrorDetailsStamp = $envelope->last(ErrorDetailsStamp::class);
+            $failedAt = $this->failedAtResolver->resolve($envelope);
 
             $failedMessageDetails = new FailedMessageDetails(
                 $this->getMessageId($envelope),
                 $envelope->getMessage()::class,
-                ($lastRedeliveryStamp?->getRedeliveredAt()->format('Y-m-d H:i:s')) ?? '',
+                $failedAt?->format('Y-m-d H:i:s') ?? '',
                 $lastErrorDetailsStamp?->getExceptionMessage(),
                 '<pre>' . print_r($envelope->getMessage(), true) . '</pre>',
             );

--- a/src/CoreShop/Bundle/MessengerBundle/Messenger/RedeliveryStampFailedAtResolver.php
+++ b/src/CoreShop/Bundle/MessengerBundle/Messenger/RedeliveryStampFailedAtResolver.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CoreShop
+ *
+ * This source file is available under the terms of the
+ * CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    CoreShop Commercial License (CCL)
+ *
+ */
+
+namespace CoreShop\Bundle\MessengerBundle\Messenger;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
+
+final class RedeliveryStampFailedAtResolver implements FailedAtResolverInterface
+{
+    public function resolve(Envelope $envelope): ?\DateTimeInterface
+    {
+        return $envelope->last(RedeliveryStamp::class)?->getRedeliveredAt();
+    }
+}

--- a/src/CoreShop/Bundle/MessengerBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/MessengerBundle/Resources/config/services.yml
@@ -40,7 +40,8 @@ services:
   CoreShop\Bundle\MessengerBundle\Messenger\FailedAtResolverInterface: '@CoreShop\Bundle\MessengerBundle\Messenger\ChainFailedAtResolver'
   CoreShop\Bundle\MessengerBundle\Messenger\ChainFailedAtResolver:
     arguments:
-      - !tagged_iterator coreshop.messenger.failed_at_resolver
+      # replaced by CoreShop\Bundle\MessengerBundle\DependencyInjection\CompilerPass\FailedAtResolverPass
+      - [ ]
 
   CoreShop\Bundle\MessengerBundle\Messenger\FailedMessageRepositoryInterface: '@CoreShop\Bundle\MessengerBundle\Messenger\FailedMessageRepository'
   CoreShop\Bundle\MessengerBundle\Messenger\FailedMessageRepository:

--- a/src/CoreShop/Bundle/MessengerBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/MessengerBundle/Resources/config/services.yml
@@ -29,11 +29,25 @@ services:
       - '@messenger.receiver_locator'
       - [ ]
 
+  CoreShop\Bundle\MessengerBundle\Messenger\RedeliveryStampFailedAtResolver:
+    tags:
+      - { name: coreshop.messenger.failed_at_resolver, priority: 100 }
+
+  CoreShop\Bundle\MessengerBundle\Messenger\AmqpDeathHeaderFailedAtResolver:
+    tags:
+      - { name: coreshop.messenger.failed_at_resolver, priority: 0 }
+
+  CoreShop\Bundle\MessengerBundle\Messenger\FailedAtResolverInterface: '@CoreShop\Bundle\MessengerBundle\Messenger\ChainFailedAtResolver'
+  CoreShop\Bundle\MessengerBundle\Messenger\ChainFailedAtResolver:
+    arguments:
+      - !tagged_iterator coreshop.messenger.failed_at_resolver
+
   CoreShop\Bundle\MessengerBundle\Messenger\FailedMessageRepositoryInterface: '@CoreShop\Bundle\MessengerBundle\Messenger\FailedMessageRepository'
   CoreShop\Bundle\MessengerBundle\Messenger\FailedMessageRepository:
     arguments:
       - '@CoreShop\Bundle\MessengerBundle\Messenger\FailureReceiversRepository'
       - '@event_dispatcher'
+      - '@CoreShop\Bundle\MessengerBundle\Messenger\ChainFailedAtResolver'
 
   CoreShop\Bundle\MessengerBundle\Messenger\MessageRepositoryInterface: '@CoreShop\Bundle\MessengerBundle\Messenger\MessageRepository'
   CoreShop\Bundle\MessengerBundle\Messenger\MessageRepository:


### PR DESCRIPTION
Refs #3159

> **This PR does not fix the symptom reported in #3159.** That turned out to be an API/UI key
> mismatch — the backend shipped `failedAt` while both grids read `failed_at` — and is fixed by
> #3179, which closes the issue. This PR closes a separate gap that happens to affect the same
> column: messages dead-lettered by the broker itself never pass through Symfony's failure
> handling, so they carry no `RedeliveryStamp` and have no date to report at all. That matters for
> setups whose *failure transport* is AMQP.

Targets `5.0` on purpose, so the fix reaches `5.1` and `2026.x` through the normal upmerge chain.

## Root cause

`FailedMessageRepository` read the date exclusively from Symfony's `RedeliveryStamp`:

```php
($lastRedeliveryStamp?->getRedeliveredAt()->format('Y-m-d H:i:s')) ?? ''
```

That stamp is added by `SendFailedMessageToFailureTransportListener` when Messenger moves a message to
the failure transport, and it survives the transport round trip with both built-in serializers — the AMQP
transport does not drop it. This was confirmed by the Symfony maintainers in
symfony/symfony#64061, which was closed as "not planned" for exactly that reason.

The case that is genuinely not covered is redelivery decided by the **broker** itself. In a typical
RabbitMQ setup, messages reach the failure/dead-letter queue through a dead-letter exchange rather than
through Messenger's failure transport listener. Messenger never sees those messages being re-queued, so
it cannot stamp them: they arrive in the queue with no `RedeliveryStamp` at all and the column stays
empty forever. RabbitMQ does record the time of every dead-lettering in the `x-death` header, which is
the only timestamp available for such a message.

## Approach

The date resolution is extracted behind a small `FailedAtResolverInterface` and a prioritised chain:

| Resolver | Priority | Source |
| --- | --- | --- |
| `RedeliveryStampFailedAtResolver` | 100 | `RedeliveryStamp::getRedeliveredAt()` — unchanged behaviour, covers Doctrine and every message that went through Messenger's retry/failure handling |
| `AmqpDeathHeaderFailedAtResolver` | 0 | the `x-death` header of the AMQP envelope, for broker dead-lettered messages |

Only `x-death` entries with reason `rejected` are considered. Delayed messages carry an `x-death` header
too, because Messenger's delay queue is implemented by dead-lettering with reason `expired`; counting
those would make a message look "failed" on its very first dispatch.

Two deliberate choices worth calling out:

* **Resolver instead of a middleware.** The Symfony issue suggests a middleware, but a middleware only
  runs while a message travels through the bus. CoreShop's UI lists envelopes straight off the failure
  receiver and never dispatches them, so a middleware would not populate the grid at all. Reading the
  header at list time does, and it needs no opt-in from the user.
* **No new dependency.** The AMQP received stamp is located by duck typing (any stamp exposing
  `getAmqpEnvelope()`), so the bundle keeps working without `symfony/amqp-messenger` installed and also
  works with third party AMQP transports that ship their own received stamp.

## Backwards compatibility

Additive only. No interface or method signature changed for implementors; the new constructor argument
on `FailedMessageRepository` is optional and falls back to the built-in chain, so manual instantiation
keeps working. Behaviour for existing Doctrine (and stamped AMQP) setups is byte-for-byte identical —
the `RedeliveryStamp` resolver runs first. Projects can register their own resolver with the
`coreshop.messenger.failed_at_resolver` tag; documented in `docs/03_Bundles/Messenger_Bundle.md`.

The tagged services are collected by a `FailedAtResolverPass` compiler pass (using Symfony's
`PriorityTaggedServiceTrait`) rather than by a `!tagged_iterator` YAML tag: the repo's CI runs
`bin/console lint:yaml src` without `--parse-tags`, so custom YAML tags other than `!php/const` are
rejected, and no other service file in the tree uses one.

## Which failure paths are covered

| Failure path | Source of the date | Covered |
| --- | --- | --- |
| (a) Consumed by Symfony, handler threw, message moved to the failure transport | `RedeliveryStamp` | yes, unchanged behaviour, for **any** transport including AMQP |
| (b) Dead-lettered by the broker itself, never seen by Messenger | `x-death` header | yes, new |
| (c) Both present | `RedeliveryStamp` wins (priority 100 vs 0) | yes |

Case (a) works on AMQP too, and this was verified rather than assumed against the installed
symfony/messenger v7.4.15:

* `SendFailedMessageToFailureTransportListener::onMessageFailed()` adds `new RedeliveryStamp(0)` before
  handing the envelope to the failure sender (`EventListener/SendFailedMessageToFailureTransportListener.php:62-66`),
  independently of which transport that sender is.
* `RedeliveryStamp` implements plain `StampInterface` (`Stamp/RedeliveryStamp.php:19`), not
  `NonSendableStampInterface`, so neither serializer strips it: `Serializer::encode()` removes only
  non-sendable stamps and then writes every remaining stamp class to an `X-Message-Stamp-*` header
  (`Transport/Serialization/Serializer.php:117-119` and `encodeStamps()` at `:150-162`), and
  `PhpSerializer::encode()` serializes the whole envelope after the same filter
  (`Transport/Serialization/PhpSerializer.php:159-172`).
* On the wire, `AmqpSender` publishes those headers as AMQP application headers
  (`Bridge/Amqp/Transport/AmqpSender.php:42` and `:73-75`) and `AmqpReceiver` decodes the envelope back
  from `$amqpEnvelope->getHeaders()` (`Bridge/Amqp/Transport/AmqpReceiver.php:77-79`), additionally
  attaching an `AmqpReceivedStamp` (`:94`) — which is the stamp the `x-death` resolver reads.
* Round trip actually executed with both built-in serializers: an envelope carrying three
  `RedeliveryStamp`s comes back with all three intact, retry counts in order `1, 2, 0`, and resolves to
  the failure-transport timestamp.

**Retry vs. final failure.** A message retried N times carries N+1 `RedeliveryStamp`s. `Envelope::last()`
returns `end($this->stamps[$fqcn])` (`Envelope.php:102-105`), i.e. the most recently added stamp. Since
the failure-transport listener stamps last, "Failed At" is the moment the message landed in the failure
transport, not the first retry. That is the intended semantics and it is asserted explicitly.

**Why the stamp beats `x-death` in case (c).** The stamp records when *Symfony* failed the message and
gave up on it, which is the event the column is named after; `x-death` only records when the *broker*
moved it between queues, and its most recent entry can be a delay-queue expiry that has nothing to do
with failing. When Messenger knows the answer, its answer is the more precise one.

One caveat for reviewers, unrelated to this change: Symfony's own `AmqpTransport`/`AmqpReceiver` do not
implement `ListableReceiverInterface`, and `FailedMessageRepository` throws `ReceiverNotListableException`
for a receiver that is not listable. Anyone seeing this grid populated with an AMQP failure transport is
therefore running a listable AMQP transport implementation, which is also why the `x-death` resolver
locates the AMQP envelope by duck typing on `getAmqpEnvelope()` instead of binding to Symfony's concrete
`AmqpReceivedStamp`.

## Verification

Ran, on the changed files:

* `ecs check src/CoreShop/Bundle/MessengerBundle/Messenger` — no errors
* `phpstan analyse --level=3` (repo `phpstan.neon`, with the Symfony container) — no errors
* `psalm src/CoreShop/Bundle/MessengerBundle/Messenger` — no errors
* DI check: `services.yml` loads, the chain receives the tagged iterator, both resolvers carry the tag
  with the intended priorities, and `FailedMessageRepository` receives the chain as third argument.
* A standalone script exercising the resolver chain against real `Symfony\Component\Messenger\Envelope`
  objects (stamps only, no broker): 10 assertions, all passing — Doctrine-shaped envelope resolves from
  the `RedeliveryStamp`; an AMQP envelope that has both prefers the stamp over `x-death`; a
  dead-lettered envelope with only `x-death` resolves to the header time; `expired` entries are ignored;
  a `rejected` entry is picked out of a mixed `x-death` list; integer, string and `DateTimeInterface`
  timestamps are all accepted; missing header, missing stamps and an unusable timestamp all return
  `null` (empty column) instead of throwing.
* A second script round-tripping a realistic post-failure envelope (two retries plus the failure
  transport stamp) through `PhpSerializer` and `Serializer::create()`: 9/9 assertions pass, covering
  stamp survival, stamp count and order, the resolved date being the failure-transport one, and the
  mixed stamp + `x-death` case. Side note found while doing this: `ErrorDetailsStamp` cannot round trip
  through the Symfony serializer when symfony/var-dumper is installed, because
  `FlattenException::$dataRepresentation` is a `VarDumper\Cloner\Data` that cannot be denormalized.
  That is pre-existing upstream behaviour, affects the "Error" column rather than "Failed At", and is
  untouched by this PR — worth a separate issue if it bites anyone.

The repository has no PHPUnit suite (`tests/` contains only a k6 script and there is no PHPUnit CI job),
so the script above was not committed — happy to add PHPUnit infrastructure in a separate PR if wanted.
The AMQP path has since been exercised against a live RabbitMQ broker — see the next section, which
also corrects a defect that the envelope/stamp level tests could not have caught.

## Verified against a real RabbitMQ broker

Run against `rabbitmq:3-management` with `php:8.3-cli` + ext-amqp 2.2.0, `symfony/amqp-messenger v7.4.11`
and `symfony/messenger v7.4.17`, using Symfony's real `AmqpTransport` on both ends.

### A defect this found, fixed in 4d060ad

The first run failed. `AmqpDeathHeaderFailedAtResolver` returned `null` for **every** broker
dead-lettered message, i.e. the bug this PR set out to fix was not actually fixed. Cause: ext-amqp
decodes the AMQP timestamp field of `x-death` into an **`AMQPTimestamp` value object**, not an int and
not a `DateTimeInterface`, so the `if (!is_int($time) && !is_string($time)) return null;` guard rejected
it before the cast that would have worked. The stamp-level tests fed integers and could never have hit
this. `AMQPTimestamp` implements `\Stringable` and stringifies to the epoch seconds, so the guard now
accepts `\Stringable` (and requires numeric strings, so a garbage header cannot produce a bogus date).

The same commit also normalises the timezone. `DateTimeImmutable::createFromFormat('U', ...)` always
returns UTC, while `RedeliveryStampFailedAtResolver` returns server local time, and
`FailedMessageRepository` formats both with a plain `format('Y-m-d H:i:s')` and no conversion — without
the added `setTimezone()`, broker dead-letterings would have been listed two hours off from Symfony side
failures in the very same grid on a `Europe/Vienna` server.

### Raw `x-death`, exactly as RabbitMQ produced it

Message published, consumed, rejected without requeue (`AmqpReceiver::reject()` → `nack`), dead-lettered
by the broker via `x-dead-letter-exchange`, then received from the failure queue:

```
array(1) {
  [0]=> array(6) {
    ["count"]=> int(1)
    ["reason"]=> string(8) "rejected"
    ["queue"]=> string(7) "t1_main"
    ["time"]=> object(AMQPTimestamp)#38 (1) {
      ["timestamp":"AMQPTimestamp":private]=> float(1787567453)
    }
    ["exchange"]=> string(5) "t1_ex"
    ["routing-keys"]=> array(1) { [0]=> string(0) "" }
  }
}
```

The TTL case is structurally identical with `["reason"]=> string(7) "expired"`.

### End-to-end assertions (16/16 pass)

1. **Broker-side reject.** Envelope carries **no** `RedeliveryStamp` (asserted), `reason` is `rejected`,
   the chain resolves `2026-08-24 12:30:53` — inside the measured reject window `1787567453..1787567454`
   — in the server timezone, and formats non-empty for the grid.
2. **TTL / `expired`.** Dead-lettered via `x-message-ttl` instead of a reject: `reason` is `expired` and
   the chain returns `null`. The delay-queue guard holds against a real broker.
3. **Symfony-side failure over AMQP.** A real `MessageBus` + `Worker` +
   `SendFailedMessageToFailureTransportListener` across two AMQP transports, handler throws: the failure
   transport envelope carries a `RedeliveryStamp`, the chain resolves through it, and the date equals
   `getRedeliveredAt()` and the measured failure moment.
4. **Precedence.** Adding a `RedeliveryStamp(1, 2020-01-02 03:04:05)` to the *real* dead-lettered
   envelope (genuine `x-death` intact) resolves to `2020-01-02 03:04:05` — priority 100 beats priority 0
   — with a control confirming `x-death` alone still resolves the broker date.

Worth knowing for review: the two resolvers cover **disjoint** cases in practice, because a
Symfony-republished failure envelope carries no `x-death` at all (Messenger republishes rather than
letting the broker dead-letter it) — case (c) above is a constructed combination, not something the
stock stack produces on its own.

### Regression check for the `AMQPTimestamp` handling (11/11 pass)

Feeding the resolver a real `AMQPTimestamp` (ext-amqp loaded), with `date.timezone=Europe/Vienna`:

```
ext-amqp loaded: yes (using the real AMQPTimestamp)

x-death[0]['time'] is a AMQPTimestamp
[ OK ] AMQP timestamp object resolves instead of returning null (the 492681e regression)
[ OK ] resolved value is 2026-08-24 12:30:53
[ OK ] resolved timezone is the server timezone (Europe/Vienna), not UTC
[ OK ] underlying instant is preserved
[ OK ] plain int timestamp still resolves to 2026-08-24 12:30:53
[ OK ] plain string timestamp still resolves to 2026-08-24 12:30:53
[ OK ] a DateTimeInterface is passed through untouched
[ OK ] expired (delayed) dead-letterings still resolve to null
[ OK ] a non-numeric string is rejected rather than turned into a bogus date
[ OK ] a missing time field resolves to null
[ OK ] an envelope without any AMQP stamp resolves to null

ALL ASSERTIONS PASSED (0 failing assertions)
```

The script falls back to a `\Stringable` stand-in mirroring `AMQPTimestamp` when ext-amqp is not
loadable, so it is runnable anywhere. As above it is not committed, since the repository has no PHPUnit
suite and this PR does not add CI infrastructure.

### Listability: what this fix does and does not get you

Stated plainly, because it is easy to read the above as "the grid now shows dates for AMQP" — it does
not, by itself. Confirmed against the installed `symfony/amqp-messenger v7.4.11`:

```
AmqpReceiver implements: QueueReceiverInterface, MessageCountAwareInterface, ReceiverInterface
```

Neither `AmqpReceiver` nor `AmqpTransport` implements `ListableReceiverInterface`, so
`FailedMessageRepository::listFailedMessages()` throws `ReceiverNotListableException` before the resolver
chain is ever reached. **With a stock Symfony AMQP transport the CoreShop grid cannot list failed
messages at all**, which also means there is no end-to-end UI test to run here and none is claimed. This
fix pays off for consumers that supply a listable AMQP transport implementation (plus anyone consuming
the `FailedMessageDetailsEvent` path). Making the stock AMQP transport listable is a separate piece of
work and out of scope for this PR.





Closes #3159