### PR TITLE
[CI] Run the per-line License Check copies against their own line on schedule and release

### DIFF
--- a/.github/workflows/license-check-5.0.yaml
+++ b/.github/workflows/license-check-5.0.yaml
@@ -32,6 +32,10 @@ env:
 
 jobs:
   lint:
+    # `release` and `schedule` always run the workflow file from the default branch, so this job
+    # also fires for releases of the other lines. Only tags of this line are checked here; the
+    # other lines have their own copy of this workflow.
+    if: ${{ github.event_name != 'release' || startsWith(github.event.release.tag_name, '5.0.') }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -52,7 +56,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # On `schedule` the workflow runs from the default branch and `github.sha` is that
+          # branch's head, not this line's — check the line's branch out explicitly. Releases
+          # (the tag) and pushes keep `github.sha`, pull requests their head commit.
+          ref: ${{ github.event.pull_request.head.sha || (github.event_name == 'schedule' && '5.0') || github.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Install PHP

--- a/.github/workflows/license-check-5.1.yaml
+++ b/.github/workflows/license-check-5.1.yaml
@@ -32,6 +32,10 @@ env:
 
 jobs:
   lint:
+    # `release` and `schedule` always run the workflow file from the default branch, so this job
+    # also fires for releases of the other lines. Only tags of this line are checked here; the
+    # other lines have their own copy of this workflow.
+    if: ${{ github.event_name != 'release' || startsWith(github.event.release.tag_name, '5.1.') }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -52,7 +56,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # On `schedule` the workflow runs from the default branch and `github.sha` is that
+          # branch's head, not this line's — check the line's branch out explicitly. Releases
+          # (the tag) and pushes keep `github.sha`, pull requests their head commit.
+          ref: ${{ github.event.pull_request.head.sha || (github.event_name == 'schedule' && '5.1') || github.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Install PHP

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -32,6 +32,10 @@ env:
 
 jobs:
   lint:
+    # `release` and `schedule` always run the workflow file from the default branch, so this job
+    # also fires for releases of the other lines. Only tags of this line are checked here; the
+    # other lines have their own copy of this workflow.
+    if: ${{ github.event_name != 'release' || startsWith(github.event.release.tag_name, '2026.') }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -52,7 +56,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # On `schedule` the workflow runs from the default branch and `github.sha` is that
+          # branch's head, not this line's — check the line's branch out explicitly. Releases
+          # (the tag) and pushes keep `github.sha`, pull requests their head commit.
+          ref: ${{ github.event.pull_request.head.sha || (github.event_name == 'schedule' && '2026.x') || github.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Install PHP


### PR DESCRIPTION
Fixes #3203

`schedule` and `release` always execute the workflow file from the default branch. The `license-check-5.0.yaml` / `license-check-5.1.yaml` copies therefore checked out the `2026.x` head on schedule and any released tag on release, then forced `pimcore/pimcore:^12.3` onto code that requires `^2026.2` — every scheduled run failed and the 2026.2.0 release turned "License Check [5.1]" red (run 33645519901).

Changes in all three `license-check*.yaml` on `2026.x`:

- job-level `if`: on `release`, run only when the tag belongs to the line (`startsWith(github.event.release.tag_name, '5.1.')`, `'5.0.'`, `'2026.'`).
- checkout `ref`: on `schedule`, check out the line's branch (`5.0` / `5.1` / `2026.x`) instead of `github.sha`; pushes and releases keep `github.sha`, pull requests their head commit.

Verification: the next scheduled run (Monday 01:00 UTC) and the next release of each line. A manual check is possible with `gh workflow run` only if `workflow_dispatch` were added, which this PR deliberately does not do.