### PR TITLE
Raise the Pimcore floor to ^2026.2

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -51,11 +51,11 @@ jobs:
       matrix:
         include:
           - php: 8.4
-            pimcore: ^2026.1
+            pimcore: ^2026.2
             dependencies: highest
             allow-failure: false
           - php: 8.5
-            pimcore: ^2026.1
+            pimcore: ^2026.2
             dependencies: highest
             allow-failure: true
 

--- a/.github/workflows/behat_ui.yml
+++ b/.github/workflows/behat_ui.yml
@@ -52,11 +52,11 @@ jobs:
       matrix:
         include:
           - php: 8.4
-            pimcore: ^2026.1
+            pimcore: ^2026.2
             dependencies: highest
             allow-failure: false
           - php: 8.5
-            pimcore: ^2026.1
+            pimcore: ^2026.2
             dependencies: highest
             allow-failure: true
 

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         php: [ 8.4, 8.5 ]
-        pimcore: [ ^2026.1 ]
+        pimcore: [ ^2026.2 ]
         dependencies: [ highest ]
     services:
       database:

--- a/.github/workflows/packages_bundles.yml
+++ b/.github/workflows/packages_bundles.yml
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [ 8.4, 8.5 ]
-        pimcore: [ ^2026.1 ]
+        pimcore: [ ^2026.2 ]
         dependencies: [ highest, lowest ]
         package: "${{ fromJson(needs.list.outputs.packages) }}"
         exclude:

--- a/.github/workflows/packages_components.yml
+++ b/.github/workflows/packages_components.yml
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [ 8.4, 8.5 ]
-        pimcore: [ ^2026.1 ]
+        pimcore: [ ^2026.2 ]
         dependencies: [ highest, lowest ]
         package: "${{ fromJson(needs.list.outputs.packages) }}"
         exclude:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         php: [ 8.4, 8.5 ]
-        pimcore: [ ^2026.1 ]
+        pimcore: [ ^2026.2 ]
         dependencies: [ highest, lowest ]
         exclude:
           - php: 8.5

--- a/CHANGELOG-2026.1.x.md
+++ b/CHANGELOG-2026.1.x.md
@@ -6,11 +6,15 @@ CoreShop switches from semantic versioning to Pimcore's year-based scheme. The p
 remains the last semver release and continues to receive maintenance; all new development targets
 `2026.1` and up.
 
-### Pimcore 2026.1 minimum requirement
+### Pimcore 2026.2 minimum requirement
 
-All CoreShop components and bundles now require **`pimcore/pimcore: ^2026.1`**. Companion bundles
-(`pimcore/studio-ui-bundle`, `pimcore/studio-backend-bundle`, `pimcore/generic-data-index-bundle`)
-are likewise bumped to `^2026.1`.
+All CoreShop components and bundles now require **`pimcore/pimcore: ^2026.2`**. Companion bundles
+(`pimcore/studio-ui-bundle`, `pimcore/studio-backend-bundle`, `pimcore/generic-data-index-bundle`,
+`pimcore/opensearch-client`) are likewise bumped to `^2026.2`.
+
+The floor tracks the Pimcore Studio SDK that CoreShop's Studio plugins are built and tested against.
+Pimcore removes exported symbols between minor versions, so declaring a minimum older than the SDK we
+build against would let Composer install a Pimcore that cannot load the shipped Studio bundles.
 
 ### Classic Admin / ExtJS removed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ Use `studio.en.yml` as the source of truth for English keys.
 ## Development Workflow
 
 - PHP 8.3+, PSR-12 via ECS, PHPStan level 3
-- Pimcore ^2026.1, Symfony 6.3+ or 7.0+
+- Pimcore ^2026.2, Symfony 6.3+ or 7.0+
 - Branch strategy: `4.0`, `4.1`, `5.0`, `2026.x` — no `master`; PRs target the lowest affected version branch, changes flow upward via automated upmerge (see `.github/workflows/upmerge.yaml`).
 
 ### Before Committing

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The build system auto-discovers all bundles with Studio assets under `src/CoreSh
 
 # Requirements
 
-- Pimcore `^2026.1`
+- Pimcore `^2026.2`
 
 # Installation
 

--- a/composer.json
+++ b/composer.json
@@ -110,7 +110,7 @@
     "payum/payum-bundle": "^2.6.2",
     "php-http/guzzle7-adapter": "^1.0",
     "php-http/message-factory": "^1.1",
-    "pimcore/pimcore": "^2026.1",
+    "pimcore/pimcore": "^2026.2",
     "rinvex/countries": "^9.0",
     "sebastian/diff": "^4.0 | ^5.0 | ^6.0",
     "stof/doctrine-extensions-bundle": "^1.14",
@@ -130,8 +130,8 @@
   "suggest": {
     "pimcore/opensearch-client": "Allows to use OpenSearch as your index engine.",
     "pimcore/elasticsearch-client": "Allows to use ElasticSearch as your index engine.",
-    "pimcore/generic-data-index-bundle": "^2.0 - Generic Data Index support for Pimcore Studio UI",
-    "pimcore/studio-ui-bundle": "^1.0 - Modern React-based Studio UI for Pimcore (recommended)"
+    "pimcore/generic-data-index-bundle": "^2026.2 - Generic Data Index support for Pimcore Studio UI",
+    "pimcore/studio-ui-bundle": "^2026.2 - Modern React-based Studio UI for Pimcore (recommended)"
   },
   "conflict": {
     "ezimuel/ringphp": "<1.4",
@@ -154,10 +154,10 @@
     "phpstan/phpstan-symfony": "^2.0",
     "phpstan/phpstan-webmozart-assert": "^2.0",
     "phpunit/phpunit": "^10.0",
-    "pimcore/opensearch-client": "^2026.1",
-    "pimcore/generic-data-index-bundle": "^2026.1",
-    "pimcore/studio-backend-bundle": "^2026.1",
-    "pimcore/studio-ui-bundle": "^2026.1",
+    "pimcore/opensearch-client": "^2026.2",
+    "pimcore/generic-data-index-bundle": "^2026.2",
+    "pimcore/studio-backend-bundle": "^2026.2",
+    "pimcore/studio-ui-bundle": "^2026.2",
     "robertfausk/behat-panther-extension": "^1.2",
     "symfony/browser-kit": "^6.4.14 || ^7.2",
     "symfony/css-selector": "^6.4.14 || ^7.2",

--- a/src/CoreShop/Bundle/AddressBundle/composer.json
+++ b/src/CoreShop/Bundle/AddressBundle/composer.json
@@ -26,10 +26,10 @@
     "require": {
         "coreshop/address": "^2026.1",
         "coreshop/resource-bundle": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
-        "pimcore/studio-ui-bundle": "^2026.1",
+        "pimcore/studio-ui-bundle": "^2026.2",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0"

--- a/src/CoreShop/Bundle/ClassDefinitionPatchBundle/composer.json
+++ b/src/CoreShop/Bundle/ClassDefinitionPatchBundle/composer.json
@@ -25,7 +25,7 @@
     ],
     "require": {
         "coreshop/pimcore": "^2026.1",
-        "pimcore/pimcore": "^2026.1",
+        "pimcore/pimcore": "^2026.2",
         "sebastian/diff": "^4.0 | ^5.0 | ^6.0"
     },
     "require-dev": {

--- a/src/CoreShop/Bundle/ConfigurationBundle/composer.json
+++ b/src/CoreShop/Bundle/ConfigurationBundle/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "coreshop/configuration": "^2026.1",
         "coreshop/resource-bundle": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Bundle/CoreBundle/composer.json
+++ b/src/CoreShop/Bundle/CoreBundle/composer.json
@@ -57,10 +57,10 @@
         "doctrine/doctrine-fixtures-bundle": "^3.4",
         "fakerphp/faker": "^1.16",
         "rinvex/countries": "^9.0",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
-        "pimcore/studio-ui-bundle": "^2026.1",
+        "pimcore/studio-ui-bundle": "^2026.2",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0"

--- a/src/CoreShop/Bundle/CurrencyBundle/composer.json
+++ b/src/CoreShop/Bundle/CurrencyBundle/composer.json
@@ -26,11 +26,11 @@
     "require": {
         "coreshop/currency": "^2026.1",
         "coreshop/resource-bundle": "^2026.1",
-        "pimcore/pimcore": "^2026.1",
+        "pimcore/pimcore": "^2026.2",
         "symfony/intl": "^6.4.14 || ^7.2"
     },
     "require-dev": {
-        "pimcore/studio-ui-bundle": "^2026.1",
+        "pimcore/studio-ui-bundle": "^2026.2",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0"

--- a/src/CoreShop/Bundle/CustomerBundle/composer.json
+++ b/src/CoreShop/Bundle/CustomerBundle/composer.json
@@ -26,10 +26,10 @@
     "require": {
         "coreshop/customer": "^2026.1",
         "coreshop/resource-bundle": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
-        "pimcore/studio-ui-bundle": "^2026.1",
+        "pimcore/studio-ui-bundle": "^2026.2",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0"

--- a/src/CoreShop/Bundle/FrontendBundle/composer.json
+++ b/src/CoreShop/Bundle/FrontendBundle/composer.json
@@ -25,7 +25,7 @@
     ],
     "require": {
         "coreshop/core-bundle": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Bundle/IndexBundle/composer.json
+++ b/src/CoreShop/Bundle/IndexBundle/composer.json
@@ -28,7 +28,7 @@
         "coreshop/registry": "^2026.1",
         "coreshop/resource-bundle": "^2026.1",
         "coreshop/menu-bundle": "^2026.1",
-        "pimcore/pimcore": "^2026.1",
+        "pimcore/pimcore": "^2026.2",
         "doctrine/migrations": "^3.9"
     },
     "suggest": {
@@ -36,11 +36,11 @@
         "pimcore/opensearch-client": "Allows to use OpenSearch as your index engine."
     },
     "require-dev": {
-        "pimcore/studio-ui-bundle": "^2026.1",
+        "pimcore/studio-ui-bundle": "^2026.2",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0",
-        "pimcore/opensearch-client": "^2026.1"
+        "pimcore/opensearch-client": "^2026.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/CoreShop/Bundle/InventoryBundle/composer.json
+++ b/src/CoreShop/Bundle/InventoryBundle/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "coreshop/inventory": "^2026.1",
         "coreshop/resource-bundle": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Bundle/LocaleBundle/composer.json
+++ b/src/CoreShop/Bundle/LocaleBundle/composer.json
@@ -27,7 +27,7 @@
         "coreshop/locale": "^2026.1",
         "coreshop/pimcore-bundle": "^2026.1",
         "coreshop/resource-bundle": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Bundle/MenuBundle/composer.json
+++ b/src/CoreShop/Bundle/MenuBundle/composer.json
@@ -27,10 +27,10 @@
         "coreshop/registry": "^2026.1",
         "coreshop/pimcore-bundle": "^2026.1",
         "knplabs/knp-menu-bundle": "^3.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
-        "pimcore/studio-ui-bundle": "^2026.1",
+        "pimcore/studio-ui-bundle": "^2026.2",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0"

--- a/src/CoreShop/Bundle/MessengerBundle/composer.json
+++ b/src/CoreShop/Bundle/MessengerBundle/composer.json
@@ -26,10 +26,10 @@
     "require": {
         "coreshop/menu-bundle": "^2026.1",
         "coreshop/pimcore-bundle": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
-        "pimcore/studio-ui-bundle": "^2026.1",
+        "pimcore/studio-ui-bundle": "^2026.2",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0"

--- a/src/CoreShop/Bundle/MoneyBundle/composer.json
+++ b/src/CoreShop/Bundle/MoneyBundle/composer.json
@@ -27,10 +27,10 @@
         "coreshop/currency": "^2026.1",
         "coreshop/pimcore-bundle": "^2026.1",
         "symfony/form": "^6.4.14 || ^7.2",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
-        "pimcore/studio-ui-bundle": "^2026.1",
+        "pimcore/studio-ui-bundle": "^2026.2",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0"

--- a/src/CoreShop/Bundle/NotificationBundle/composer.json
+++ b/src/CoreShop/Bundle/NotificationBundle/composer.json
@@ -28,10 +28,10 @@
         "coreshop/registry": "^2026.1",
         "coreshop/rule-bundle": "^2026.1",
         "coreshop/messenger-bundle": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
-        "pimcore/studio-ui-bundle": "^2026.1",
+        "pimcore/studio-ui-bundle": "^2026.2",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0"

--- a/src/CoreShop/Bundle/OptimisticEntityLockBundle/composer.json
+++ b/src/CoreShop/Bundle/OptimisticEntityLockBundle/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Bundle/OrderBundle/composer.json
+++ b/src/CoreShop/Bundle/OrderBundle/composer.json
@@ -35,10 +35,10 @@
         "coreshop/money-bundle": "^2026.1",
         "coreshop/workflow-bundle": "^2026.1",
         "coreshop/order": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
-        "pimcore/studio-ui-bundle": "^2026.1",
+        "pimcore/studio-ui-bundle": "^2026.2",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0"

--- a/src/CoreShop/Bundle/PaymentBundle/composer.json
+++ b/src/CoreShop/Bundle/PaymentBundle/composer.json
@@ -29,10 +29,10 @@
         "coreshop/resource-bundle": "^2026.1",
         "coreshop/rule-bundle": "^2026.1",
         "coreshop/workflow-bundle": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
-        "pimcore/studio-ui-bundle": "^2026.1",
+        "pimcore/studio-ui-bundle": "^2026.2",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0"

--- a/src/CoreShop/Bundle/PayumBundle/composer.json
+++ b/src/CoreShop/Bundle/PayumBundle/composer.json
@@ -34,7 +34,7 @@
         "symfony/notifier": "^6.4.14 || ^7.2",
         "symfony/serializer": "^6.4.14 || ^7.2",
         "php-http/guzzle7-adapter": "^1.0",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Bundle/PayumPaymentBundle/composer.json
+++ b/src/CoreShop/Bundle/PayumPaymentBundle/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "coreshop/payment-bundle": "^2026.1",
         "coreshop/payum-payment": "^2026.1",
-        "pimcore/pimcore": "^2026.1",
+        "pimcore/pimcore": "^2026.2",
         "payum/payum-bundle": "^2.6.2",
         "php-http/guzzle7-adapter": "^1.0"
     },

--- a/src/CoreShop/Bundle/PimcoreBundle/composer.json
+++ b/src/CoreShop/Bundle/PimcoreBundle/composer.json
@@ -26,10 +26,10 @@
     "require": {
         "coreshop/pimcore": "^2026.1",
         "coreshop/registry": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
-        "pimcore/studio-ui-bundle": "^2026.1",
+        "pimcore/studio-ui-bundle": "^2026.2",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0"

--- a/src/CoreShop/Bundle/ProductBundle/composer.json
+++ b/src/CoreShop/Bundle/ProductBundle/composer.json
@@ -30,10 +30,10 @@
         "coreshop/currency-bundle": "^2026.1",
         "coreshop/resource-bundle": "^2026.1",
         "coreshop/money-bundle": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
-        "pimcore/studio-ui-bundle": "^2026.1",
+        "pimcore/studio-ui-bundle": "^2026.2",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0"

--- a/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/composer.json
+++ b/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/composer.json
@@ -33,10 +33,10 @@
         "coreshop/product-quantity-price-rules": "^2026.1",
         "coreshop/rule-bundle": "^2026.1",
         "coreshop/money-bundle": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
-        "pimcore/studio-ui-bundle": "^2026.1",
+        "pimcore/studio-ui-bundle": "^2026.2",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0"

--- a/src/CoreShop/Bundle/ResourceBundle/composer.json
+++ b/src/CoreShop/Bundle/ResourceBundle/composer.json
@@ -44,10 +44,10 @@
         "symfony/validator": "^6.4.14 || ^7.2",
         "symfony/yaml": "^6.4.14 || ^7.2",
         "gedmo/doctrine-extensions": "^3.11.0",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
-        "pimcore/studio-ui-bundle": "^2026.1",
+        "pimcore/studio-ui-bundle": "^2026.2",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0"

--- a/src/CoreShop/Bundle/RuleBundle/composer.json
+++ b/src/CoreShop/Bundle/RuleBundle/composer.json
@@ -27,10 +27,10 @@
         "coreshop/rule": "^2026.1",
         "coreshop/registry": "^2026.1",
         "coreshop/resource-bundle": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
-        "pimcore/studio-ui-bundle": "^2026.1",
+        "pimcore/studio-ui-bundle": "^2026.2",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0"

--- a/src/CoreShop/Bundle/SEOBundle/composer.json
+++ b/src/CoreShop/Bundle/SEOBundle/composer.json
@@ -25,7 +25,7 @@
     ],
     "require": {
         "coreshop/seo": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Bundle/SequenceBundle/composer.json
+++ b/src/CoreShop/Bundle/SequenceBundle/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "coreshop/sequence": "^2026.1",
         "coreshop/resource-bundle": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Bundle/ShippingBundle/composer.json
+++ b/src/CoreShop/Bundle/ShippingBundle/composer.json
@@ -31,10 +31,10 @@
         "coreshop/resource-bundle": "^2026.1",
         "coreshop/money-bundle": "^2026.1",
         "coreshop/currency-bundle": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
-        "pimcore/studio-ui-bundle": "^2026.1",
+        "pimcore/studio-ui-bundle": "^2026.2",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0"

--- a/src/CoreShop/Bundle/StoreBundle/composer.json
+++ b/src/CoreShop/Bundle/StoreBundle/composer.json
@@ -28,10 +28,10 @@
         "coreshop/currency-bundle": "^2026.1",
         "coreshop/theme-bundle": "^2026.1",
         "coreshop/store": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
-        "pimcore/studio-ui-bundle": "^2026.1",
+        "pimcore/studio-ui-bundle": "^2026.2",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0"

--- a/src/CoreShop/Bundle/StudioFormBundle/composer.json
+++ b/src/CoreShop/Bundle/StudioFormBundle/composer.json
@@ -31,8 +31,8 @@
         "symfony/http-kernel": "^6.3 || ^7.0",
         "symfony/framework-bundle": "^6.3 || ^7.0",
         "symfony/serializer": "^6.3 || ^7.0",
-        "pimcore/pimcore": "^2026.1",
-        "pimcore/studio-ui-bundle": "^2026.1"
+        "pimcore/pimcore": "^2026.2",
+        "pimcore/studio-ui-bundle": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Bundle/TaxationBundle/composer.json
+++ b/src/CoreShop/Bundle/TaxationBundle/composer.json
@@ -27,10 +27,10 @@
         "coreshop/taxation": "^2026.1",
         "coreshop/resource-bundle": "^2026.1",
         "coreshop/money-bundle": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
-        "pimcore/studio-ui-bundle": "^2026.1",
+        "pimcore/studio-ui-bundle": "^2026.2",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0"

--- a/src/CoreShop/Bundle/TestBundle/composer.json
+++ b/src/CoreShop/Bundle/TestBundle/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "pimcore/pimcore": "^2026.1",
+        "pimcore/pimcore": "^2026.2",
         "coreshop/pimcore": "^2026.1",
         "behat/behat": "^3.8",
         "robertfausk/behat-panther-extension": "^1.0",
@@ -44,9 +44,9 @@
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0",
-        "pimcore/generic-data-index-bundle": "^2026.1",
-        "pimcore/studio-backend-bundle": "^2026.1",
-        "pimcore/studio-ui-bundle": "^2026.1"
+        "pimcore/generic-data-index-bundle": "^2026.2",
+        "pimcore/studio-backend-bundle": "^2026.2",
+        "pimcore/studio-ui-bundle": "^2026.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/CoreShop/Bundle/ThemeBundle/composer.json
+++ b/src/CoreShop/Bundle/ThemeBundle/composer.json
@@ -27,7 +27,7 @@
         "coreshop/registry": "^2026.1",
         "coreshop/pimcore-bundle": "^2026.1",
         "sylius/theme-bundle": "^2.2",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Bundle/TrackingBundle/composer.json
+++ b/src/CoreShop/Bundle/TrackingBundle/composer.json
@@ -27,7 +27,7 @@
         "coreshop/registry": "^2026.1",
         "coreshop/tracking": "^2026.1",
         "coreshop/pimcore-bundle": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Bundle/UserBundle/composer.json
+++ b/src/CoreShop/Bundle/UserBundle/composer.json
@@ -26,10 +26,10 @@
     "require": {
         "coreshop/user": "^2026.1",
         "coreshop/resource-bundle": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
-        "pimcore/studio-ui-bundle": "^2026.1",
+        "pimcore/studio-ui-bundle": "^2026.2",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0"

--- a/src/CoreShop/Bundle/VariantBundle/composer.json
+++ b/src/CoreShop/Bundle/VariantBundle/composer.json
@@ -28,7 +28,7 @@
         "coreshop/variant": "^2026.1"
     },
     "require-dev": {
-        "pimcore/studio-ui-bundle": "^2026.1",
+        "pimcore/studio-ui-bundle": "^2026.2",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0"

--- a/src/CoreShop/Bundle/WorkflowBundle/composer.json
+++ b/src/CoreShop/Bundle/WorkflowBundle/composer.json
@@ -35,7 +35,7 @@
         "symfony/config": "^6.4.14 || ^7.2",
         "symfony/workflow": "^6.4.14 || ^7.2",
         "symfony/yaml": "^6.4.14 || ^7.2",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Component/Address/composer.json
+++ b/src/CoreShop/Component/Address/composer.json
@@ -26,7 +26,7 @@
     ],
     "require": {
         "coreshop/resource": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Component/Configuration/composer.json
+++ b/src/CoreShop/Component/Configuration/composer.json
@@ -25,7 +25,7 @@
     ],
     "require": {
         "coreshop/resource": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Component/Core/composer.json
+++ b/src/CoreShop/Component/Core/composer.json
@@ -46,7 +46,7 @@
         "coreshop/user": "^2026.1",
         "coreshop/tracking": "^2026.1",
         "coreshop/wishlist": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Component/Currency/composer.json
+++ b/src/CoreShop/Component/Currency/composer.json
@@ -25,7 +25,7 @@
     ],
     "require": {
         "coreshop/resource": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Component/Customer/composer.json
+++ b/src/CoreShop/Component/Customer/composer.json
@@ -25,7 +25,7 @@
     ],
     "require": {
         "coreshop/resource": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Component/Index/composer.json
+++ b/src/CoreShop/Component/Index/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "coreshop/registry": "^2026.1",
         "coreshop/resource": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Component/Inventory/composer.json
+++ b/src/CoreShop/Component/Inventory/composer.json
@@ -25,7 +25,7 @@
     ],
     "require": {
         "coreshop/resource": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Component/Locale/composer.json
+++ b/src/CoreShop/Component/Locale/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "pimcore/pimcore": "^2026.1",
+        "pimcore/pimcore": "^2026.2",
         "coreshop/pimcore": "^2026.1"
     },
     "require-dev": {

--- a/src/CoreShop/Component/Notification/composer.json
+++ b/src/CoreShop/Component/Notification/composer.json
@@ -28,7 +28,7 @@
         "coreshop/registry": "^2026.1",
         "coreshop/resource": "^2026.1",
         "coreshop/pimcore": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Component/Order/composer.json
+++ b/src/CoreShop/Component/Order/composer.json
@@ -37,7 +37,7 @@
         "coreshop/customer": "^2026.1",
         "coreshop/storage-list": "^2026.1",
         "coreshop/workflow-bundle": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Component/Pimcore/composer.json
+++ b/src/CoreShop/Component/Pimcore/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Component/Product/composer.json
+++ b/src/CoreShop/Component/Product/composer.json
@@ -29,7 +29,7 @@
         "coreshop/currency": "^2026.1",
         "coreshop/rule": "^2026.1",
         "coreshop/address": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Component/ProductQuantityPriceRules/composer.json
+++ b/src/CoreShop/Component/ProductQuantityPriceRules/composer.json
@@ -33,7 +33,7 @@
         "coreshop/resource": "^2026.1",
         "coreshop/registry": "^2026.1",
         "coreshop/rule": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Component/Resource/composer.json
+++ b/src/CoreShop/Component/Resource/composer.json
@@ -30,7 +30,7 @@
         "coreshop/locale": "^2026.1",
         "doctrine/orm": "^3.0",
         "webmozart/assert": "^1.10",
-        "pimcore/pimcore": "^2026.1",
+        "pimcore/pimcore": "^2026.2",
         "symfony/finder": "^6.4.14 || ^7.2"
     },
     "require-dev": {

--- a/src/CoreShop/Component/Rule/composer.json
+++ b/src/CoreShop/Component/Rule/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "coreshop/resource": "^2026.1",
         "coreshop/registry": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Component/SEO/composer.json
+++ b/src/CoreShop/Component/SEO/composer.json
@@ -25,7 +25,7 @@
     ],
     "require": {
         "coreshop/registry": "^2026.1",
-        "pimcore/pimcore": "^2026.1",
+        "pimcore/pimcore": "^2026.2",
         "webmozart/assert": "^1.10"
     },
     "require-dev": {

--- a/src/CoreShop/Component/Sequence/composer.json
+++ b/src/CoreShop/Component/Sequence/composer.json
@@ -25,7 +25,7 @@
     ],
     "require": {
         "coreshop/resource": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Component/Shipping/composer.json
+++ b/src/CoreShop/Component/Shipping/composer.json
@@ -29,7 +29,7 @@
         "coreshop/taxation": "^2026.1",
         "coreshop/address": "^2026.1",
         "coreshop/rule": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Component/StorageList/composer.json
+++ b/src/CoreShop/Component/StorageList/composer.json
@@ -25,7 +25,7 @@
     ],
     "require": {
         "coreshop/resource": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Component/Store/composer.json
+++ b/src/CoreShop/Component/Store/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "coreshop/resource": "^2026.1",
         "coreshop/currency": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Component/Taxation/composer.json
+++ b/src/CoreShop/Component/Taxation/composer.json
@@ -25,7 +25,7 @@
     ],
     "require": {
         "coreshop/resource": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",

--- a/src/CoreShop/Component/User/composer.json
+++ b/src/CoreShop/Component/User/composer.json
@@ -25,7 +25,7 @@
     ],
     "require": {
         "coreshop/resource": "^2026.1",
-        "pimcore/pimcore": "^2026.1",
+        "pimcore/pimcore": "^2026.2",
         "symfony/security-core": "^6.4.14 || ^7.2"
     },
     "require-dev": {

--- a/src/CoreShop/Component/Wishlist/composer.json
+++ b/src/CoreShop/Component/Wishlist/composer.json
@@ -30,7 +30,7 @@
         "coreshop/customer": "^2026.1",
         "coreshop/product": "^2026.1",
         "coreshop/storage-list": "^2026.1",
-        "pimcore/pimcore": "^2026.1"
+        "pimcore/pimcore": "^2026.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",


### PR DESCRIPTION
Fixes #3189

Release preparation: CoreShop `2026.x` is developed, built and tested against the Pimcore **2026.2**
line, but declared `^2026.1` as its Composer minimum. Pimcore removes exported symbols between minor
versions, so a floor older than what we build against lets Composer install a Pimcore the code no
longer supports — the same class of breakage as `VariantTabManager` disappearing between 2025.4 and
2026.1.

## What changed (69 files)

| Area | Files | Change |
| --- | --- | --- |
| Root manifest | `composer.json` | `require.pimcore/pimcore` and the four `require-dev` companions (`opensearch-client`, `generic-data-index-bundle`, `studio-backend-bundle`, `studio-ui-bundle`) `^2026.1` → `^2026.2`; `suggest` entries corrected |
| Split packages | 59 × `src/CoreShop/{Bundle,Component}/*/composer.json` | every `pimcore/*` constraint `^2026.1` → `^2026.2` |
| CI matrices | `.github/workflows/{behat,behat_ui,packages_bundles,packages_components,static}.yml`, `license-check.yaml` | matrix pin `pimcore: ^2026.1` → `^2026.2` (8 occurrences) |
| Docs | `README.md`, `CLAUDE.md`, `CHANGELOG-2026.1.x.md` | stated requirement updated; changelog section now records the 2026.2 floor and why |

Deliberately **not** touched: the `coreshop/*` sibling constraints and `extra.branch-alias`. Those
track CoreShop's own version line (`2026.1` / `2026.x-dev`), which is independent of Pimcore's.

The root `suggest` block was stale in a way unrelated to this bump — its version strings predate the
2026 numbering entirely:

```diff
-    "pimcore/generic-data-index-bundle": "^2.0 - Generic Data Index support for Pimcore Studio UI",
-    "pimcore/studio-ui-bundle": "^1.0 - Modern React-based Studio UI for Pimcore (recommended)"
+    "pimcore/generic-data-index-bundle": "^2026.2 - Generic Data Index support for Pimcore Studio UI",
+    "pimcore/studio-ui-bundle": "^2026.2 - Modern React-based Studio UI for Pimcore (recommended)"
```

## Verification

`composer validate --strict` on the root — clean apart from the pre-existing `payum/payum: 1.7.x-dev`
warning that predates this branch:

```
./composer.json is valid, but with a few warnings
# General warnings
- require.payum/payum : exact version constraints (1.7.x-dev) should be avoided if the package follows semantic versioning
```

Mechanical split-package assertion (the check #3173 introduced):

```
root pimcore/pimcore: ^2026.2
split packages total: 66
matching root constraint: 58
no direct pimcore/pimcore requirement: 8
   - src/CoreShop/Bundle/StorageListBundle/composer.json
   - src/CoreShop/Bundle/VariantBundle/composer.json
   - src/CoreShop/Bundle/WishlistBundle/composer.json
   - src/CoreShop/Component/Payment/composer.json
   - src/CoreShop/Component/PayumPayment/composer.json
   - src/CoreShop/Component/Registry/composer.json
   - src/CoreShop/Component/Tracking/composer.json
   - src/CoreShop/Component/Variant/composer.json
MISMATCHED: 0

companion constraints across all manifests:
   pimcore/generic-data-index-bundle: ^2026.2  (2x)
   pimcore/opensearch-client: ^2026.2  (2x)
   pimcore/studio-backend-bundle: ^2026.2  (2x)
   pimcore/studio-ui-bundle: ^2026.2  (24x)
```

The eight packages without a direct `pimcore/pimcore` requirement are a pre-existing, deliberate
pattern, not drift: the five components are framework-agnostic libraries, and the three bundles pull
Pimcore transitively through `coreshop/resource-bundle`. No package disagrees with the root.

Real resolution (`composer update --dry-run`, no lock file is tracked so this is a full resolve —
276 installs, 0 conflicts):

```
Lock file operations: 276 installs, 0 updates, 0 removals
  - Locking pimcore/elasticsearch-client (v2026.2.0)
  - Locking pimcore/generic-data-index-bundle (v2026.2.7)
  - Locking pimcore/opensearch-client (v2026.2.1)
  - Locking pimcore/pimcore (v2026.2.11)
  - Locking pimcore/static-resolver-bundle (v2026.2.0)
  - Locking pimcore/studio-backend-bundle (v2026.2.8)
  - Locking pimcore/studio-ui-bundle (v2026.2.8)
```

Nothing in the tree fails to satisfy `^2026.2`.

## Follow-up, not in this PR

`package.json` pins `@pimcore/studio-ui-bundle` at **`2026.1.0`**, one minor behind the new composer
floor. That direction is the safe one — Studio plugins built against an older SDK load on a newer
runtime; the reverse is what breaks — so it does not block this bump. Raising the npm pin needs a
Studio artifact rebuild and belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
