### PR TITLE
[5.1] Treat PHP deprecations the way Pimcore does and drop the react/promise conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -137,7 +137,6 @@
     },
   "conflict": {
     "ezimuel/ringphp": "<1.4",
-    "react/promise": "<3",
     "symfony/error-handler": "<6.4.14"
   },
   "require-dev": {

--- a/src/CoreShop/Behat/Resources/config/profiles/default.yml
+++ b/src/CoreShop/Behat/Resources/config/profiles/default.yml
@@ -13,6 +13,13 @@ default:
                 class: BehatKernel
                 environment: test
 
+    calls:
+        # Deprecations must never fail a scenario: Behat's runtime call handler turns every
+        # reported error into a failing step, while Pimcore's own test setup (Codeception's
+        # default error_level) reports deprecations without escalating them. 8191 is
+        # E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED.
+        error_reporting: 8191
+
     gherkin:
         filters:
             tags: '@domain&&~@wip'

--- a/src/CoreShop/Behat/Resources/config/profiles/ui.yml
+++ b/src/CoreShop/Behat/Resources/config/profiles/ui.yml
@@ -56,6 +56,13 @@ ui:
 
         Robertfausk\Behat\PantherExtension: ~
 
+    calls:
+        # Deprecations must never fail a scenario: Behat's runtime call handler turns every
+        # reported error into a failing step, while Pimcore's own test setup (Codeception's
+        # default error_level) reports deprecations without escalating them. 8191 is
+        # E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED.
+        error_reporting: 8191
+
     gherkin:
         filters:
             tags: '@ui&&~@ui_precision&&~@ui_pimcore&&~@wip'

--- a/src/CoreShop/Behat/Resources/config/profiles/ui_pimcore.yml
+++ b/src/CoreShop/Behat/Resources/config/profiles/ui_pimcore.yml
@@ -55,6 +55,13 @@ ui_pimcore:
 
         Robertfausk\Behat\PantherExtension: ~
 
+    calls:
+        # Deprecations must never fail a scenario: Behat's runtime call handler turns every
+        # reported error into a failing step, while Pimcore's own test setup (Codeception's
+        # default error_level) reports deprecations without escalating them. 8191 is
+        # E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED.
+        error_reporting: 8191
+
     gherkin:
         filters:
             tags: '@ui_pimcore&&~@wip'

--- a/src/CoreShop/Behat/Resources/config/profiles/ui_precision.yml
+++ b/src/CoreShop/Behat/Resources/config/profiles/ui_precision.yml
@@ -29,6 +29,13 @@ ui_precision:
 
         Robertfausk\Behat\PantherExtension: ~
 
+    calls:
+        # Deprecations must never fail a scenario: Behat's runtime call handler turns every
+        # reported error into a failing step, while Pimcore's own test setup (Codeception's
+        # default error_level) reports deprecations without escalating them. 8191 is
+        # E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED.
+        error_reporting: 8191
+
     gherkin:
         filters:
             tags: '@ui_precision&&~@wip'


### PR DESCRIPTION
Backport of #3148 to `5.1` (cherry-pick of b269d391, clean).

## Why now

The `5.1` matrix started failing today on `Deps highest` (see the `5.1` branch run for d1bb1ee33f and the release PR #3197): `pimcore/studio-backend-bundle` 2025.4.x now pulls `pimcore/generic-data-index-bundle ^2.5.3` → `pimcore/opensearch-client ^2.2.1` → `react/promise ^2.11`, which the root `conflict: {"react/promise": "<3"}` blocks. Composer cannot resolve the monolith at all.

## Change

Same as #3148: configure Behat's call error reporting to `E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED` (`8191`) in all four Behat profiles, so the PHP 8.4 implicit-nullable deprecations raised by react/promise 2.11 no longer abort scenarios, and remove the `react/promise` conflict that only existed to keep 2.11 out.

Blocks the 5.1.0 release (#3197).