### PR TITLE
[Telemetry] Daily telemetry ping with license status for the license portal

### DIFF
--- a/CHANGELOG-2026.2.x.md
+++ b/CHANGELOG-2026.2.x.md
@@ -1,5 +1,112 @@
 ## 2026.2.1
 
+### Telemetry ping and license check
+
+CoreShop now sends an anonymous ping to the CoreShop license portal once every 24 hours through the Pimcore
+maintenance task `coreshop_telemetry`. It transmits a hashed instance identifier, the configured domains, CoreShop,
+Pimcore and PHP versions and the list of installed CoreShop packages and Pimcore bundles. No customer or content data
+is sent. The subscription token contributed by `coreshop/enterprise-subscription-bundle` is transmitted as a SHA-256
+hash only.
+
+- Added `CoreShop\Component\Core\Telemetry\TelemetryDataProviderInterface` (tag `coreshop.telemetry.provider`),
+  `TelemetryPingerInterface`, `TelemetryResultStorageInterface` and `InstanceIdentifierProviderInterface`.
+- Added the console command `coreshop:telemetry:ping [--dump]`.
+- Added the configuration node `core_shop_core.telemetry` (`enabled`, `endpoint`, `timeout`). Opt out with
+  `CORESHOP_TELEMETRY=false`. The previously unused `send_usage_log` option is superseded by `telemetry.enabled`.
+- See [Telemetry and License Check](docs/01_Getting_Started/05_Telemetry.md).
+
+### Version scheme aligned with Pimcore
+
+CoreShop switches from semantic versioning to Pimcore's year-based scheme. The previous line (`5.x`)
+remains the last semver release and continues to receive maintenance; all new development targets
+`2026.1` and up.
+
+### Pimcore 2026.1 minimum requirement
+
+All CoreShop components and bundles now require **`pimcore/pimcore: ^2026.1`**. Companion bundles
+(`pimcore/studio-ui-bundle`, `pimcore/studio-backend-bundle`, `pimcore/generic-data-index-bundle`)
+are likewise bumped to `^2026.1`.
+
+### Classic Admin / ExtJS removed
+
+Pimcore Classic Admin (ExtJS) support is removed. CoreShop 2026.1 targets **Pimcore Studio exclusively**.
+
+Removed:
+
+- All `Resources/public/pimcore/` ExtJS asset trees (~480 JS/CSS files across 22 bundles).
+- All `AdminClass/` namespaces (grid column operators, admin-JS injection listeners, admin-grid filter
+  listeners, the Pimcore Grid Config Installer).
+- All `classic_admin.yml` service files and the conditional `PimcoreAdminBundle` loading blocks in
+  bundle extensions.
+- `pimcore_admin` configuration section from `CoreShopPimcoreExtension` and all bundle `Configuration`
+  classes, plus the `registerPimcoreResources()` helper on `AbstractPimcoreExtension`.
+- `CoreShop\Component\Pimcore\DataObject\Grid\GridFilterInterface`, `AsGridFilter` attribute,
+  `RegisterGridFilterPass` compiler pass, `GridConfigInstaller` / `GridConfigInstallerInterface`.
+- `CoreShop\Bundle\PimcoreBundle\Controller\Admin\*` controllers. Studio-facing actions were moved to
+  `CoreShop\Bundle\PimcoreBundle\Controller\{DynamicDropdown,Grid}Controller`.
+- ExtJS menu rendering (`coreshop_menu` route, `menu.js.twig`, `JsonRenderer`). The Studio menu API
+  (`coreshop_menu_api`, `StudioRenderer`) is unchanged.
+- `pimcore/admin-ui-classic-bundle` suggest entries from all bundle `composer.json`.
+- Classic Admin firewall / ACL / role hierarchy scaffolding in `config/packages/security.yaml`.
+
+If you have project code referencing any of these symbols, see the migration notes in the
+upgrade guide.
+
+### Studio extension points unchanged
+
+The following Studio APIs, routes, and registries continue to work as in `5.1`:
+
+- `GET /pimcore-studio/api/coreshop/grid/studio-filters/{listType}`
+- `GET /pimcore-studio/api/coreshop/grid/actions/{listType}`
+- `POST /pimcore-studio/api/coreshop/grid/apply-action`
+- `/pimcore-studio/api/coreshop/dynamic-dropdown/{options,methods}`
+- `/pimcore-studio/api/coreshop/menus`
+- The seven entity extension types (form / table-column / save-decorator / tab / action / validation /
+  lifecycle) and all dynamic type registrations.
+
+### Static routes migrated to native Symfony routing (opt-in)
+
+CoreShop no longer depends on the deprecated `pimcore/static-routes-bundle`. The ~40 frontend shop
+routes previously defined in `FrontendBundle/Resources/install/pimcore/staticroutes.yml` and written
+into Pimcore's `settings-store` on install are now declared as native Symfony routes under
+`FrontendBundle/Resources/config/routes/`, split per URL topic (`shop/index.yaml`,
+`shop/cart.yaml`, `shop/catalog.yaml`, `shop/checkout.yaml`, `shop/customer.yaml`, `shop/wishlist.yaml`,
+`partial.yaml`).
+
+**Routes are opt-in.** The bundle no longer auto-registers them via Pimcore's `pimcore_bundle` route
+loader. Projects must explicitly import them in their own `config/routes.yaml`:
+
+```yaml
+coreshop_frontend:
+    resource: "@CoreShopFrontendBundle/Resources/config/routes.yaml"
+```
+
+Projects with a custom storefront can skip the top-level import and cherry-pick only the sub-files
+they want (e.g. `routes/shop/cart.yaml` without `routes/shop/checkout.yaml`). See the Installation
+Guide for details.
+
+Additional effects:
+
+- Installing CoreShop no longer runs a route-installation step; the Symfony router picks the routes
+  up at cache warm-up.
+- `PimcoreRoutesInstaller`, `RouteConfiguration`, and the `coreshop.resource.installer.routes`
+  service definition are removed.
+- `PimcoreStaticRoutesBundle` is removed from `config/bundles.php` and from the conditional
+  registration in `CoreShopResourceBundle::registerDependentBundles()`.
+- `LocaleSwitcherExtension` no longer calls `Staticroute::getByName()` — it inspects the current
+  route's compiled parameters via `RouterInterface::getRouteCollection()`.
+- The `pimcore_wishlist_summary` path previously exposed both `/{_locale}/shop/wishlist` and
+  `/{_locale}/shop/wishlist/{identifier}` under one name. The identifier variant is now a separate
+  route, `coreshop_wishlist_summary_identifier`. Existing twig/template callers pass no identifier
+  and are unaffected.
+- Route names and reverse URLs are preserved 1:1 — no template or redirect URL change is required.
+
+### Documentation
+
+Developer docs covering `rule-engine`, `payment-provider`, `menu-bundle`, `form-extension`, and
+`order-detail` extension have been rewritten to use Studio patterns (StudioFormBundle schema,
+TabExtension / ActionExtension slots). ExtJS code samples were removed.
+
 ### Studio builds ship as archives
 
 The Studio frontend build of every bundle is now committed as a single archive,

--- a/docs/01_Getting_Started/05_Telemetry.md
+++ b/docs/01_Getting_Started/05_Telemetry.md
@@ -1,0 +1,61 @@
+# Telemetry and License Check
+
+CoreShop is licensed under the CoreShop Commercial License (CCL). To know which installations exist and whether they
+carry a valid subscription, CoreShop sends a small, anonymous ping to the CoreShop license portal once every 24 hours.
+
+The ping is sent by the Pimcore maintenance task `coreshop_telemetry`. If the maintenance is not running, it is also
+triggered on demand by the `coreshop/enterprise-subscription-bundle` when the Pimcore Studio checks the subscription
+status. It never runs inside a storefront request, uses a short timeout and never throws: a portal that is unreachable
+only produces a warning in the application log.
+
+## What is sent
+
+| Field | Content |
+|---|---|
+| `id` | SHA-256 of the Pimcore instance identifier (`PIMCORE_INSTANCE_IDENTIFIER`). If none is configured, a UUID is generated once and stored in the Pimcore settings store. The raw identifier is never sent. |
+| `pimcoreInstanceId` | HMAC of the Pimcore instance identifier with the Pimcore encryption secret, the same value Pimcore uses for its product registration. Omitted when either value is missing. |
+| `hosts`, `currentDomain` | The main domain from the Pimcore system settings, all domains of all Pimcore sites, and the host of the current request if any. |
+| `coreshop`, `pimcore`, `php` | Version numbers. |
+| `environment` | The Symfony kernel environment (`prod`, `dev`, …). |
+| `bundles` | Name and version of every installed `coreshop/*` Composer package and every package of type `pimcore-bundle`. |
+| `production`, `tokenHash` | Contributed by the enterprise subscription bundle: whether the installation is flagged as a production system, and the SHA-256 of the subscription token. The token itself is never transmitted. |
+| `timestamp` | Time of the ping. |
+
+No customer data, no content, no order or product data is transmitted.
+
+## Opt-out and configuration
+
+```yaml
+core_shop_core:
+    telemetry:
+        enabled: '%env(bool:CORESHOP_TELEMETRY)%'   # default true
+        endpoint: 'https://license.coreshop.com/v1/ping'
+        timeout: 4.0
+```
+
+Set `CORESHOP_TELEMETRY=false` in your `.env` to disable the ping entirely. Note that without the ping the license
+portal cannot confirm your subscription and the Studio will show a warning.
+
+## Manual ping
+
+```bash
+bin/console coreshop:telemetry:ping --dump   # show the payload without sending
+bin/console coreshop:telemetry:ping          # send now and print the portal response
+bin/console pimcore:maintenance --job=coreshop_telemetry
+```
+
+## Contributing data from a bundle
+
+Implement `CoreShop\Component\Core\Telemetry\TelemetryDataProviderInterface` and return a partial payload. Services
+implementing the interface are tagged `coreshop.telemetry.provider` automatically. Values are merged on top of the core
+payload; `hosts` and `bundles` are concatenated.
+
+```php
+final class MyDataProvider implements TelemetryDataProviderInterface
+{
+    public function provide(): array
+    {
+        return ['myBundleFeatureX' => true];
+    }
+}
+```

--- a/docs/01_Getting_Started/index.md
+++ b/docs/01_Getting_Started/index.md
@@ -6,5 +6,6 @@ This section provides a quick tutorial to get started with CoreShop. It covers t
 2. **Architecture Overview**: [Architecture Overview](./01_Architecture_Overview.md)
 3. **Upgrade Notes**: [Upgrade Notes](./02_Upgrade_Notes.md)
 4. **Upgrade Guide**: [Upgrade Guide](02_Upgrade_Guide.md)
-5. **UI Documentation**: [User Interface Documentation](../02_User_Documentation/index.md)
-6. **Developer Documentation**: [Developer Documentation](../03_Development/index.md)
+5. **Telemetry**: [Telemetry and License Check](./05_Telemetry.md)
+6. **UI Documentation**: [User Interface Documentation](../02_User_Documentation/index.md)
+7. **Developer Documentation**: [Developer Documentation](../03_Development/index.md)

--- a/src/CoreShop/Bundle/CoreBundle/Command/TelemetryPingCommand.php
+++ b/src/CoreShop/Bundle/CoreBundle/Command/TelemetryPingCommand.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CoreShop
+ *
+ * This source file is available under the terms of the
+ * CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    CoreShop Commercial License (CCL)
+ *
+ */
+
+namespace CoreShop\Bundle\CoreBundle\Command;
+
+use CoreShop\Component\Core\Telemetry\TelemetryPingerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+final class TelemetryPingCommand extends Command
+{
+    public function __construct(
+        private readonly TelemetryPingerInterface $pinger,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('coreshop:telemetry:ping')
+            ->setDescription('Sends the CoreShop telemetry ping to the license portal now.')
+            ->addOption('dump', null, InputOption::VALUE_NONE, 'Print the payload that would be sent, without sending it.')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        if (!$this->pinger->isEnabled()) {
+            $io->note('Telemetry is disabled (CORESHOP_TELEMETRY / core_shop_core.telemetry.enabled).');
+        }
+
+        if ($input->getOption('dump')) {
+            $io->writeln(json_encode($this->pinger->buildPayload(), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_THROW_ON_ERROR));
+
+            return Command::SUCCESS;
+        }
+
+        if (!$this->pinger->isEnabled()) {
+            return Command::SUCCESS;
+        }
+
+        $response = $this->pinger->ping();
+
+        if (null === $response) {
+            $io->warning('Ping failed, see the application log for details.');
+
+            return Command::SUCCESS;
+        }
+
+        $io->success('Ping sent.');
+        $io->writeln(json_encode($response, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_THROW_ON_ERROR));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/CoreShop/Bundle/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop/Bundle/CoreBundle/DependencyInjection/Configuration.php
@@ -39,6 +39,17 @@ final class Configuration implements ConfigurationInterface
                 ->scalarNode('checkout_manager_factory')->cannotBeEmpty()->end()
                 ->scalarNode('after_logout_redirect_route')->defaultValue('coreshop_index')->cannotBeEmpty()->end()
                 ->scalarNode('autoconfigure_with_attributes')->defaultFalse()->end()
+                ->arrayNode('telemetry')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('enabled')
+                            ->info('Daily anonymous ping to the CoreShop license portal. Set CORESHOP_TELEMETRY=false to opt out.')
+                            ->defaultValue('%env(bool:CORESHOP_TELEMETRY)%')
+                        ->end()
+                        ->scalarNode('endpoint')->defaultValue('https://license.coreshop.com/v1/ping')->cannotBeEmpty()->end()
+                        ->floatNode('timeout')->defaultValue(4.0)->min(0.5)->end()
+                    ->end()
+                ->end()
             ->end()
         ;
         $this->addModelsSection($rootNode);

--- a/src/CoreShop/Bundle/CoreBundle/DependencyInjection/CoreShopCoreExtension.php
+++ b/src/CoreShop/Bundle/CoreBundle/DependencyInjection/CoreShopCoreExtension.php
@@ -21,16 +21,19 @@ use CoreShop\Bundle\CoreBundle\Attribute\AsPortlet;
 use CoreShop\Bundle\CoreBundle\Attribute\AsReport;
 use CoreShop\Bundle\CoreBundle\DependencyInjection\Compiler\RegisterPortletsPass;
 use CoreShop\Bundle\CoreBundle\DependencyInjection\Compiler\RegisterReportsPass;
+use CoreShop\Bundle\CoreBundle\Telemetry\TelemetryPinger;
 use CoreShop\Bundle\ResourceBundle\CoreShopResourceBundle;
 use CoreShop\Bundle\ResourceBundle\DependencyInjection\Extension\AbstractModelExtension;
 use CoreShop\Component\Core\Portlet\PortletInterface;
 use CoreShop\Component\Core\Report\ReportInterface;
+use CoreShop\Component\Core\Telemetry\TelemetryDataProviderInterface;
 use CoreShop\Component\Order\Checkout\CheckoutManagerFactoryInterface;
 use CoreShop\Component\Order\Checkout\DefaultCheckoutManagerFactory;
 use CoreShop\Component\Registry\Autoconfiguration;
 use Pimcore\Bundle\CustomReportsBundle\PimcoreCustomReportsBundle;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -78,6 +81,11 @@ final class CoreShopCoreExtension extends AbstractModelExtension implements Prep
 
         $container->setParameter('coreshop.after_logout_redirect_route', $configs['after_logout_redirect_route']);
 
+        $container->setParameter('coreshop.telemetry.enabled', $configs['telemetry']['enabled']);
+        $container->setParameter('coreshop.telemetry.endpoint', $configs['telemetry']['endpoint']);
+        $container->setParameter('coreshop.telemetry.timeout', $configs['telemetry']['timeout']);
+        $container->registerForAutoconfiguration(TelemetryDataProviderInterface::class)->addTag('coreshop.telemetry.provider');
+
         $bundles = $container->getParameter('kernel.bundles');
 
         if (array_key_exists('PimcoreDataHubBundle', $bundles)) {
@@ -89,6 +97,8 @@ final class CoreShopCoreExtension extends AbstractModelExtension implements Prep
         }
 
         $loader->load('services.yml');
+        // lint:yaml runs without --parse-tags, so the provider iterator is wired here instead of via !tagged_iterator
+        $container->getDefinition(TelemetryPinger::class)->replaceArgument(1, new TaggedIteratorArgument('coreshop.telemetry.provider'));
 
         $env = (string) $container->getParameter('kernel.environment');
         if (str_contains($env, 'test')) {

--- a/src/CoreShop/Bundle/CoreBundle/Maintenance/TelemetryTask.php
+++ b/src/CoreShop/Bundle/CoreBundle/Maintenance/TelemetryTask.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CoreShop
+ *
+ * This source file is available under the terms of the
+ * CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    CoreShop Commercial License (CCL)
+ *
+ */
+
+namespace CoreShop\Bundle\CoreBundle\Maintenance;
+
+use CoreShop\Component\Core\Telemetry\TelemetryPingerInterface;
+use Pimcore\Maintenance\TaskInterface;
+
+final class TelemetryTask implements TaskInterface
+{
+    public function __construct(
+        private readonly TelemetryPingerInterface $pinger,
+    ) {
+    }
+
+    public function execute(): void
+    {
+        // the pinger owns the 24h throttle, so running every maintenance cycle is cheap
+        $this->pinger->pingIfStale();
+    }
+}

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services.yml
@@ -31,6 +31,7 @@ imports:
     - { resource: services/shipping-taxation.yml }
     - { resource: services/taxation.yml }
     - { resource: services/fixtures.yaml }
+    - { resource: services/telemetry.yml }
 
 services:
     _defaults:

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services/telemetry.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services/telemetry.yml
@@ -1,0 +1,65 @@
+parameters:
+    env(CORESHOP_TELEMETRY): 'true'
+
+services:
+    _defaults:
+        public: false
+
+    CoreShop\Component\Core\Telemetry\InstanceIdentifierProviderInterface: '@CoreShop\Bundle\CoreBundle\Telemetry\InstanceIdentifierProvider'
+    CoreShop\Bundle\CoreBundle\Telemetry\InstanceIdentifierProvider:
+        arguments:
+            - '%pimcore.product_registration.instance_identifier%'
+            - '%pimcore.encryption.secret%'
+
+    CoreShop\Component\Core\Telemetry\TelemetryResultStorageInterface: '@CoreShop\Bundle\CoreBundle\Telemetry\SettingsStoreTelemetryResultStorage'
+    CoreShop\Bundle\CoreBundle\Telemetry\SettingsStoreTelemetryResultStorage: ~
+
+    CoreShop\Bundle\CoreBundle\Telemetry\Provider\SystemDataProvider:
+        arguments:
+            - '%kernel.environment%'
+        tags:
+            - { name: coreshop.telemetry.provider }
+
+    CoreShop\Bundle\CoreBundle\Telemetry\Provider\HostsDataProvider:
+        arguments:
+            - '%pimcore.config%'
+            - '@router.request_context'
+        tags:
+            - { name: coreshop.telemetry.provider }
+
+    CoreShop\Bundle\CoreBundle\Telemetry\Provider\BundlesDataProvider:
+        tags:
+            - { name: coreshop.telemetry.provider }
+
+    # own client so the timeout is isolated from any framework.http_client configuration
+    coreshop.telemetry.http_client:
+        class: Symfony\Contracts\HttpClient\HttpClientInterface
+        factory: ['Symfony\Component\HttpClient\HttpClient', 'create']
+        arguments:
+            - { timeout: '%coreshop.telemetry.timeout%' }
+
+    CoreShop\Component\Core\Telemetry\TelemetryPingerInterface: '@CoreShop\Bundle\CoreBundle\Telemetry\TelemetryPinger'
+    CoreShop\Bundle\CoreBundle\Telemetry\TelemetryPinger:
+        public: true
+        arguments:
+            - '@coreshop.telemetry.http_client'
+            - [] # replaced in CoreShopCoreExtension by TaggedIteratorArgument('coreshop.telemetry.provider'); lint:yaml has no custom tag support
+            - '@CoreShop\Component\Core\Telemetry\InstanceIdentifierProviderInterface'
+            - '@CoreShop\Component\Core\Telemetry\TelemetryResultStorageInterface'
+            - '@logger'
+            - '%coreshop.telemetry.enabled%'
+            - '%coreshop.telemetry.endpoint%'
+            - '%coreshop.telemetry.timeout%'
+
+    coreshop.maintenance.telemetry_task:
+        class: CoreShop\Bundle\CoreBundle\Maintenance\TelemetryTask
+        arguments:
+            - '@CoreShop\Component\Core\Telemetry\TelemetryPingerInterface'
+        tags:
+            - { name: pimcore.maintenance.task, type: coreshop_telemetry }
+
+    CoreShop\Bundle\CoreBundle\Command\TelemetryPingCommand:
+        arguments:
+            - '@CoreShop\Component\Core\Telemetry\TelemetryPingerInterface'
+        tags:
+            - { name: console.command, command: coreshop:telemetry:ping }

--- a/src/CoreShop/Bundle/CoreBundle/Resources/config/services_test.yml
+++ b/src/CoreShop/Bundle/CoreBundle/Resources/config/services_test.yml
@@ -4,3 +4,7 @@ services:
             - '%kernel.cache_dir%/notifications'
         tags:
             - { name: kernel.event_listener, event: coreshop.notification.pre_process_rules, method: applyNewFired }
+
+    # never call the license portal from the test-suite
+    coreshop.telemetry.http_client:
+        class: Symfony\Component\HttpClient\MockHttpClient

--- a/src/CoreShop/Bundle/CoreBundle/Telemetry/InstanceIdentifierProvider.php
+++ b/src/CoreShop/Bundle/CoreBundle/Telemetry/InstanceIdentifierProvider.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CoreShop
+ *
+ * This source file is available under the terms of the
+ * CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    CoreShop Commercial License (CCL)
+ *
+ */
+
+namespace CoreShop\Bundle\CoreBundle\Telemetry;
+
+use CoreShop\Component\Core\Telemetry\InstanceIdentifierProviderInterface;
+use Pimcore\Model\Tool\SettingsStore;
+use Symfony\Component\Uid\Uuid;
+
+final class InstanceIdentifierProvider implements InstanceIdentifierProviderInterface
+{
+    public const string SETTINGS_SCOPE = 'coreshop';
+
+    public const string SETTINGS_KEY = 'telemetry.instance_id';
+
+    private ?string $identifier = null;
+
+    public function __construct(
+        private readonly ?string $pimcoreInstanceIdentifier,
+        private readonly ?string $encryptionSecret,
+    ) {
+    }
+
+    public function getIdentifier(): string
+    {
+        if (null !== $this->identifier) {
+            return $this->identifier;
+        }
+
+        if (null !== $this->pimcoreInstanceIdentifier && '' !== trim($this->pimcoreInstanceIdentifier)) {
+            return $this->identifier = trim($this->pimcoreInstanceIdentifier);
+        }
+
+        $stored = SettingsStore::get(self::SETTINGS_KEY, self::SETTINGS_SCOPE);
+        $data = $stored?->getData();
+
+        if (is_string($data) && '' !== $data) {
+            return $this->identifier = $data;
+        }
+
+        $generated = Uuid::v6()->toBase58();
+        SettingsStore::set(self::SETTINGS_KEY, $generated, 'string', self::SETTINGS_SCOPE);
+
+        return $this->identifier = $generated;
+    }
+
+    public function getHashedIdentifier(): string
+    {
+        return hash('sha256', $this->getIdentifier());
+    }
+
+    public function getPimcoreInstanceId(): ?string
+    {
+        if (null === $this->pimcoreInstanceIdentifier || '' === trim($this->pimcoreInstanceIdentifier)) {
+            return null;
+        }
+
+        if (null === $this->encryptionSecret || '' === $this->encryptionSecret) {
+            return null;
+        }
+
+        return hash_hmac('sha256', trim($this->pimcoreInstanceIdentifier), $this->encryptionSecret);
+    }
+}

--- a/src/CoreShop/Bundle/CoreBundle/Telemetry/Provider/BundlesDataProvider.php
+++ b/src/CoreShop/Bundle/CoreBundle/Telemetry/Provider/BundlesDataProvider.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CoreShop
+ *
+ * This source file is available under the terms of the
+ * CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    CoreShop Commercial License (CCL)
+ *
+ */
+
+namespace CoreShop\Bundle\CoreBundle\Telemetry\Provider;
+
+use Composer\InstalledVersions;
+use CoreShop\Component\Core\Telemetry\TelemetryDataProviderInterface;
+
+/**
+ * Reports every installed CoreShop package plus every package of type
+ * `pimcore-bundle`. The client carries no product knowledge; mapping packages to
+ * products happens in the license portal.
+ */
+final class BundlesDataProvider implements TelemetryDataProviderInterface
+{
+    private const string VENDOR_PREFIX = 'coreshop/';
+
+    private const string BUNDLE_TYPE = 'pimcore-bundle';
+
+    public function provide(): array
+    {
+        $names = [];
+
+        foreach (InstalledVersions::getInstalledPackages() as $name) {
+            if (str_starts_with($name, self::VENDOR_PREFIX)) {
+                $names[$name] = true;
+            }
+        }
+
+        foreach (InstalledVersions::getInstalledPackagesByType(self::BUNDLE_TYPE) as $name) {
+            $names[$name] = true;
+        }
+
+        $names = array_keys($names);
+        sort($names);
+
+        $bundles = [];
+        foreach ($names as $name) {
+            $version = InstalledVersions::getPrettyVersion($name);
+
+            // packages only known through "replace"/"provide" carry no version; the replacing package is reported instead
+            if (null === $version) {
+                continue;
+            }
+
+            $bundles[] = ['name' => $name, 'version' => $version];
+        }
+
+        return ['bundles' => $bundles];
+    }
+}

--- a/src/CoreShop/Bundle/CoreBundle/Telemetry/Provider/HostsDataProvider.php
+++ b/src/CoreShop/Bundle/CoreBundle/Telemetry/Provider/HostsDataProvider.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CoreShop
+ *
+ * This source file is available under the terms of the
+ * CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    CoreShop Commercial License (CCL)
+ *
+ */
+
+namespace CoreShop\Bundle\CoreBundle\Telemetry\Provider;
+
+use CoreShop\Component\Core\Telemetry\TelemetryDataProviderInterface;
+use Pimcore\Model\Site;
+use Symfony\Component\Routing\RequestContext;
+
+final class HostsDataProvider implements TelemetryDataProviderInterface
+{
+    private const array IGNORED_HOSTS = ['', 'localhost', '127.0.0.1', '::1'];
+
+    /**
+     * @param array<string, mixed> $pimcoreConfig
+     */
+    public function __construct(
+        private readonly array $pimcoreConfig,
+        private readonly ?RequestContext $requestContext = null,
+    ) {
+    }
+
+    public function provide(): array
+    {
+        $hosts = [];
+
+        $mainDomain = $this->pimcoreConfig['general']['domain'] ?? null;
+        if (is_string($mainDomain)) {
+            $hosts[] = $mainDomain;
+        }
+
+        try {
+            foreach ((new Site\Listing())->load() as $site) {
+                $hosts[] = $site->getMainDomain();
+                $hosts = array_merge($hosts, $site->getDomains());
+            }
+        } catch (\Throwable) {
+            // sites may be unavailable (e.g. no database during install); hosts are best-effort
+        }
+
+        $hosts = array_values(array_unique(array_filter(
+            array_map(static fn (mixed $host): string => strtolower(trim((string) $host)), $hosts),
+            static fn (string $host): bool => !in_array($host, self::IGNORED_HOSTS, true),
+        )));
+
+        $payload = ['hosts' => $hosts];
+
+        $currentHost = strtolower(trim((string) $this->requestContext?->getHost()));
+        if (!in_array($currentHost, self::IGNORED_HOSTS, true)) {
+            $payload['currentDomain'] = $currentHost;
+        }
+
+        return $payload;
+    }
+}

--- a/src/CoreShop/Bundle/CoreBundle/Telemetry/Provider/SystemDataProvider.php
+++ b/src/CoreShop/Bundle/CoreBundle/Telemetry/Provider/SystemDataProvider.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CoreShop
+ *
+ * This source file is available under the terms of the
+ * CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    CoreShop Commercial License (CCL)
+ *
+ */
+
+namespace CoreShop\Bundle\CoreBundle\Telemetry\Provider;
+
+use Composer\InstalledVersions;
+use CoreShop\Bundle\CoreBundle\Application\Version;
+use CoreShop\Component\Core\Telemetry\TelemetryDataProviderInterface;
+
+final class SystemDataProvider implements TelemetryDataProviderInterface
+{
+    public function __construct(
+        private readonly string $kernelEnvironment,
+    ) {
+    }
+
+    public function provide(): array
+    {
+        return [
+            'environment' => $this->kernelEnvironment,
+            'coreshop' => Version::getVersion(),
+            'pimcore' => InstalledVersions::getPrettyVersion('pimcore/pimcore') ?? 'unknown',
+            'php' => \PHP_VERSION,
+            'timestamp' => (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format(\DateTimeInterface::ATOM),
+        ];
+    }
+}

--- a/src/CoreShop/Bundle/CoreBundle/Telemetry/SettingsStoreTelemetryResultStorage.php
+++ b/src/CoreShop/Bundle/CoreBundle/Telemetry/SettingsStoreTelemetryResultStorage.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CoreShop
+ *
+ * This source file is available under the terms of the
+ * CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    CoreShop Commercial License (CCL)
+ *
+ */
+
+namespace CoreShop\Bundle\CoreBundle\Telemetry;
+
+use CoreShop\Component\Core\Telemetry\TelemetryResultStorageInterface;
+use Pimcore\Model\Tool\SettingsStore;
+
+final class SettingsStoreTelemetryResultStorage implements TelemetryResultStorageInterface
+{
+    public const string SETTINGS_SCOPE = 'coreshop';
+
+    public const string KEY_LAST_PING = 'telemetry.last_ping';
+
+    public const string KEY_LAST_ATTEMPT = 'telemetry.last_attempt';
+
+    public const string KEY_LAST_RESPONSE = 'telemetry.last_response';
+
+    public function store(array $response): void
+    {
+        $now = time();
+
+        SettingsStore::set(self::KEY_LAST_RESPONSE, json_encode($response, \JSON_THROW_ON_ERROR), 'string', self::SETTINGS_SCOPE);
+        SettingsStore::set(self::KEY_LAST_PING, $now, 'int', self::SETTINGS_SCOPE);
+        SettingsStore::set(self::KEY_LAST_ATTEMPT, $now, 'int', self::SETTINGS_SCOPE);
+    }
+
+    public function get(): ?array
+    {
+        $data = SettingsStore::get(self::KEY_LAST_RESPONSE, self::SETTINGS_SCOPE)?->getData();
+
+        if (!is_string($data) || '' === $data) {
+            return null;
+        }
+
+        try {
+            $decoded = json_decode($data, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return null;
+        }
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    public function getLastPing(): ?int
+    {
+        return $this->getInt(self::KEY_LAST_PING);
+    }
+
+    public function getLastAttempt(): ?int
+    {
+        return $this->getInt(self::KEY_LAST_ATTEMPT);
+    }
+
+    public function markAttempt(): void
+    {
+        SettingsStore::set(self::KEY_LAST_ATTEMPT, time(), 'int', self::SETTINGS_SCOPE);
+    }
+
+    private function getInt(string $key): ?int
+    {
+        $data = SettingsStore::get($key, self::SETTINGS_SCOPE)?->getData();
+
+        if (null === $data) {
+            return null;
+        }
+
+        return (int) $data;
+    }
+}

--- a/src/CoreShop/Bundle/CoreBundle/Telemetry/TelemetryPinger.php
+++ b/src/CoreShop/Bundle/CoreBundle/Telemetry/TelemetryPinger.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CoreShop
+ *
+ * This source file is available under the terms of the
+ * CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    CoreShop Commercial License (CCL)
+ *
+ */
+
+namespace CoreShop\Bundle\CoreBundle\Telemetry;
+
+use CoreShop\Bundle\CoreBundle\Application\Version;
+use CoreShop\Component\Core\Telemetry\InstanceIdentifierProviderInterface;
+use CoreShop\Component\Core\Telemetry\TelemetryDataProviderInterface;
+use CoreShop\Component\Core\Telemetry\TelemetryPingerInterface;
+use CoreShop\Component\Core\Telemetry\TelemetryResultStorageInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final class TelemetryPinger implements TelemetryPingerInterface
+{
+    /**
+     * Minimum seconds between two attempts, successful or not. Prevents hammering the
+     * portal when pingIfStale() is triggered from the admin UI while the portal is down.
+     */
+    public const int ATTEMPT_BACKOFF = 900;
+
+    private const array LIST_KEYS = ['hosts', 'bundles'];
+
+    /**
+     * @param iterable<TelemetryDataProviderInterface> $providers
+     */
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly iterable $providers,
+        private readonly InstanceIdentifierProviderInterface $identifierProvider,
+        private readonly TelemetryResultStorageInterface $storage,
+        private readonly LoggerInterface $logger,
+        private readonly bool $enabled,
+        private readonly string $endpoint,
+        private readonly float $timeout,
+    ) {
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled && '' !== $this->endpoint;
+    }
+
+    public function buildPayload(): array
+    {
+        $payload = [
+            'id' => $this->identifierProvider->getHashedIdentifier(),
+            'pimcoreInstanceId' => $this->identifierProvider->getPimcoreInstanceId(),
+        ];
+
+        foreach ($this->providers as $provider) {
+            $payload = $this->merge($payload, $provider->provide());
+        }
+
+        return array_filter($payload, static fn (mixed $value): bool => null !== $value && '' !== $value);
+    }
+
+    public function ping(): ?array
+    {
+        if (!$this->isEnabled()) {
+            return null;
+        }
+
+        try {
+            $this->storage->markAttempt();
+
+            $payload = $this->buildPayload();
+
+            $response = $this->httpClient->request('POST', $this->endpoint, [
+                'json' => $payload,
+                'timeout' => $this->timeout,
+                'max_duration' => $this->timeout + 1,
+                'headers' => [
+                    'User-Agent' => 'CoreShop/' . Version::getVersion(),
+                    'X-CoreShop-Client' => Version::getVersion(),
+                ],
+            ]);
+
+            $status = $response->getStatusCode();
+            $data = $response->toArray(false);
+
+            if ($status >= 400) {
+                $this->logger->warning('CoreShop telemetry ping rejected by portal', ['status' => $status, 'response' => $data]);
+
+                return null;
+            }
+
+            $this->storage->store($data);
+
+            return $data;
+        } catch (\Throwable $e) {
+            $this->logger->warning('CoreShop telemetry ping failed', ['exception' => $e]);
+
+            return null;
+        }
+    }
+
+    public function pingIfStale(int $ttl = self::DEFAULT_TTL): ?array
+    {
+        if (!$this->isEnabled()) {
+            return null;
+        }
+
+        try {
+            $now = time();
+            $lastPing = $this->storage->getLastPing();
+            $lastAttempt = $this->storage->getLastAttempt();
+
+            $isFresh = null !== $lastPing && ($now - $lastPing) <= $ttl;
+            $inBackoff = null !== $lastAttempt && ($now - $lastAttempt) < self::ATTEMPT_BACKOFF;
+
+            if ($isFresh || $inBackoff) {
+                return $this->storage->get();
+            }
+        } catch (\Throwable $e) {
+            $this->logger->warning('CoreShop telemetry storage unavailable', ['exception' => $e]);
+
+            return null;
+        }
+
+        return $this->ping() ?? $this->safeGet();
+    }
+
+    public function getLastResult(): array
+    {
+        try {
+            return ['response' => $this->storage->get(), 'lastPing' => $this->storage->getLastPing()];
+        } catch (\Throwable) {
+            return ['response' => null, 'lastPing' => null];
+        }
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function safeGet(): ?array
+    {
+        try {
+            return $this->storage->get();
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $base
+     * @param array<string, mixed> $addition
+     *
+     * @return array<string, mixed>
+     */
+    private function merge(array $base, array $addition): array
+    {
+        foreach ($addition as $key => $value) {
+            if (in_array($key, self::LIST_KEYS, true) && is_array($value) && is_array($base[$key] ?? null)) {
+                $base[$key] = array_values(array_merge($base[$key], $value));
+
+                continue;
+            }
+
+            $base[$key] = $value;
+        }
+
+        return $base;
+    }
+}

--- a/src/CoreShop/Component/Core/Telemetry/InstanceIdentifierProviderInterface.php
+++ b/src/CoreShop/Component/Core/Telemetry/InstanceIdentifierProviderInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CoreShop
+ *
+ * This source file is available under the terms of the
+ * CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    CoreShop Commercial License (CCL)
+ *
+ */
+
+namespace CoreShop\Component\Core\Telemetry;
+
+interface InstanceIdentifierProviderInterface
+{
+    /**
+     * Raw identifier: Pimcore's instance identifier if configured, otherwise a
+     * UUID generated once and persisted. Never transmitted as-is.
+     */
+    public function getIdentifier(): string;
+
+    /**
+     * sha256 hex of the raw identifier. This is the `id` sent to the portal.
+     */
+    public function getHashedIdentifier(): string;
+
+    /**
+     * HMAC of Pimcore's instance identifier with the Pimcore encryption secret,
+     * identical to what Pimcore's product registration uses. Null when either is missing.
+     */
+    public function getPimcoreInstanceId(): ?string;
+}

--- a/src/CoreShop/Component/Core/Telemetry/TelemetryDataProviderInterface.php
+++ b/src/CoreShop/Component/Core/Telemetry/TelemetryDataProviderInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CoreShop
+ *
+ * This source file is available under the terms of the
+ * CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    CoreShop Commercial License (CCL)
+ *
+ */
+
+namespace CoreShop\Component\Core\Telemetry;
+
+/**
+ * Contributes a partial telemetry payload. Providers are collected via the
+ * `coreshop.telemetry.provider` tag and merged shallowly; list-valued keys
+ * (`hosts`, `bundles`) are concatenated.
+ */
+interface TelemetryDataProviderInterface
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function provide(): array;
+}

--- a/src/CoreShop/Component/Core/Telemetry/TelemetryPingerInterface.php
+++ b/src/CoreShop/Component/Core/Telemetry/TelemetryPingerInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CoreShop
+ *
+ * This source file is available under the terms of the
+ * CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    CoreShop Commercial License (CCL)
+ *
+ */
+
+namespace CoreShop\Component\Core\Telemetry;
+
+interface TelemetryPingerInterface
+{
+    public const int DEFAULT_TTL = 86400;
+
+    /**
+     * Sends the ping unconditionally. Never throws; returns the decoded portal
+     * response or null on failure / when disabled.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function ping(): ?array;
+
+    /**
+     * Pings only when the last successful ping is older than $ttl seconds and the
+     * last attempt is older than the attempt backoff; otherwise returns the stored result.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function pingIfStale(int $ttl = self::DEFAULT_TTL): ?array;
+
+    /**
+     * @return array{response: array<string, mixed>|null, lastPing: int|null}
+     */
+    public function getLastResult(): array;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function buildPayload(): array;
+
+    public function isEnabled(): bool;
+}

--- a/src/CoreShop/Component/Core/Telemetry/TelemetryResultStorageInterface.php
+++ b/src/CoreShop/Component/Core/Telemetry/TelemetryResultStorageInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CoreShop
+ *
+ * This source file is available under the terms of the
+ * CoreShop Commercial License (CCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) CoreShop GmbH (https://www.coreshop.com)
+ * @license    CoreShop Commercial License (CCL)
+ *
+ */
+
+namespace CoreShop\Component\Core\Telemetry;
+
+interface TelemetryResultStorageInterface
+{
+    /**
+     * @param array<string, mixed> $response
+     */
+    public function store(array $response): void;
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function get(): ?array;
+
+    public function getLastPing(): ?int;
+
+    public function getLastAttempt(): ?int;
+
+    public function markAttempt(): void;
+}


### PR DESCRIPTION
Closes #3213

## Identity and payload

`CoreShop\Component\Core\Telemetry\*` holds the contracts; `CoreShop\Bundle\CoreBundle\Telemetry\*` the implementation. `InstanceIdentifierProvider` uses `%pimcore.product_registration.instance_identifier%` (sha256 of it as `id`, hmac like Pimcore's `RegistrationValidator` as `pimcoreInstanceId`) and falls back to a UUIDv6 persisted in the SettingsStore. `SystemDataProvider`, `HostsDataProvider` and `BundlesDataProvider` add versions, the Symfony environment, main/site domains and every installed `coreshop/*` and `pimcore-bundle` package with its pretty version. Other bundles contribute through `TelemetryDataProviderInterface` (tag `coreshop.telemetry.provider`, autoconfigured).

## Pinger, maintenance task, command

`TelemetryPinger` POSTs to `core_shop_core.telemetry.endpoint` (default `https://license.coreshop.com/v1/ping`) with a 4s timeout, stores the JSON answer plus `last_ping`/`last_attempt` in the SettingsStore (scope `coreshop`) and never throws: every failure is a logged warning. `pingIfStale()` enforces 24h between pings and 15 min between attempts, so callers from a request context cannot hammer the portal. `TelemetryTask` (tag `pimcore.maintenance.task`, type `coreshop_telemetry`) calls it daily; `coreshop:telemetry:ping [--dump]` shows the payload and forces a ping.

## Configuration

New `core_shop_core.telemetry { enabled, endpoint, timeout }`; `enabled` reads `CORESHOP_TELEMETRY` (default true). `services_test.yml` swaps the HTTP client for `MockHttpClient`, so Behat never calls out. Docs page `docs/01_Getting_Started/05_Telemetry.md` lists every field and the opt-out; changelog entry added. The unused `send_usage_log` node is left in place.

## Not in this PR

The license token itself lives in `coreshop/enterprise-subscription-bundle` (contributes `tokenHash` and `production`); the portal is `coreshop/license-portal`. A 5.1 backport follows as a separate PR.

## Test

- `vendor/bin/ecs check` on the changed paths: no errors
- `vendor/bin/phpstan analyse`: no errors
- `vendor/bin/psalm`: no errors
- `bin/console coreshop:telemetry:ping --dump` against a local portal: payload with id, pimcoreInstanceId, environment, versions, hosts and bundles; answer stored in `settings_store`
- unreachable endpoint: warning logged, exit code 0