### PR TITLE
[UPMERGE] 4.1 -> 5.0

### DIFF
--- a/features/ui/frontend/account/login.feature
+++ b/features/ui/frontend/account/login.feature
@@ -12,3 +12,10 @@ Feature: Signing in to the store
         And I specify the password as "test"
         And I log in
         Then I should be logged in
+
+    Scenario: Sign in ignores a redirect target pointing to a foreign host
+        When I want to log in with "//example.com" as redirect target
+        And I specify the username as "dominik@example.com"
+        And I specify the password as "test"
+        And I log in
+        Then I should be logged in

--- a/src/CoreShop/Behat/Context/Ui/Frontend/LoginContext.php
+++ b/src/CoreShop/Behat/Context/Ui/Frontend/LoginContext.php
@@ -44,6 +44,14 @@ final class LoginContext implements Context
     }
 
     /**
+     * @When I want to log in with :target as redirect target
+     */
+    public function iWantToLogInWithRedirectTarget(string $target): void
+    {
+        $this->loginPage->open(['target' => $target]);
+    }
+
+    /**
      * @When I want to reset password
      */
     public function iWantToResetPassword(): void

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/pimcore/security.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/pimcore/security.yml
@@ -25,6 +25,8 @@ security:
                 default_target_path: coreshop_index
                 use_forward: false
                 use_referer: true
+                success_handler: CoreShop\Bundle\CoreBundle\Security\ShopUserAuthenticationSuccessHandler
+                failure_handler: CoreShop\Bundle\CoreBundle\Security\ShopUserAuthenticationFailureHandler
             remember_me:
                 secret: "%secret%"
                 name: APP_CORESHOP_REMEMBER_ME

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services/handler.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services/handler.yml
@@ -2,6 +2,15 @@ services:
     _defaults:
         public: true
 
+    CoreShop\Bundle\CoreBundle\Security\ShopUserAuthenticationSuccessHandler:
+        arguments:
+            - '@security.http_utils'
+
+    CoreShop\Bundle\CoreBundle\Security\ShopUserAuthenticationFailureHandler:
+        arguments:
+            - '@http_kernel'
+            - '@security.http_utils'
+
     CoreShop\Bundle\CoreBundle\EventListener\ShopUserLogoutHandler:
         arguments:
             - '@router'

--- a/src/CoreShop/Bundle/CoreBundle/Security/ShopUserAuthenticationFailureHandler.php
+++ b/src/CoreShop/Bundle/CoreBundle/Security/ShopUserAuthenticationFailureHandler.php
@@ -40,15 +40,18 @@ class ShopUserAuthenticationFailureHandler extends DefaultAuthenticationFailureH
     {
         $parameter = $this->options['failure_path_parameter'];
         $root = false === ($position = strpos($parameter, '[')) ? $parameter : substr($parameter, 0, $position);
-        $failureUrl = $request->get($root);
 
-        if (is_string($failureUrl) && !$this->isAllowedRedirectUrl($request, $failureUrl)) {
+        foreach ([$request->attributes, $request->query, $request->request] as $bag) {
+            $failureUrl = $bag->all()[$root] ?? null;
+
+            if (!is_string($failureUrl) || $this->isAllowedRedirectUrl($request, $failureUrl)) {
+                continue;
+            }
+
             // Drop the rejected value so the parent falls back to the configured failure path.
             // This happens before delegating because the parent would otherwise treat a value
             // such as "https:evil.tld" as a route name and fail with a RouteNotFoundException.
-            $request->attributes->remove($root);
-            $request->query->remove($root);
-            $request->request->remove($root);
+            $bag->remove($root);
         }
 
         $response = parent::onAuthenticationFailure($request, $exception);

--- a/src/CoreShop/Bundle/CoreBundle/Security/ShopUserAuthenticationFailureHandler.php
+++ b/src/CoreShop/Bundle/CoreBundle/Security/ShopUserAuthenticationFailureHandler.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CoreShop
+ *
+ * This source file is available under two different licenses:
+ *  - GNU General Public License version 3 (GPLv3)
+ *  - CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    https://www.coreshop.com/license     GPLv3 and CCL
+ *
+ */
+
+namespace CoreShop\Bundle\CoreBundle\Security;
+
+use CoreShop\Bundle\ResourceBundle\Controller\RedirectUrlValidationTrait;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationFailureHandler;
+use Symfony\Component\Security\Http\ParameterBagUtils;
+
+/**
+ * Applies the same allow-list as the frontend controllers to the target URL of a failed login.
+ *
+ * Symfony accepts any "_failure_path" that starts with "/" or "http". As it is evaluated on a
+ * failed login attempt, an attacker only needs the victim to submit the login form once, without
+ * ever learning the credentials, to have the browser end up on a foreign host.
+ */
+class ShopUserAuthenticationFailureHandler extends DefaultAuthenticationFailureHandler
+{
+    use RedirectUrlValidationTrait;
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
+    {
+        $parameter = $this->options['failure_path_parameter'];
+        $failureUrl = ParameterBagUtils::getRequestParameterValue($request, $parameter);
+
+        if (is_string($failureUrl) && '' === $this->validateRedirectUrl($request, $failureUrl, '')) {
+            // Drop the rejected value so the parent falls back to the configured failure path
+            $root = false === ($position = strpos($parameter, '[')) ? $parameter : substr($parameter, 0, $position);
+
+            $request->attributes->remove($root);
+            $request->query->remove($root);
+            $request->request->remove($root);
+        }
+
+        return parent::onAuthenticationFailure($request, $exception);
+    }
+}

--- a/src/CoreShop/Bundle/CoreBundle/Security/ShopUserAuthenticationFailureHandler.php
+++ b/src/CoreShop/Bundle/CoreBundle/Security/ShopUserAuthenticationFailureHandler.php
@@ -19,11 +19,11 @@ declare(strict_types=1);
 namespace CoreShop\Bundle\CoreBundle\Security;
 
 use CoreShop\Bundle\ResourceBundle\Controller\RedirectUrlValidationTrait;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationFailureHandler;
-use Symfony\Component\Security\Http\ParameterBagUtils;
 
 /**
  * Applies the same allow-list as the frontend controllers to the target URL of a failed login.
@@ -39,17 +39,31 @@ class ShopUserAuthenticationFailureHandler extends DefaultAuthenticationFailureH
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
     {
         $parameter = $this->options['failure_path_parameter'];
-        $failureUrl = ParameterBagUtils::getRequestParameterValue($request, $parameter);
+        $root = false === ($position = strpos($parameter, '[')) ? $parameter : substr($parameter, 0, $position);
+        $failureUrl = $request->get($root);
 
-        if (is_string($failureUrl) && '' === $this->validateRedirectUrl($request, $failureUrl, '')) {
-            // Drop the rejected value so the parent falls back to the configured failure path
-            $root = false === ($position = strpos($parameter, '[')) ? $parameter : substr($parameter, 0, $position);
-
+        if (is_string($failureUrl) && !$this->isAllowedRedirectUrl($request, $failureUrl)) {
+            // Drop the rejected value so the parent falls back to the configured failure path.
+            // This happens before delegating because the parent would otherwise treat a value
+            // such as "https:evil.tld" as a route name and fail with a RouteNotFoundException.
             $request->attributes->remove($root);
             $request->query->remove($root);
             $request->request->remove($root);
         }
 
-        return parent::onAuthenticationFailure($request, $exception);
+        $response = parent::onAuthenticationFailure($request, $exception);
+
+        // The failure path can also be configured as a nested parameter, which the check above
+        // does not see, so validate what the parent actually decided to redirect to
+        if ($response instanceof RedirectResponse && !$this->isAllowedRedirectUrl($request, $response->getTargetUrl())) {
+            return $this->httpUtils->createRedirectResponse($request, $this->options['failure_path'] ?? $this->options['login_path']);
+        }
+
+        return $response;
+    }
+
+    private function isAllowedRedirectUrl(Request $request, string $url): bool
+    {
+        return '' !== $this->validateRedirectUrl($request, $url, '');
     }
 }

--- a/src/CoreShop/Bundle/CoreBundle/Security/ShopUserAuthenticationSuccessHandler.php
+++ b/src/CoreShop/Bundle/CoreBundle/Security/ShopUserAuthenticationSuccessHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CoreShop
+ *
+ * This source file is available under two different licenses:
+ *  - GNU General Public License version 3 (GPLv3)
+ *  - CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    https://www.coreshop.com/license     GPLv3 and CCL
+ *
+ */
+
+namespace CoreShop\Bundle\CoreBundle\Security;
+
+use CoreShop\Bundle\ResourceBundle\Controller\RedirectUrlValidationTrait;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler;
+
+/**
+ * Applies the same allow-list as the frontend controllers to the target URL of a successful login.
+ *
+ * Symfony accepts any "_target_path" (and, with use_referer, any Referer) that starts with "/" or
+ * "http", which allows redirecting a freshly authenticated customer to a foreign host.
+ */
+class ShopUserAuthenticationSuccessHandler extends DefaultAuthenticationSuccessHandler
+{
+    use RedirectUrlValidationTrait;
+
+    protected function determineTargetUrl(Request $request): string
+    {
+        $defaultTargetPath = $this->options['default_target_path'];
+
+        return $this->validateRedirectUrl($request, parent::determineTargetUrl($request), $defaultTargetPath);
+    }
+}

--- a/src/CoreShop/Bundle/FrontendBundle/Controller/CartController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/CartController.php
@@ -226,7 +226,12 @@ class CartController extends FrontendController
         $this->denyAccessUnlessGranted('CORESHOP_CART');
         $this->denyAccessUnlessGranted('CORESHOP_CART_ADD_ITEM');
 
-        $redirect = $this->getParameterFromRequest($request, '_redirect', $this->generateUrl('coreshop_index'));
+        $defaultRedirectGet = $this->generateUrl('coreshop_index');
+        $redirect = $this->validateRedirectUrl(
+            $request,
+            (string) $this->getParameterFromRequest($request, '_redirect', $defaultRedirectGet),
+            $defaultRedirectGet,
+        );
 
         $product = $this->container->get('coreshop.repository.stack.purchasable')->find($this->getParameterFromRequest($request, 'product'));
 
@@ -249,7 +254,12 @@ class CartController extends FrontendController
         $form = $this->container->get('form.factory')->createNamed('coreshop-' . $product->getId(), AddToCartType::class, $addToCart);
 
         if ($request->isMethod('POST')) {
-            $redirect = $this->getParameterFromRequest($request, '_redirect', $this->generateUrl('coreshop_cart_summary'));
+            $defaultRedirectPost = $this->generateUrl('coreshop_cart_summary');
+            $redirect = $this->validateRedirectUrl(
+                $request,
+                (string) $this->getParameterFromRequest($request, '_redirect', $defaultRedirectPost),
+                $defaultRedirectPost,
+            );
 
             $form->handleRequest($request);
 

--- a/src/CoreShop/Bundle/FrontendBundle/Controller/CustomerController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/CustomerController.php
@@ -194,8 +194,14 @@ class CustomerController extends FrontendController
                 $this->fireEvent($request, $address, sprintf('%s.%s.%s_post', 'coreshop', 'address', $eventType));
                 $this->addFlash('success', $this->container->get('translator')->trans(sprintf('coreshop.ui.customer.address_successfully_%s', $eventType === 'add' ? 'added' : 'updated')));
 
+                $defaultRedirect = $this->generateUrl('coreshop_customer_addresses');
+
                 return $this->redirect(
-                    $this->getParameterFromRequest($request, '_redirect', $this->generateUrl('coreshop_customer_addresses')),
+                    $this->validateRedirectUrl(
+                        $request,
+                        (string) $this->getParameterFromRequest($request, '_redirect', $defaultRedirect),
+                        $defaultRedirect,
+                    ),
                 );
             }
         }

--- a/src/CoreShop/Bundle/FrontendBundle/Controller/FrontendController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/FrontendController.php
@@ -73,4 +73,50 @@ abstract class FrontendController extends AbstractController
 
         return $default;
     }
+
+    /**
+     * Validates a redirect URL to prevent open redirects.
+     *
+     * Only allows:
+     * - Relative URLs (starting with "/" but not "//")
+     * - URLs on the same host as the current request
+     *
+     * @param Request $request The current request to validate against
+     * @param string  $url     The URL to validate
+     * @param string  $default The default URL to return if validation fails
+     *
+     * @return string The validated URL or the default if invalid
+     */
+    protected function validateRedirectUrl(Request $request, string $url, string $default): string
+    {
+        // Empty URL, use default
+        if ('' === $url) {
+            return $default;
+        }
+
+        // Check for protocol-relative URLs (//example.com) which could be used for open redirects
+        if (str_starts_with($url, '//')) {
+            return $default;
+        }
+
+        // Relative URLs (starting with /) are safe
+        if (str_starts_with($url, '/')) {
+            return $url;
+        }
+
+        // For absolute URLs, verify the host matches the current request
+        $parsedUrl = parse_url($url);
+
+        // If parsing failed or no host is present, use default
+        if (false === $parsedUrl || !isset($parsedUrl['host'])) {
+            return $default;
+        }
+
+        // Check if the host matches the current request host
+        if (strtolower($parsedUrl['host']) === strtolower($request->getHost())) {
+            return $url;
+        }
+
+        return $default;
+    }
 }

--- a/src/CoreShop/Bundle/FrontendBundle/Controller/FrontendController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/FrontendController.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 namespace CoreShop\Bundle\FrontendBundle\Controller;
 
 use CoreShop\Bundle\FrontendBundle\TemplateConfigurator\TemplateConfiguratorInterface;
+use CoreShop\Bundle\ResourceBundle\Controller\RedirectUrlValidationTrait;
 use CoreShop\Component\Core\Context\ShopperContextInterface;
 use CoreShop\Component\Order\Context\CartContextInterface;
 use CoreShop\Component\SEO\SEOPresentationInterface;
@@ -29,6 +30,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 abstract class FrontendController extends AbstractController
 {
+    use RedirectUrlValidationTrait;
+
     public function __construct(
         \Psr\Container\ContainerInterface $container,
     ) {
@@ -69,67 +72,6 @@ abstract class FrontendController extends AbstractController
 
         if ($request->request->has($key)) {
             return $request->request->all()[$key];
-        }
-
-        return $default;
-    }
-
-    /**
-     * Validates a redirect URL to prevent open redirects.
-     *
-     * Only allows:
-     * - Relative URLs (starting with "/" but not "//")
-     * - URLs on the same host as the current request with http/https scheme
-     *
-     * @param Request $request The current request to validate against
-     * @param string  $url     The URL to validate
-     * @param string  $default The default URL to return if validation fails
-     *
-     * @return string The validated URL or the default if invalid
-     */
-    protected function validateRedirectUrl(Request $request, string $url, string $default): string
-    {
-        // Empty URL, use default
-        if ('' === $url) {
-            return $default;
-        }
-
-        // Check for protocol-relative URLs (//example.com) which could be used for open redirects
-        if (str_starts_with($url, '//')) {
-            return $default;
-        }
-
-        // Relative URLs (starting with /) are safe if they don't contain dangerous characters
-        if (str_starts_with($url, '/')) {
-            // Reject URLs with backslashes, control characters, or whitespace that could be misinterpreted
-            if (preg_match('/[\\\\\\x00-\\x1f\\x7f]/', $url)) {
-                return $default;
-            }
-
-            return $url;
-        }
-
-        // For absolute URLs, verify the host matches the current request
-        $parsedUrl = parse_url($url);
-
-        // If parsing failed or no host is present, use default
-        if (false === $parsedUrl || !isset($parsedUrl['host'])) {
-            return $default;
-        }
-
-        // Only allow http and https schemes
-        if (isset($parsedUrl['scheme']) && !in_array(strtolower($parsedUrl['scheme']), ['http', 'https'], true)) {
-            return $default;
-        }
-
-        // Reject URLs with @ in the authority component (user:pass@host manipulation)
-        if (isset($parsedUrl['user']) || str_contains($url, '@')) {
-            return $default;
-        }
-
-        // Check if the host matches the current request host
-        if (strtolower($parsedUrl['host']) === strtolower($request->getHost())) {
-            return $url;
         }
 
         return $default;

--- a/src/CoreShop/Bundle/FrontendBundle/Controller/FrontendController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/FrontendController.php
@@ -79,7 +79,7 @@ abstract class FrontendController extends AbstractController
      *
      * Only allows:
      * - Relative URLs (starting with "/" but not "//")
-     * - URLs on the same host as the current request
+     * - URLs on the same host as the current request with http/https scheme
      *
      * @param Request $request The current request to validate against
      * @param string  $url     The URL to validate
@@ -99,8 +99,13 @@ abstract class FrontendController extends AbstractController
             return $default;
         }
 
-        // Relative URLs (starting with /) are safe
+        // Relative URLs (starting with /) are safe if they don't contain dangerous characters
         if (str_starts_with($url, '/')) {
+            // Reject URLs with backslashes, control characters, or whitespace that could be misinterpreted
+            if (preg_match('/[\\\\\\x00-\\x1f\\x7f]/', $url)) {
+                return $default;
+            }
+
             return $url;
         }
 
@@ -109,6 +114,16 @@ abstract class FrontendController extends AbstractController
 
         // If parsing failed or no host is present, use default
         if (false === $parsedUrl || !isset($parsedUrl['host'])) {
+            return $default;
+        }
+
+        // Only allow http and https schemes
+        if (isset($parsedUrl['scheme']) && !in_array(strtolower($parsedUrl['scheme']), ['http', 'https'], true)) {
+            return $default;
+        }
+
+        // Reject URLs with @ in the authority component (user:pass@host manipulation)
+        if (isset($parsedUrl['user']) || str_contains($url, '@')) {
             return $default;
         }
 

--- a/src/CoreShop/Bundle/FrontendBundle/Controller/RegisterController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/RegisterController.php
@@ -50,7 +50,12 @@ class RegisterController extends FrontendController
 
         $form = $this->container->get('form.factory')->createNamed('customer', CustomerRegistrationType::class, $this->container->get('coreshop.factory.customer')->createNew());
 
-        $redirect = $this->getParameterFromRequest($request, '_redirect', $this->generateUrl('coreshop_customer_profile'));
+        $defaultRedirect = $this->generateUrl('coreshop_customer_profile');
+        $redirect = $this->validateRedirectUrl(
+            $request,
+            (string) $this->getParameterFromRequest($request, '_redirect', $defaultRedirect),
+            $defaultRedirect,
+        );
 
         if (in_array($request->getMethod(), ['POST', 'PUT', 'PATCH'], true)) {
             $form = $form->handleRequest($request);

--- a/src/CoreShop/Bundle/FrontendBundle/Controller/SecurityController.php
+++ b/src/CoreShop/Bundle/FrontendBundle/Controller/SecurityController.php
@@ -46,9 +46,26 @@ class SecurityController extends FrontendController
             'form' => $form->createView(),
             'last_username' => $lastUsername,
             'last_error' => $lastError,
-            'target' => $this->getParameterFromRequest($request, 'target', null),
-            'failure' => $this->getParameterFromRequest($request, 'failure', null),
+            'target' => $this->validateRedirectParameter($request, 'target'),
+            'failure' => $this->validateRedirectParameter($request, 'failure'),
         ]);
+    }
+
+    /**
+     * The values end up in the "_target_path"/"_failure_path" fields of the login form, which
+     * Symfony redirects to after a successful/failed login attempt.
+     */
+    private function validateRedirectParameter(Request $request, string $parameter): ?string
+    {
+        $value = $this->getParameterFromRequest($request, $parameter, null);
+
+        if (!is_string($value) || '' === $value) {
+            return null;
+        }
+
+        $validated = $this->validateRedirectUrl($request, $value, '');
+
+        return '' === $validated ? null : $validated;
     }
 
     public static function getSubscribedServices(): array

--- a/src/CoreShop/Bundle/ResourceBundle/Controller/RedirectUrlValidationTrait.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Controller/RedirectUrlValidationTrait.php
@@ -42,18 +42,19 @@ trait RedirectUrlValidationTrait
             return $default;
         }
 
+        // Reject backslashes and control characters anywhere in the URL: browsers normalise
+        // backslashes to slashes and control characters can hide a different target from parse_url()
+        if (preg_match('/[\\\\\\x00-\\x1f\\x7f]/', $url)) {
+            return $default;
+        }
+
         // Check for protocol-relative URLs (//example.com) which could be used for open redirects
         if (str_starts_with($url, '//')) {
             return $default;
         }
 
-        // Relative URLs (starting with /) are safe if they don't contain dangerous characters
+        // Relative URLs (starting with a single /) are safe
         if (str_starts_with($url, '/')) {
-            // Reject URLs with backslashes, control characters, or whitespace that could be misinterpreted
-            if (preg_match('/[\\\\\\x00-\\x1f\\x7f]/', $url)) {
-                return $default;
-            }
-
             return $url;
         }
 
@@ -70,8 +71,9 @@ trait RedirectUrlValidationTrait
             return $default;
         }
 
-        // Reject URLs with @ in the authority component (user:pass@host manipulation)
-        if (isset($parsedUrl['user']) || str_contains($url, '@')) {
+        // Reject credentials in the authority component (user:pass@host manipulation).
+        // Only the authority is checked, an "@" inside the query or fragment is harmless.
+        if (isset($parsedUrl['user']) || isset($parsedUrl['pass'])) {
             return $default;
         }
 

--- a/src/CoreShop/Bundle/ResourceBundle/Controller/RedirectUrlValidationTrait.php
+++ b/src/CoreShop/Bundle/ResourceBundle/Controller/RedirectUrlValidationTrait.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CoreShop
+ *
+ * This source file is available under two different licenses:
+ *  - GNU General Public License version 3 (GPLv3)
+ *  - CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    https://www.coreshop.com/license     GPLv3 and CCL
+ *
+ */
+
+namespace CoreShop\Bundle\ResourceBundle\Controller;
+
+use Symfony\Component\HttpFoundation\Request;
+
+trait RedirectUrlValidationTrait
+{
+    /**
+     * Validates a redirect URL to prevent open redirects.
+     *
+     * Only allows:
+     * - Relative URLs (starting with "/" but not "//")
+     * - URLs on the same host as the current request with http/https scheme
+     *
+     * @param Request $request The current request to validate against
+     * @param string  $url     The URL to validate
+     * @param string  $default The default URL to return if validation fails
+     *
+     * @return string The validated URL or the default if invalid
+     */
+    protected function validateRedirectUrl(Request $request, string $url, string $default): string
+    {
+        // Empty URL, use default
+        if ('' === $url) {
+            return $default;
+        }
+
+        // Check for protocol-relative URLs (//example.com) which could be used for open redirects
+        if (str_starts_with($url, '//')) {
+            return $default;
+        }
+
+        // Relative URLs (starting with /) are safe if they don't contain dangerous characters
+        if (str_starts_with($url, '/')) {
+            // Reject URLs with backslashes, control characters, or whitespace that could be misinterpreted
+            if (preg_match('/[\\\\\\x00-\\x1f\\x7f]/', $url)) {
+                return $default;
+            }
+
+            return $url;
+        }
+
+        // For absolute URLs, verify the host matches the current request
+        $parsedUrl = parse_url($url);
+
+        // If parsing failed or no host is present, use default
+        if (false === $parsedUrl || !isset($parsedUrl['host'])) {
+            return $default;
+        }
+
+        // Only allow http and https schemes
+        if (isset($parsedUrl['scheme']) && !in_array(strtolower($parsedUrl['scheme']), ['http', 'https'], true)) {
+            return $default;
+        }
+
+        // Reject URLs with @ in the authority component (user:pass@host manipulation)
+        if (isset($parsedUrl['user']) || str_contains($url, '@')) {
+            return $default;
+        }
+
+        // Check if the host matches the current request host
+        if (strtolower($parsedUrl['host']) === strtolower($request->getHost())) {
+            return $url;
+        }
+
+        return $default;
+    }
+}

--- a/src/CoreShop/Bundle/StorageListBundle/Controller/StorageListController.php
+++ b/src/CoreShop/Bundle/StorageListBundle/Controller/StorageListController.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 
 namespace CoreShop\Bundle\StorageListBundle\Controller;
 
+use CoreShop\Bundle\ResourceBundle\Controller\RedirectUrlValidationTrait;
 use CoreShop\Component\Resource\Model\ResourceInterface;
 use CoreShop\Component\Resource\Repository\RepositoryInterface;
 use CoreShop\Component\StorageList\Context\StorageListContextInterface;
@@ -45,6 +46,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class StorageListController extends AbstractController
 {
+    use RedirectUrlValidationTrait;
+
     public function __construct(
         ContainerInterface $container,
         protected string $identifier,
@@ -290,67 +293,6 @@ class StorageListController extends AbstractController
 
         if ($request->request->has($key)) {
             return $request->request->all()[$key];
-        }
-
-        return $default;
-    }
-
-    /**
-     * Validates a redirect URL to prevent open redirects.
-     *
-     * Only allows:
-     * - Relative URLs (starting with "/" but not "//")
-     * - URLs on the same host as the current request with http/https scheme
-     *
-     * @param Request $request The current request to validate against
-     * @param string  $url     The URL to validate
-     * @param string  $default The default URL to return if validation fails
-     *
-     * @return string The validated URL or the default if invalid
-     */
-    protected function validateRedirectUrl(Request $request, string $url, string $default): string
-    {
-        // Empty URL, use default
-        if ('' === $url) {
-            return $default;
-        }
-
-        // Check for protocol-relative URLs (//example.com) which could be used for open redirects
-        if (str_starts_with($url, '//')) {
-            return $default;
-        }
-
-        // Relative URLs (starting with /) are safe if they don't contain dangerous characters
-        if (str_starts_with($url, '/')) {
-            // Reject URLs with backslashes, control characters, or whitespace that could be misinterpreted
-            if (preg_match('/[\\\\\\x00-\\x1f\\x7f]/', $url)) {
-                return $default;
-            }
-
-            return $url;
-        }
-
-        // For absolute URLs, verify the host matches the current request
-        $parsedUrl = parse_url($url);
-
-        // If parsing failed or no host is present, use default
-        if (false === $parsedUrl || !isset($parsedUrl['host'])) {
-            return $default;
-        }
-
-        // Only allow http and https schemes
-        if (isset($parsedUrl['scheme']) && !in_array(strtolower($parsedUrl['scheme']), ['http', 'https'], true)) {
-            return $default;
-        }
-
-        // Reject URLs with @ in the authority component (user:pass@host manipulation)
-        if (isset($parsedUrl['user']) || str_contains($url, '@')) {
-            return $default;
-        }
-
-        // Check if the host matches the current request host
-        if (strtolower($parsedUrl['host']) === strtolower($request->getHost())) {
-            return $url;
         }
 
         return $default;

--- a/src/CoreShop/Bundle/StorageListBundle/Controller/StorageListController.php
+++ b/src/CoreShop/Bundle/StorageListBundle/Controller/StorageListController.php
@@ -300,7 +300,7 @@ class StorageListController extends AbstractController
      *
      * Only allows:
      * - Relative URLs (starting with "/" but not "//")
-     * - URLs on the same host as the current request
+     * - URLs on the same host as the current request with http/https scheme
      *
      * @param Request $request The current request to validate against
      * @param string  $url     The URL to validate
@@ -320,8 +320,13 @@ class StorageListController extends AbstractController
             return $default;
         }
 
-        // Relative URLs (starting with /) are safe
+        // Relative URLs (starting with /) are safe if they don't contain dangerous characters
         if (str_starts_with($url, '/')) {
+            // Reject URLs with backslashes, control characters, or whitespace that could be misinterpreted
+            if (preg_match('/[\\\\\\x00-\\x1f\\x7f]/', $url)) {
+                return $default;
+            }
+
             return $url;
         }
 
@@ -330,6 +335,16 @@ class StorageListController extends AbstractController
 
         // If parsing failed or no host is present, use default
         if (false === $parsedUrl || !isset($parsedUrl['host'])) {
+            return $default;
+        }
+
+        // Only allow http and https schemes
+        if (isset($parsedUrl['scheme']) && !in_array(strtolower($parsedUrl['scheme']), ['http', 'https'], true)) {
+            return $default;
+        }
+
+        // Reject URLs with @ in the authority component (user:pass@host manipulation)
+        if (isset($parsedUrl['user']) || str_contains($url, '@')) {
             return $default;
         }
 

--- a/src/CoreShop/Bundle/StorageListBundle/Controller/StorageListController.php
+++ b/src/CoreShop/Bundle/StorageListBundle/Controller/StorageListController.php
@@ -85,7 +85,12 @@ class StorageListController extends AbstractController
         $this->denyAccessUnlessGranted($privilege);
         $this->denyAccessUnlessGranted($privilegeAdd);
 
-        $redirect = $this->getParameterFromRequest($request, '_redirect', $this->generateUrl($this->summaryRoute));
+        $defaultRedirect = $this->generateUrl($this->summaryRoute);
+        $redirect = $this->validateRedirectUrl(
+            $request,
+            (string) $this->getParameterFromRequest($request, '_redirect', $defaultRedirect),
+            $defaultRedirect,
+        );
         $product = $this->productRepository->find($this->getParameterFromRequest($request, 'product'));
         $storageList = $this->context->getStorageList();
 
@@ -285,6 +290,52 @@ class StorageListController extends AbstractController
 
         if ($request->request->has($key)) {
             return $request->request->all()[$key];
+        }
+
+        return $default;
+    }
+
+    /**
+     * Validates a redirect URL to prevent open redirects.
+     *
+     * Only allows:
+     * - Relative URLs (starting with "/" but not "//")
+     * - URLs on the same host as the current request
+     *
+     * @param Request $request The current request to validate against
+     * @param string  $url     The URL to validate
+     * @param string  $default The default URL to return if validation fails
+     *
+     * @return string The validated URL or the default if invalid
+     */
+    protected function validateRedirectUrl(Request $request, string $url, string $default): string
+    {
+        // Empty URL, use default
+        if ('' === $url) {
+            return $default;
+        }
+
+        // Check for protocol-relative URLs (//example.com) which could be used for open redirects
+        if (str_starts_with($url, '//')) {
+            return $default;
+        }
+
+        // Relative URLs (starting with /) are safe
+        if (str_starts_with($url, '/')) {
+            return $url;
+        }
+
+        // For absolute URLs, verify the host matches the current request
+        $parsedUrl = parse_url($url);
+
+        // If parsing failed or no host is present, use default
+        if (false === $parsedUrl || !isset($parsedUrl['host'])) {
+            return $default;
+        }
+
+        // Check if the host matches the current request host
+        if (strtolower($parsedUrl['host']) === strtolower($request->getHost())) {
+            return $url;
         }
 
         return $default;


### PR DESCRIPTION
Upmerge of `4.1` into `5.0`.

**Remember!** The upmerge should always be merged with the `Merge pull request` button.

### What it carries forward
- #2963 — **security fix: open redirect via the `_redirect` parameter**, including the new login success/failure handlers (5 commits).

### Security-relevant files carried by this merge
A reviewer can confirm at a glance that the fix arrived intact:

| file | role |
|---|---|
| `ResourceBundle/Controller/RedirectUrlValidationTrait.php` | **new** — the single `validateRedirectUrl()` implementation (rejects dangerous schemes/special characters, scopes the authority check) |
| `CoreBundle/Security/ShopUserAuthenticationSuccessHandler.php` | **new** — validates the post-login redirect target |
| `CoreBundle/Security/ShopUserAuthenticationFailureHandler.php` | **new** — reads the failure path from the request bags directly, avoiding Symfony's internal `ParameterBagUtils` |
| `CoreBundle/Resources/config/services/handler.yml` | wires both handlers (`@security.http_utils`, `@http_kernel`) |
| `CoreBundle/Resources/config/pimcore/security.yml` | registers them as `success_handler` / `failure_handler` on the shop firewall |
| `FrontendBundle/Controller/{Cart,Customer,Frontend,Register,Security}Controller.php` | consume the trait instead of trusting `_redirect` |
| `StorageListBundle/Controller/StorageListController.php` | same |
| `features/ui/frontend/account/login.feature`, `Behat/Context/Ui/Frontend/LoginContext.php` | regression coverage |

All three new classes are present on the merged tree (verified by path, not just by diff).

### Conflicts
None — the merge applied cleanly, zero conflicted files.

### Verification

Net diff against `5.0` is exactly the 13 files of #2963 and nothing else:

```
 features/ui/frontend/account/login.feature         |  7 ++
 .../Behat/Context/Ui/Frontend/LoginContext.php     |  8 ++
 .../Resources/config/pimcore/security.yml          |  2 +
 .../Resources/config/services/handler.yml          |  9 +++
 .../ShopUserAuthenticationFailureHandler.php       | 72 ++++++++++++++++++
 .../ShopUserAuthenticationSuccessHandler.php       | 41 ++++++++++
 .../FrontendBundle/Controller/CartController.php   | 14 +++-
 .../Controller/CustomerController.php              |  8 +-
 .../Controller/FrontendController.php              |  3 +
 .../Controller/RegisterController.php              |  7 +-
 .../Controller/SecurityController.php              | 21 +++++-
 .../Controller/RedirectUrlValidationTrait.php      | 87 ++++++++++++++++++++++
 .../Controller/StorageListController.php           | 10 ++-
 13 files changed, 282 insertions(+), 7 deletions(-)
```

- **No duplication**: exactly **one** `validateRedirectUrl()` definition exists on the merged tree (the trait), consumed by 5 files. `5.0` had no prior equivalent — both handler classes are new, not overwrites.
- **The `security.yml` touched here is `CoreBundle/Resources/config/pimcore/security.yml`**, the shop firewall config — *not* the root `config/packages/security.yaml`. The root file is **not touched** by this merge, so nothing regex-related is affected on this leg.
- Root `composer.json`: not touched; `replace` set equality holds — **65 split packages, 65 entries, missing `[]`, extra `[]`**.
- Split-package branch-value invariant: **`checked=65 bad=0`** (siblings `^5.0`, `branch-alias.dev-main` at `5.0-dev`).
- No files under any `Resources/public/studio/` touched.
- `php -l` clean on every changed PHP file; `handler.yml` parses. `pimcore/security.yml` fails a strict PyYAML parse on the pre-existing IPv6 `::1` in flow syntax — the identical failure occurs on pristine `5.0`, so it is not merge-induced and Symfony's parser accepts it.

### Ordering
This is the first of three legs. Merge order: **this PR → `[UPMERGE] 5.0 -> 5.1` → `[UPMERGE] 5.1 -> 2026.x`.**
