### PR TITLE
Merge in the upmerge workflow and auto-resolve Studio artifact conflicts

### DIFF
--- a/.github/workflows/upmerge.yaml
+++ b/.github/workflows/upmerge.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'coreshop/coreshop'
     name: Upmerge
-    timeout-minutes: 5
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -35,23 +35,133 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ matrix.target_branch }}
+          # A real merge needs the full history of both branches.
+          fetch-depth: 0
 
       -
-        name: Reset upmerge branch
+        name: Merge ${{ matrix.base_branch }} into ${{ matrix.target_branch }}
+        id: merge
+        env:
+          BASE: ${{ matrix.base_branch }}
+          TARGET: ${{ matrix.target_branch }}
+          UPMERGE_BRANCH: "upmerge/${{ matrix.base_branch }}_${{ matrix.target_branch }}"
         run: |
-          git fetch origin ${{ matrix.base_branch }}:${{ matrix.base_branch }}
-          git reset --hard ${{ matrix.base_branch }}
+          set -euo pipefail
+
+          # The only tracked generated content in the repository is the Studio build output, and
+          # it lives exclusively under this pathspec — the same one `shared-frontend-build` stages
+          # after a build. It is also the only pathspec the automatic conflict resolution below
+          # ever passes to git, which is what bounds that resolution to build artifacts.
+          # The trailing `/*` is load-bearing: a git pathspec containing a wildcard is matched
+          # against the whole path, so without it nothing under the directory matches at all.
+          ARTIFACTS='src/CoreShop/Bundle/*/Resources/public/studio/*'
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+          git fetch --no-tags origin "${BASE}:refs/remotes/origin/${BASE}"
+
+          if [ "$(git rev-list --count "HEAD..origin/${BASE}")" -eq 0 ]; then
+            echo 'status=skipped' >> "$GITHUB_OUTPUT"
+            echo "Nothing to merge: \`${TARGET}\` already contains every commit from \`${BASE}\`." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # `create-pull-request` resets an existing pull request branch to whatever this run
+          # produces, and it offers no way to opt out of that. So the branch is checked for
+          # commits this workflow did not make — a human's conflict resolution — and the leg is
+          # left alone rather than force-pushed over. It resumes once that pull request is merged
+          # and the branch is deleted.
+          if git fetch --no-tags origin "${UPMERGE_BRANCH}:refs/remotes/origin/${UPMERGE_BRANCH}" 2>/dev/null; then
+            FOREIGN="$(git log --format='%h %an <%ae> %s' "origin/${UPMERGE_BRANCH}" --not HEAD "origin/${BASE}" \
+              | grep -v ' github-actions\[bot\] ' || true)"
+            if [ -n "$FOREIGN" ]; then
+              echo 'status=skipped' >> "$GITHUB_OUTPUT"
+              {
+                echo "Skipped: \`${UPMERGE_BRANCH}\` carries commits that this workflow did not make."
+                echo
+                echo '```'
+                echo "$FOREIGN"
+                echo '```'
+                echo
+                echo 'Recreating the branch would discard that work, so this leg is left untouched'
+                echo 'until its pull request is merged.'
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+          fi
+
+          # `--no-commit` so that the clean and the conflicted case converge on the same
+          # normalisation and the same commit below.
+          if git merge --no-commit --no-ff "origin/${BASE}"; then
+            :
+          else
+            OUTSIDE="$(git diff --name-only --diff-filter=U -- . ":(exclude)${ARTIFACTS}")"
+            if [ -n "$OUTSIDE" ]; then
+              # A genuine source conflict. Nothing is resolved automatically; the branch is reset
+              # to the base exactly as this workflow always did, so the pull request opens with
+              # the conflicts visible and a human resolves them.
+              git merge --abort
+              git reset --hard "origin/${BASE}"
+              echo 'status=conflict' >> "$GITHUB_OUTPUT"
+              echo "note=**Not merged automatically.** This branch is the tip of \`${BASE}\`; it conflicts with \`${TARGET}\` outside the Studio build artifacts, so nothing was resolved for you. Please resolve it manually." >> "$GITHUB_OUTPUT"
+              {
+                echo "Conflicts outside the Studio build artifacts — left for manual resolution:"
+                echo
+                echo '```'
+                echo "$OUTSIDE"
+                echo '```'
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+          fi
+
+          # Take the target's build output wholesale instead of resolving artifact conflicts file
+          # by file. Rename detection pairs build directories across branches only sometimes, so a
+          # file-by-file resolution can still leave both branches' directories side by side;
+          # restoring the target's tree verbatim keeps exactly one build directory per bundle.
+          #
+          # Nothing is lost by preferring the target: `shared-frontend-build` rebuilds and commits
+          # these assets on the next push to a release branch, so the merged branch regenerates
+          # them from the merged sources anyway.
+          git rm -rq --force --ignore-unmatch -- "$ARTIFACTS"
+          git checkout HEAD -- "$ARTIFACTS"
+
+          # Post-conditions. Both must hold before anything is committed.
+          if [ -n "$(git diff --name-only --diff-filter=U)" ]; then
+            echo '::error::Unmerged paths remain after resolving the Studio build artifacts.'
+            exit 1
+          fi
+          if ! git diff --cached --quiet HEAD -- "$ARTIFACTS"; then
+            echo '::error::The Studio build artifacts do not match the target branch after resolution.'
+            exit 1
+          fi
+
+          git commit --no-edit --no-verify -m "Merge branch '${BASE}' into ${TARGET}"
+
+          echo 'status=merged' >> "$GITHUB_OUTPUT"
+          echo "note=Merged automatically. Conflicting Studio build artifacts, if any, were resolved in favour of \`${TARGET}\`." >> "$GITHUB_OUTPUT"
+          {
+            echo "Merged \`${BASE}\` into \`${TARGET}\`."
+            echo
+            echo '```'
+            git show --stat --format='%h %s' HEAD | head -50
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       -
         name: Create Pull Request
+        if: steps.merge.outputs.status != 'skipped'
         uses: peter-evans/create-pull-request@v8
         with:
           title: '[UPMERGE] ${{ matrix.base_branch }} -> ${{ matrix.target_branch }}'
           body: |
             This PR has been generated automatically.
-            
+
+            ${{ steps.merge.outputs.note }}
+
             **Remember!** The upmerge should always be merged with using `Merge pull request` button.
-            
+
             In case of conflicts, please resolve them manually with usign the following commands:
             ```
             git fetch upstream


### PR DESCRIPTION
Fixes #3185

The nightly upmerge now performs the merge itself, resolves Studio build-artifact conflicts in favour of the target branch, and skips legs that have nothing to merge instead of failing.

## What changed

`git reset --hard <base>` is replaced by `git merge --no-commit --no-ff origin/<base>` on top of the target branch, plus four guards:

1. **Nothing to merge** — if `git rev-list --count HEAD..origin/<base>` is `0` the leg exits early with a note in the job summary, and `create-pull-request` is skipped via `if: steps.merge.outputs.status != 'skipped'`. This removes the nightly `Validation Failed: {"message":"No commits between ..."}`.
2. **Artifact conflicts** — resolved automatically in favour of the target.
3. **Any other conflict** — `git merge --abort` followed by `git reset --hard origin/<base>`, i.e. byte-for-byte today's behaviour, so the PR opens with the conflicts visible and a human resolves them. The PR body says so explicitly in that case.
4. **Human-owned branch** — if `upmerge/<base>_<target>` already carries commits this workflow did not author, the leg is skipped rather than recreated.

Branch naming (`upmerge/<base>_<target>`) and PR titles (`[UPMERGE] <base> -> <target>`) are unchanged, so the guardrail's merge-up exemption still keys off them.

## How the auto-resolution is bounded to artifacts

The resolution is two commands, and both are restricted to one pathspec that is defined once at the top of the step:

```sh
ARTIFACTS='src/CoreShop/Bundle/*/Resources/public/studio/*'
...
git rm -rq --force --ignore-unmatch -- "$ARTIFACTS"
git checkout HEAD -- "$ARTIFACTS"
```

No other command in the step writes to the index or the working tree, so by construction nothing outside that pathspec can be altered. Before the resolution runs at all, the step checks `git diff --name-only --diff-filter=U -- . ":(exclude)$ARTIFACTS"` and bails out to the manual path if it is non-empty. Afterwards two post-conditions are asserted and fail the job if violated: no unmerged paths remain, and `git diff --cached HEAD -- "$ARTIFACTS"` is empty (the artifact tree is exactly the target's).

Two notes on the pathspec:

* It is the same glob `shared-frontend-build` uses to stage built assets, and it is exhaustive — every one of the 925 tracked files whose path contains `/studio/` matches it, and no tracked file outside `src/CoreShop/Bundle/*/Resources/public/studio/` carries Studio output. There is no component-level or otherwise differently laid out copy.
* The trailing `/*` is load-bearing. A git pathspec containing a wildcard is matched against the whole path, so `.../public/studio` alone matches **zero** files. The first draft of this change had that bug and silently classified last night's artifact-only conflict as a source conflict.

The resolution takes the target's artifact tree wholesale rather than resolving conflicted files one by one. Rename detection only sometimes pairs build directories across branches, so a file-by-file resolution can leave both branches' build directories in the tree; restoring the target's subtree verbatim guarantees exactly one build directory per bundle.

**Nothing is lost by preferring the target.** `shared-frontend-build` rebuilds and commits these assets on every push to a release branch, so the merged target regenerates them from the merged sources right after the PR lands.

## Verification

`actionlint` is clean. The step's `run:` script was extracted from the YAML with `yaml.safe_load` and executed **verbatim** against throwaway clones, so what was tested is exactly what will run.

### Last night's scenario (#3184): `5.1` → `2026.x`, artifacts only

Reconstructed from the real commits — target `879d4ffb70`, base `eb4d84986f`, merge base `e2bb61e44`:

```
script exit: 0
status=merged

1. merge commit: 2d36accbe parents=[879d4ffb7 eb4d84986] Merge branch '5.1' into 2026.x
2. net diff vs target 2026.x  : 0 changed files
3. artifacts differing from target: 0
5. bundles with more than one build dir: count: 0
6. total bundles with exactly one build dir: 22
7. tree identical to the human resolution 0c32e4ec20: YES
```

Point 7 is the strongest result: the automated resolution produces a tree **byte-identical** to the one the maintainer produced by hand last night.

And nothing was dropped, because there was nothing outside the artifacts to drop:

```
merge base: e2bb61e44 Merge pull request #3181 from coreshop/upmerge/5.0_5.1

paths 5.1 changed since the merge base, OUTSIDE artifacts:
    count: 0
5.1 brought no non-artifact changes at all -> nothing could be dropped.

paths 5.1 changed since the merge base, INSIDE artifacts: 12
```

12 changed files, 16 conflicts, all under the artifact pathspec — matching #3184 exactly.

### Genuine source conflict: must NOT auto-resolve

Same two branches, plus conflicting edits to `src/CoreShop/Bundle/CoreBundle/CoreShopCoreBundle.php` on each side — so the merge has both artifact conflicts *and* a real source conflict:

```
script exit: 0
status=conflict
note=**Not merged automatically.** This branch is the tip of `5.1`; it conflicts with `2026.x`
     outside the Studio build artifacts, so nothing was resolved for you. Please resolve it manually.

Conflicts outside the Studio build artifacts — left for manual resolution:
    src/CoreShop/Bundle/CoreBundle/CoreShopCoreBundle.php

HEAD is now: 5abc20ed2 Base-side source change
HEAD == tip of base 5.1 (today's behaviour): YES
any merge in progress: NO
```

Nothing was resolved, nothing was committed, and the branch is the base tip — identical to what the workflow does today.

### Empty leg

Target already contains the base (`2f2b65602a` / `eb4d84986f`):

```
exit: 0   (job stays green)
status=skipped
Nothing to merge: `2026.x` already contains every commit from `5.1`.
```

### Branch carrying a human's resolution

```
status=skipped
Skipped: `upmerge/5.1_2026.x` carries commits that this workflow did not make.
    c3797ace7 Dominik Pfaffenbauer <pfaffenbauer@cors.gmbh> Resolve conflicts between 5.1 and 2026.x
```

A branch whose extra commits are all `github-actions[bot]` is **not** skipped and updates as usual (verified separately: `status=merged`).

## On the force-push

`peter-evans/create-pull-request` cannot express "only reset the branch when it has no non-bot commits". Its `create-or-update-branch` logic resets the PR branch to the freshly built temp branch whenever the two differ, with no opt-out. So the guard is implemented before the action runs, by inspecting `origin/<upmerge-branch>` for commits not reachable from the base or the target and not authored by `github-actions[bot]`, and skipping the leg if any exist. The leg resumes once that PR is merged and the branch is deleted.

Reading that same logic confirmed the merge commit survives: because the checked-out branch *is* the action's `base`, no cherry-pick or squash happens, and the merge commit is pushed as-is. That matters — a squashed PR would leave the base commits unreachable from the target and the same leg would be proposed again every night.

## Deliberately not done

* **The stale matrices on `4.1`, `5.0` and `5.1` are untouched.** All three still list `3.2→4.0 … 5.0→next`. Only `2026.x` carries the current legs, and since a scheduled workflow only runs from the default branch (`2026.x`), those copies never execute. They are cleaned up by the upmerge itself; fixing them here would mean three extra PRs for dead configuration.
* **Artifact changes from the base are discarded even when they would merge cleanly**, since the target's subtree is restored wholesale. This is intentional (see above) and self-heals on the next build. One consequence worth naming: if the base adds a *new* bundle with Studio assets, that bundle's assets are absent from the merge commit until `shared-frontend-build` runs on the target, which happens on the very next push.
