### PR TITLE
Messenger: fix empty "Failed At" column by emitting the key the UI reads

### DIFF
--- a/src/CoreShop/Bundle/MessengerBundle/Messenger/FailedMessageDetails.php
+++ b/src/CoreShop/Bundle/MessengerBundle/Messenger/FailedMessageDetails.php
@@ -70,7 +70,7 @@ final class FailedMessageDetails implements \JsonSerializable
         return [
             'id' => $this->id,
             'class' => $this->class,
-            'failedAt' => $this->failedAt,
+            'failed_at' => $this->failedAt,
             'error' => $this->error,
             'serialized' => $this->serialized,
         ];

--- a/src/CoreShop/Bundle/MessengerBundle/Resources/public/pimcore/js/list.js
+++ b/src/CoreShop/Bundle/MessengerBundle/Resources/public/pimcore/js/list.js
@@ -252,7 +252,7 @@ coreshop.messenger.list = Class.create({
                     rootProperty: 'data'
                 }
             },
-            fields: ['id', 'class', 'failedAt', 'error']
+            fields: ['id', 'class', 'failed_at', 'error']
         });
 
         var grid = new Ext.grid.Panel({


### PR DESCRIPTION
Fixes #3159

Targets `5.0` on purpose, so the fix reaches `5.1` and `2026.x` through the normal upmerge chain.

## Summary

The "Failed At" column in the Messenger UI is empty because the API and the UI disagree on one key.
The backend ships `failedAt`; every frontend reads `failed_at`. This makes the backend emit the key
everything else already expects.

This is **not** transport specific, despite how #3159 is worded. It is empty for Doctrine failure
transports too, and it was empty before any of the AMQP work in #3178. Verified against a live
RabbitMQ broker and a live MySQL failure transport — see *Verification* below.

## Root cause

`FailedMessageDetails` carries `#[SerializedName('failed_at')]` on its getters, so `failed_at` was
clearly the intended contract. But the class also implements `\JsonSerializable`:

```php
public function jsonSerialize(): mixed
{
    return [
        'id' => $this->id,
        'class' => $this->class,
        'failedAt' => $this->failedAt,   // <-- camelCase
        ...
```

`AdminAbstractController` inherits Symfony's `AbstractController::json()`, which uses the `serializer`
service whenever it exists — it does under Pimcore. In the framework serializer,
`serializer.normalizer.json_serializable` is tagged **priority -950** and `serializer.normalizer.object`
**priority -1000** (`framework-bundle/Resources/config/serializer.php`). The higher priority wins, so
`JsonSerializableNormalizer` handles the object, `jsonSerialize()` decides the keys, and the
`#[SerializedName]` attributes never take effect at all.

Result: the API ships `failedAt`, every consumer reads `failed_at`, and the cell is always empty.

## Who reads what

| Branch | classic `list.js` | Studio `MessengerFailedGrid.tsx` | backend emitted | frontends read |
| --- | --- | --- | --- | --- |
| `5.0` | present, `dataIndex: 'failed_at'` | not present yet | `failedAt` | `failed_at` |
| `5.1` | present, `dataIndex: 'failed_at'` | present, `dataIndex: 'failed_at'` | `failedAt` | `failed_at` |
| `2026.x` | removed with the classic admin | present, `dataIndex: 'failed_at'` | `failedAt` | `failed_at` |

Both UIs are broken, in both cases by the same mismatch. The symptom differs slightly: the classic
grid renders an empty cell, the Studio grid renders `-` (its `render` does `if (!date) return '-'`).

The mismatch survived review because the Studio type declares **both** spellings, so TypeScript
accepts either one:

```ts
export interface MessengerFailedMessage extends MessengerMessage {
  failed_at: string
  failedAt: string   // only occurrence of the camelCase key anywhere in the Studio sources
  error: string
}
```

## The fix

Two one-word changes:

* `FailedMessageDetails::jsonSerialize()` emits `failed_at` instead of `failedAt`, which makes the
  existing `#[SerializedName('failed_at')]` true instead of dead code;
* the classic store in `list.js` declares `failed_at` instead of `failedAt`, matching its own column's
  `dataIndex` (which was already `failed_at`).

**The Studio grid needs no change and no asset rebuild.** That is the main reason for fixing this on
the backend rather than pointing the two frontends at `failedAt`: the alternative would touch
`list.js`, `MessengerFailedGrid.tsx` and `types/index.ts`, and would require rebuilding
`Resources/public/studio/**`, which is gitignored locally and force-added by CI
(`.gitignore`: *"Studio frontend build artifacts — locally ignored, force-added in CI"*). Changing one
string in the DTO avoids all of that and leaves a single, consistent key across the whole stack.

No API contract is broken that anything depends on: `failedAt` appears nowhere in the repository
outside that one redundant TypeScript line. `coreshop/batch-messenger-bundle` was checked as well and
consumes neither `FailedMessageDetails` nor the `list-failed` endpoint.

## Verification

`ecs check` on the changed PHP file: no errors. `php -l` and `node --check` on the two changed files:
clean. No Studio build is involved.

The payload was checked against the real, patched class through a framework-shaped serializer
(`JsonSerializableNormalizer` before `ObjectNormalizer`, as the framework orders them):

```
=== payload from the PATCHED FailedMessageDetails ===
  {"id":1,"class":"App\\Message\\Foo","failed_at":"2026-08-24 13:01:15","error":"boom","serialized":"<pre>x<\/pre>"}
  [ OK ] payload key is now "failed_at"
  [ OK ] camelCase "failedAt" is gone
  value: 2026-08-24 13:01:15

=== against what each frontend reads ===
  classic store fields  : id, class, failed_at, error
  classic column        : failed_at
  studio  column        : failed_at   (MessengerFailedGrid.tsx, 5.1/2026.x -- unchanged)
  [ OK ] classic store now declares failed_at
  [ OK ] classic column dataIndex matches the payload
  [ OK ] classic store and column now agree
  [ OK ] studio column matches the payload with no Studio change
```

For comparison, the same check against the current `5.0` code:

```
=== today ===
  payload key            : failedAt
  classic reads          : failed_at -> MISSING
  studio  reads          : failed_at -> MISSING
```

That the backend date itself was always correct was confirmed end to end against a real RabbitMQ
broker (AMQP main transport) with a real MySQL Doctrine failure transport — a handler throws, Symfony
forwards the envelope to the failure transport, and it is read back exactly as
`FailedMessageRepository::listFailedMessages()` does:

```
stamps in the stored envelope:
  - ErrorDetailsStamp
  - SentToFailureTransportStamp
  - DelayStamp
  - RedeliveryStamp

RedeliveryStamp::getRedeliveredAt(): 2026-08-24 13:01:15.564078 +02:00
resolved "failed at"                : 2026-08-24 13:01:15
```

So the date was resolved correctly all along, including before #3178 — it simply never reached the
grid.

## Follow-ups, deliberately not in this PR

Both are pre-existing and orthogonal; they only become visible once a value actually arrives:

* The classic column applies `formatter: 'date("m/d/Y")'` to a `Y-m-d H:i:s` string, so it renders
  date-only in US format and drops the time.
* The Studio grid does `new Date('2026-08-24 13:01:15')`. That string is not ISO-8601; V8 parses it as
  local time, but Safari has historically been stricter about non-ISO formats.

Emitting ISO-8601 (`DATE_ATOM`) from `FailedMessageRepository` instead of `Y-m-d H:i:s` would address
both properly, at the cost of a deliberate API change — worth doing separately rather than smuggling
it in here.

## Relationship to #3178

#3178 is a different problem that happens to touch the same column: messages dead-lettered by the
broker itself never pass through Symfony's failure handling, so they carry no `RedeliveryStamp` and
have no date to show at all. That is a real gap for setups whose *failure transport* is AMQP, and it
stands on its own — but it is not what #3159 reported, and it would not have fixed it. This PR closes
#3159; #3178 closes the AMQP dead-letter gap.
