### PR TITLE
Messenger: drop the redundant failedAt field from MessengerFailedMessage

### DIFF
--- a/src/CoreShop/Bundle/MessengerBundle/Resources/assets/pimcore-studio/src/types/index.ts
+++ b/src/CoreShop/Bundle/MessengerBundle/Resources/assets/pimcore-studio/src/types/index.ts
@@ -23,7 +23,6 @@ export interface MessengerMessage {
 
 export interface MessengerFailedMessage extends MessengerMessage {
   failed_at: string
-  failedAt: string
   error: string
 }
 


### PR DESCRIPTION
Refs #3159, follow-up to #3179.

## What

Drops the redundant `failedAt: string` from `MessengerFailedMessage`:

```ts
 export interface MessengerFailedMessage extends MessengerMessage {
   failed_at: string
-  failedAt: string
   error: string
 }
```

## Why

The interface declared **both** spellings of the same field, so TypeScript accepted either one and
could not catch the mismatch that #3179 fixes: the API shipped `failedAt` while
`MessengerFailedGrid.tsx` reads `dataIndex: 'failed_at'`, leaving the "Failed At" column showing `-`.

With #3179 the payload key is `failed_at` for good, so `failedAt` describes a field that no longer
exists. Removing it means a future typo in either direction is a compile error rather than a silently
empty column.

`failedAt` has no other occurrence anywhere in the Studio sources — this declaration was its only
one — so nothing else needs touching.

## Scope

Type declaration only. No behaviour change, no component change, and no rebuild of
`Resources/public/studio/**`.

Targets `5.1` rather than `5.0` because the Studio assets do not exist on `5.0`; `2026.x` picks this
up through the normal upmerge chain. The functional fix in #3179 targets `5.0`, since the backend DTO
and the classic grid it also touches do exist there.
