### PR TITLE
Raise the Studio UI SDK pin to 2026.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "coreshop-studio-plugins",
       "version": "1.0.0",
       "dependencies": {
-        "@pimcore/studio-ui-bundle": "2026.1.0",
+        "@pimcore/studio-ui-bundle": "2026.2.5",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -2886,9 +2886,9 @@
       }
     },
     "node_modules/@pimcore/studio-ui-bundle": {
-      "version": "2026.1.0",
-      "resolved": "https://registry.npmjs.org/@pimcore/studio-ui-bundle/-/studio-ui-bundle-2026.1.0.tgz",
-      "integrity": "sha512-Ss13kke82B1dXD/w8wcylMS/NLe6TAls5bTjd/w0BKI77UCa/Cg46WnOvXB+K8fBqt5G2eTyTst6k7M2gpCsKg==",
+      "version": "2026.2.5",
+      "resolved": "https://registry.npmjs.org/@pimcore/studio-ui-bundle/-/studio-ui-bundle-2026.2.5.tgz",
+      "integrity": "sha512-bdRAi9lh3slpMxdK7Do9qj9FzVy657hDRoUvkVNgNtgzWzNsBXim2R92yTHowAlqKRJnFNYsBNthYeTpdwPmwQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@ant-design/charts": "^2.4.0",
@@ -2916,19 +2916,20 @@
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@uiw/react-codemirror": "^4.23.6",
+        "adm-zip": "^0.5.16",
         "antd": "5.22.x",
         "antd-style": "3.7.x",
         "classnames": "^2.5.1",
-        "dompurify": "^3.2.1",
+        "dompurify": "^3.4.8",
         "flexlayout-react": "^0.7.15",
         "framer-motion": "^11.11.17",
         "i18next": "^23.16.8",
         "immer": "^10.1.1",
         "inversify": "6.1.x",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.2.0",
         "leaflet": "^1.9.4",
         "leaflet-draw": "^1.0.4",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.0",
         "react": "18.3.x",
         "react-compiler-runtime": "^19.1.0-rc.2",
         "react-dom": "18.3.x",
@@ -2936,10 +2937,22 @@
         "react-i18next": "^14.1.3",
         "react-redux": "^9.1.2",
         "react-refresh": "^0.18.0",
-        "react-router-dom": "^6.28.0",
+        "react-router-dom": "^6.30.4",
         "reflect-metadata": "0.2.x",
         "ts-patch": "^3.3.0",
         "uuid": "^10.0.0"
+      },
+      "bin": {
+        "studio-package-build": "bundler/package-build.cjs"
+      }
+    },
+    "node_modules/@pimcore/studio-ui-bundle/node_modules/adm-zip": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
+      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/@pimcore/studio-ui-bundle/node_modules/antd": {
@@ -13493,7 +13506,7 @@
         "zustand": "^5.0.7"
       },
       "peerDependencies": {
-        "@pimcore/studio-ui-bundle": "2026.1.0",
+        "@pimcore/studio-ui-bundle": "2026.2.5",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -13524,7 +13537,7 @@
         "zustand": "^5.0.7"
       },
       "peerDependencies": {
-        "@pimcore/studio-ui-bundle": "2026.1.0",
+        "@pimcore/studio-ui-bundle": "2026.2.5",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -13543,7 +13556,7 @@
         "zustand": "^5.0.7"
       },
       "peerDependencies": {
-        "@pimcore/studio-ui-bundle": "2026.1.0",
+        "@pimcore/studio-ui-bundle": "2026.2.5",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -13561,7 +13574,7 @@
         "zustand": "^5.0.7"
       },
       "peerDependencies": {
-        "@pimcore/studio-ui-bundle": "2026.1.0",
+        "@pimcore/studio-ui-bundle": "2026.2.5",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -13580,7 +13593,7 @@
         "zustand": "^5.0.7"
       },
       "peerDependencies": {
-        "@pimcore/studio-ui-bundle": "2026.1.0",
+        "@pimcore/studio-ui-bundle": "2026.2.5",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -13597,7 +13610,7 @@
         "zustand": "^5.0.7"
       },
       "peerDependencies": {
-        "@pimcore/studio-ui-bundle": "2026.1.0",
+        "@pimcore/studio-ui-bundle": "2026.2.5",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -13614,7 +13627,7 @@
         "zustand": "^5.0.7"
       },
       "peerDependencies": {
-        "@pimcore/studio-ui-bundle": "2026.1.0",
+        "@pimcore/studio-ui-bundle": "2026.2.5",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -13631,7 +13644,7 @@
         "zustand": "^5.0.7"
       },
       "peerDependencies": {
-        "@pimcore/studio-ui-bundle": "2026.1.0",
+        "@pimcore/studio-ui-bundle": "2026.2.5",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -13653,7 +13666,7 @@
         "zustand": "^5.0.7"
       },
       "peerDependencies": {
-        "@pimcore/studio-ui-bundle": "2026.1.0",
+        "@pimcore/studio-ui-bundle": "2026.2.5",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -13675,7 +13688,7 @@
         "zustand": "^5.0.7"
       },
       "peerDependencies": {
-        "@pimcore/studio-ui-bundle": "2026.1.0",
+        "@pimcore/studio-ui-bundle": "2026.2.5",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -13695,7 +13708,7 @@
         "zustand": "^5.0.7"
       },
       "peerDependencies": {
-        "@pimcore/studio-ui-bundle": "2026.1.0",
+        "@pimcore/studio-ui-bundle": "2026.2.5",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -13712,7 +13725,7 @@
         "zustand": "^5.0.7"
       },
       "peerDependencies": {
-        "@pimcore/studio-ui-bundle": "2026.1.0",
+        "@pimcore/studio-ui-bundle": "2026.2.5",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -13733,7 +13746,7 @@
         "zustand": "^5.0.7"
       },
       "peerDependencies": {
-        "@pimcore/studio-ui-bundle": "2026.1.0",
+        "@pimcore/studio-ui-bundle": "2026.2.5",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -13752,7 +13765,7 @@
         "zustand": "^5.0.7"
       },
       "peerDependencies": {
-        "@pimcore/studio-ui-bundle": "2026.1.0",
+        "@pimcore/studio-ui-bundle": "2026.2.5",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -13771,7 +13784,7 @@
         "zustand": "^5.0.7"
       },
       "peerDependencies": {
-        "@pimcore/studio-ui-bundle": "2026.1.0",
+        "@pimcore/studio-ui-bundle": "2026.2.5",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -13790,7 +13803,7 @@
         "zustand": "^5.0.7"
       },
       "peerDependencies": {
-        "@pimcore/studio-ui-bundle": "2026.1.0",
+        "@pimcore/studio-ui-bundle": "2026.2.5",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -13810,7 +13823,7 @@
         "zustand": "^5.0.7"
       },
       "peerDependencies": {
-        "@pimcore/studio-ui-bundle": "2026.1.0",
+        "@pimcore/studio-ui-bundle": "2026.2.5",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -13830,7 +13843,7 @@
         "zustand": "^5.0.7"
       },
       "peerDependencies": {
-        "@pimcore/studio-ui-bundle": "2026.1.0",
+        "@pimcore/studio-ui-bundle": "2026.2.5",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -13844,7 +13857,7 @@
       "version": "1.0.0",
       "license": "CCL",
       "peerDependencies": {
-        "@pimcore/studio-ui-bundle": "2026.1.0",
+        "@pimcore/studio-ui-bundle": "2026.2.5",
         "antd": "^5.12.0",
         "react": "18.3.x",
         "react-dom": "18.3.x"
@@ -13860,7 +13873,7 @@
         "zustand": "^5.0.7"
       },
       "peerDependencies": {
-        "@pimcore/studio-ui-bundle": "2026.1.0",
+        "@pimcore/studio-ui-bundle": "2026.2.5",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -13877,7 +13890,7 @@
         "zustand": "^5.0.7"
       },
       "peerDependencies": {
-        "@pimcore/studio-ui-bundle": "2026.1.0",
+        "@pimcore/studio-ui-bundle": "2026.2.5",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",
@@ -13895,7 +13908,7 @@
         "zustand": "^5.0.7"
       },
       "peerDependencies": {
-        "@pimcore/studio-ui-bundle": "2026.1.0",
+        "@pimcore/studio-ui-bundle": "2026.2.5",
         "@reduxjs/toolkit": "^2.0.1",
         "antd": "^5.12.0",
         "immer": "^10.1.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@pimcore/studio-ui-bundle": "2026.1.0",
+    "@pimcore/studio-ui-bundle": "2026.2.5",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/AddressBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/AddressBundle/Resources/assets/pimcore-studio/package.json
@@ -18,7 +18,7 @@
     "@coreshop/studio-form": "*"
   },
   "peerDependencies": {
-    "@pimcore/studio-ui-bundle": "2026.1.0",
+    "@pimcore/studio-ui-bundle": "2026.2.5",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/CoreBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/assets/pimcore-studio/package.json
@@ -30,7 +30,7 @@
     "@coreshop/taxation": "file:../../../../TaxationBundle/Resources/assets/pimcore-studio"
   },
   "peerDependencies": {
-    "@pimcore/studio-ui-bundle": "2026.1.0",
+    "@pimcore/studio-ui-bundle": "2026.2.5",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/CurrencyBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/CurrencyBundle/Resources/assets/pimcore-studio/package.json
@@ -18,7 +18,7 @@
     "@coreshop/studio-form": "*"
   },
   "peerDependencies": {
-    "@pimcore/studio-ui-bundle": "2026.1.0",
+    "@pimcore/studio-ui-bundle": "2026.2.5",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/CustomerBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/CustomerBundle/Resources/assets/pimcore-studio/package.json
@@ -17,7 +17,7 @@
     "@coreshop/resource": "file:../../../../ResourceBundle/Resources/assets/pimcore-studio"
   },
   "peerDependencies": {
-    "@pimcore/studio-ui-bundle": "2026.1.0",
+    "@pimcore/studio-ui-bundle": "2026.2.5",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/IndexBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/IndexBundle/Resources/assets/pimcore-studio/package.json
@@ -18,7 +18,7 @@
     "@coreshop/studio-form": "*"
   },
   "peerDependencies": {
-    "@pimcore/studio-ui-bundle": "2026.1.0",
+    "@pimcore/studio-ui-bundle": "2026.2.5",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/MenuBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/MenuBundle/Resources/assets/pimcore-studio/package.json
@@ -16,7 +16,7 @@
     "zustand": "^5.0.7"
   },
   "peerDependencies": {
-    "@pimcore/studio-ui-bundle": "2026.1.0",
+    "@pimcore/studio-ui-bundle": "2026.2.5",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/MessengerBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/MessengerBundle/Resources/assets/pimcore-studio/package.json
@@ -16,7 +16,7 @@
     "zustand": "^5.0.7"
   },
   "peerDependencies": {
-    "@pimcore/studio-ui-bundle": "2026.1.0",
+    "@pimcore/studio-ui-bundle": "2026.2.5",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/MoneyBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/MoneyBundle/Resources/assets/pimcore-studio/package.json
@@ -16,7 +16,7 @@
     "zustand": "^5.0.7"
   },
   "peerDependencies": {
-    "@pimcore/studio-ui-bundle": "2026.1.0",
+    "@pimcore/studio-ui-bundle": "2026.2.5",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/NotificationBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/NotificationBundle/Resources/assets/pimcore-studio/package.json
@@ -21,7 +21,7 @@
     "@coreshop/studio-form": "*"
   },
   "peerDependencies": {
-    "@pimcore/studio-ui-bundle": "2026.1.0",
+    "@pimcore/studio-ui-bundle": "2026.2.5",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/OrderBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/OrderBundle/Resources/assets/pimcore-studio/package.json
@@ -21,7 +21,7 @@
     "@coreshop/studio-form": "*"
   },
   "peerDependencies": {
-    "@pimcore/studio-ui-bundle": "2026.1.0",
+    "@pimcore/studio-ui-bundle": "2026.2.5",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/PaymentBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/PaymentBundle/Resources/assets/pimcore-studio/package.json
@@ -19,7 +19,7 @@
     "@coreshop/studio-form": "*"
   },
   "peerDependencies": {
-    "@pimcore/studio-ui-bundle": "2026.1.0",
+    "@pimcore/studio-ui-bundle": "2026.2.5",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/PimcoreBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/PimcoreBundle/Resources/assets/pimcore-studio/package.json
@@ -16,7 +16,7 @@
     "zustand": "^5.0.7"
   },
   "peerDependencies": {
-    "@pimcore/studio-ui-bundle": "2026.1.0",
+    "@pimcore/studio-ui-bundle": "2026.2.5",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/ProductBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/ProductBundle/Resources/assets/pimcore-studio/package.json
@@ -20,7 +20,7 @@
     "@coreshop/studio-form": "*"
   },
   "peerDependencies": {
-    "@pimcore/studio-ui-bundle": "2026.1.0",
+    "@pimcore/studio-ui-bundle": "2026.2.5",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/ProductQuantityPriceRulesBundle/Resources/assets/pimcore-studio/package.json
@@ -18,7 +18,7 @@
     "@coreshop/studio-form": "*"
   },
   "peerDependencies": {
-    "@pimcore/studio-ui-bundle": "2026.1.0",
+    "@pimcore/studio-ui-bundle": "2026.2.5",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/ResourceBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/ResourceBundle/Resources/assets/pimcore-studio/package.json
@@ -18,7 +18,7 @@
     "@coreshop/studio-form": "*"
   },
   "peerDependencies": {
-    "@pimcore/studio-ui-bundle": "2026.1.0",
+    "@pimcore/studio-ui-bundle": "2026.2.5",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/RuleBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/RuleBundle/Resources/assets/pimcore-studio/package.json
@@ -18,7 +18,7 @@
     "@coreshop/studio-form": "*"
   },
   "peerDependencies": {
-    "@pimcore/studio-ui-bundle": "2026.1.0",
+    "@pimcore/studio-ui-bundle": "2026.2.5",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/ShippingBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/ShippingBundle/Resources/assets/pimcore-studio/package.json
@@ -19,7 +19,7 @@
     "@coreshop/studio-form": "*"
   },
   "peerDependencies": {
-    "@pimcore/studio-ui-bundle": "2026.1.0",
+    "@pimcore/studio-ui-bundle": "2026.2.5",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/StoreBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/StoreBundle/Resources/assets/pimcore-studio/package.json
@@ -19,7 +19,7 @@
     "@coreshop/studio-form": "*"
   },
   "peerDependencies": {
-    "@pimcore/studio-ui-bundle": "2026.1.0",
+    "@pimcore/studio-ui-bundle": "2026.2.5",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/StudioFormBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/StudioFormBundle/Resources/assets/pimcore-studio/package.json
@@ -13,7 +13,7 @@
   "license": "CCL",
   "private": true,
   "peerDependencies": {
-    "@pimcore/studio-ui-bundle": "2026.1.0",
+    "@pimcore/studio-ui-bundle": "2026.2.5",
     "antd": "^5.12.0",
     "react": "18.3.x",
     "react-dom": "18.3.x"

--- a/src/CoreShop/Bundle/TaxationBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/TaxationBundle/Resources/assets/pimcore-studio/package.json
@@ -18,7 +18,7 @@
     "zustand": "^5.0.7"
   },
   "peerDependencies": {
-    "@pimcore/studio-ui-bundle": "2026.1.0",
+    "@pimcore/studio-ui-bundle": "2026.2.5",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/UserBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/UserBundle/Resources/assets/pimcore-studio/package.json
@@ -16,7 +16,7 @@
     "zustand": "^5.0.7"
   },
   "peerDependencies": {
-    "@pimcore/studio-ui-bundle": "2026.1.0",
+    "@pimcore/studio-ui-bundle": "2026.2.5",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",

--- a/src/CoreShop/Bundle/VariantBundle/Resources/assets/pimcore-studio/package.json
+++ b/src/CoreShop/Bundle/VariantBundle/Resources/assets/pimcore-studio/package.json
@@ -17,7 +17,7 @@
     "zustand": "^5.0.7"
   },
   "peerDependencies": {
-    "@pimcore/studio-ui-bundle": "2026.1.0",
+    "@pimcore/studio-ui-bundle": "2026.2.5",
     "@reduxjs/toolkit": "^2.0.1",
     "antd": "^5.12.0",
     "immer": "^10.1.1",


### PR DESCRIPTION
Fixes #3191

Companion to #3190 (Composer floor `^2026.1` → `^2026.2`), deliberately split so each can be reviewed
on its own. This one is the npm half: the Studio plugin sources built against
`@pimcore/studio-ui-bundle` `2026.1.0`, one minor behind the new floor.

## Version chosen: `2026.2.5`, not `2026.2.8`

`2026.2.8` is what Composer resolves here and what npm's `latest` tag points at, but "newest
available" is the wrong criterion for this pin. The SDK is consumed as a **Module Federation remote**
resolved at runtime (`rsbuild.template.config.ts` loads it from `window.StudioUIBundleRemoteUrl`), so
the npm pin governs types and build-time imports only — it does not decide what the browser loads.
That makes the pin a statement about the *lowest* SDK our plugins must compile against, and building
at the low end of the supported range is the safe direction: a plugin built against an older SDK loads
on a newer runtime, while the reverse is what breaks when Pimcore drops an export.

`2026.2.5` is also exactly what the 14 external CoreShop bundles pin, so this keeps every CoreShop
plugin in the org on one SDK minor and the Module Federation share graph consistent between the core
plugins and the bundles. Picking `2026.2.8` here would build the core plugins against a newer SDK than
the bundles they federate with — the skew this PR exists to remove.

Residual gap, stated for the record: the Composer floor `^2026.2` admits `2026.2.0`–`2026.2.4`, so a
project on one of those runs plugins compiled against `2026.2.5`. That is the same narrow gap the
external bundles already carry, and closing it would mean pinning `2026.2.0`. Happy to drop to
`2026.2.0` or move up to `2026.2.8` if you'd rather optimise for a different edge.

## What changed (24 files)

- `package.json` — root `dependencies["@pimcore/studio-ui-bundle"]`.
- 22 × `src/CoreShop/Bundle/*/Resources/assets/pimcore-studio/package.json` — each package's
  `peerDependencies["@pimcore/studio-ui-bundle"]`. All 23 pins move together; a split pin would skew
  the federation shares.
- `package-lock.json` — regenerated with `npm install --package-lock-only`.

## No asset rebuild, by design

`.gitignore:74` ignores `src/CoreShop/Bundle/*/Resources/public/studio/*/`, and
`.github/workflows/shared-frontend-build.yaml` force-adds the built bundles on push to a release
branch. This PR is source-only — **expect zero committed asset churn**; CI regenerates the Studio
bundles on merge.

## Verification (no build run)

Lockfile resolution is surgical — the SDK and one nested dependency, nothing else moved:

```
node_modules/@pimcore/studio-ui-bundle: 2026.1.0 -> 2026.2.5
node_modules/@pimcore/studio-ui-bundle/node_modules/adm-zip: (new) 0.5.18
removed packages: none
```

`npm ci` from the regenerated lock installs cleanly (971 packages, no peer conflicts, no
`ERESOLVE`). `@pimcore/studio-ui-bundle@2026.2.5` declares no `peerDependencies` of its own, so
nothing constrains React/antd/redux further than today.

`npm run check-types` — **exit 0, zero TypeScript errors across all 22 workspaces**, compiled against
the real installed `2026.2.5` types:

```
> @coreshop/address@1.0.0 check-types
> tsc --noEmit
... (22 workspaces) ...
> @coreshop/variant@1.0.0 check-types
> tsc --noEmit
exit=0
```

Worth noting this is a *real* signal in this repo, unlike in the external bundles: core resolves its
own `node_modules` rather than type-checking against a vendored Pimcore baseline, so a symbol removed
between 2026.1 and 2026.2 would have surfaced here as a TS error. None did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
