### PR TITLE
[CI] Shard Behat and chunk the package matrices

### DIFF
--- a/.github/bin/behat-shard.php
+++ b/.github/bin/behat-shard.php
@@ -1,0 +1,243 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Splits the Behat suites of a profile into shards that can run on separate CI runners.
+ *
+ * The suites of a profile are declared one file per domain and filtered by tag, so they are the
+ * natural unit to split by: every suite can run on its own with `behat --suite=…`. Their sizes
+ * differ by two orders of magnitude, though (the cart suite alone holds more than a quarter of
+ * all domain scenarios), so a round-robin split would leave one runner carrying the whole tail.
+ * Each suite is therefore weighted by the number of scenarios its tag filter matches, and the
+ * suites are then distributed longest-first onto the shard that is currently the emptiest.
+ *
+ * The scenario count is an approximation of the runtime, not a measurement of it: a scenario
+ * outline counts once, and no scenario is more expensive than another. It is good enough to keep
+ * the shards within a few percent of each other, and it needs no timing data to be carried
+ * between runs.
+ *
+ * Usage:
+ *   php .github/bin/behat-shard.php --shard=2 --shards=4
+ *   php .github/bin/behat-shard.php --profile=ui --shards=4 --plan
+ *
+ * Prints the suite names of the requested shard to STDOUT, one per line, and the full
+ * distribution to STDERR.
+ */
+
+use Symfony\Component\Yaml\Yaml;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$options = getopt('', ['shard::', 'shards::', 'config::', 'profile::', 'features::', 'plan']);
+
+$shards = (int) ($options['shards'] ?? 4);
+$shard = (int) ($options['shard'] ?? 0);
+$configFile = $options['config'] ?? __DIR__ . '/../../behat.yml.dist';
+$profile = $options['profile'] ?? 'default';
+$featuresDir = $options['features'] ?? __DIR__ . '/../../features';
+$planOnly = array_key_exists('plan', $options);
+
+if ($shards < 1) {
+    fwrite(STDERR, "--shards must be at least 1\n");
+
+    exit(1);
+}
+
+if (!$planOnly && ($shard < 1 || $shard > $shards)) {
+    fwrite(STDERR, sprintf("--shard must be between 1 and %d, got %d\n", $shards, $shard));
+
+    exit(1);
+}
+
+/**
+ * Behat resolves the paths in `imports` relative to the directory of the file that imports them,
+ * and merges what it loads recursively.
+ */
+$load = static function (string $file) use (&$load): array {
+    if (!is_file($file)) {
+        fwrite(STDERR, sprintf("Config file not found: %s\n", $file));
+
+        exit(1);
+    }
+
+    $config = Yaml::parseFile($file) ?? [];
+    $imports = $config['imports'] ?? [];
+    unset($config['imports']);
+
+    $merged = [];
+
+    foreach ($imports as $import) {
+        $merged = array_replace_recursive($merged, $load(dirname($file) . '/' . $import));
+    }
+
+    return array_replace_recursive($merged, $config);
+};
+
+$config = $load($configFile);
+
+// Every Behat profile extends `default`, which is where all suites of this repository are
+// declared — the other profiles only replace the extensions and the tag filter around them.
+$settings = array_replace_recursive($config['default'] ?? [], $config[$profile] ?? []);
+
+if (!isset($settings['suites'])) {
+    fwrite(STDERR, sprintf("Profile \"%s\" declares no suites in %s\n", $profile, $configFile));
+
+    exit(1);
+}
+
+$suites = $settings['suites'];
+$profileFilter = $settings['gherkin']['filters']['tags'] ?? null;
+
+/**
+ * Collects the tags of every scenario below the features directory. Tags written above `Feature:`
+ * belong to all of its scenarios, tags written above a scenario only to that one. A scenario
+ * outline counts as a single scenario.
+ *
+ * @return list<array<string, true>>
+ */
+$scenarioTags = static function (string $directory): array {
+    if (!is_dir($directory)) {
+        fwrite(STDERR, sprintf("Features directory not found: %s\n", $directory));
+
+        exit(1);
+    }
+
+    $files = new RegexIterator(
+        new RecursiveIteratorIterator(new RecursiveDirectoryIterator($directory)),
+        '/\.feature$/',
+    );
+
+    $scenarios = [];
+
+    foreach ($files as $file) {
+        $featureTags = [];
+        $pendingTags = [];
+
+        foreach (file($file->getPathname()) as $line) {
+            $line = trim($line);
+
+            if (str_starts_with($line, '@')) {
+                foreach (preg_split('/\s+/', $line) as $tag) {
+                    $pendingTags[ltrim($tag, '@')] = true;
+                }
+
+                continue;
+            }
+
+            if (str_starts_with($line, 'Feature:')) {
+                $featureTags = $pendingTags;
+                $pendingTags = [];
+
+                continue;
+            }
+
+            if (str_starts_with($line, 'Scenario:') || str_starts_with($line, 'Scenario Outline:')) {
+                $scenarios[] = $featureTags + $pendingTags;
+                $pendingTags = [];
+            }
+        }
+    }
+
+    return $scenarios;
+};
+
+/**
+ * Evaluates a Behat tag filter the way Behat's own TagFilter does: `&&` separates conjunctions,
+ * `,` alternatives within one conjunction, and a leading `~` negates a tag.
+ *
+ * @param array<string, true> $tags
+ */
+$matches = static function (string $expression, array $tags): bool {
+    foreach (explode('&&', $expression) as $conjunct) {
+        $satisfied = false;
+
+        foreach (explode(',', $conjunct) as $tag) {
+            $tag = trim($tag);
+            $negated = str_starts_with($tag, '~');
+            $tag = ltrim($tag, '~@');
+
+            if (isset($tags[$tag]) !== $negated) {
+                $satisfied = true;
+
+                break;
+            }
+        }
+
+        if (!$satisfied) {
+            return false;
+        }
+    }
+
+    return true;
+};
+
+$scenarios = $scenarioTags($featuresDir);
+
+$weights = [];
+$empty = [];
+
+foreach ($suites as $name => $suite) {
+    // Behat applies the profile's own filter on top of the suite's, so a suite only sees the
+    // scenarios that satisfy both. That is what keeps the UI suites — which live in the same
+    // `default` profile as the domain suites — empty for a `-p default` run.
+    $filter = implode('&&', array_filter([$profileFilter, $suite['filters']['tags'] ?? null]));
+
+    $weight = '' === $filter ? count($scenarios) : count(array_filter(
+        $scenarios,
+        static fn (array $tags): bool => $matches($filter, $tags),
+    ));
+
+    // Handing a suite without a single matching scenario to Behat costs a full kernel boot and
+    // runs nothing, so leave it out of the plan — but say so, because a suite that unexpectedly
+    // turns up here is a suite whose scenarios nobody is running.
+    if (0 === $weight) {
+        $empty[] = $name;
+
+        continue;
+    }
+
+    $weights[$name] = $weight;
+}
+
+// Longest processing time first: the heaviest suite is placed first, every following suite goes
+// onto whichever shard is the emptiest so far. Sorting by name where weights are equal keeps the
+// distribution stable across runs, so all shards of one build agree on who runs what.
+uksort($weights, static fn (string $a, string $b): int => [$weights[$b], $a] <=> [$weights[$a], $b]);
+
+$plan = array_fill(1, $shards, []);
+$totals = array_fill(1, $shards, 0);
+
+foreach ($weights as $name => $weight) {
+    $target = array_search(min($totals), $totals, true);
+
+    $plan[$target][] = $name;
+    $totals[$target] += $weight;
+}
+
+foreach ($plan as $index => $names) {
+    fwrite(STDERR, sprintf(
+        "Shard %d/%d — %d scenarios in %d suites: %s\n",
+        $index,
+        $shards,
+        $totals[$index],
+        count($names),
+        implode(', ', $names),
+    ));
+}
+
+fwrite(STDERR, sprintf(
+    "%d scenarios in %d suites of profile \"%s\"; %d suites match nothing and are skipped: %s\n",
+    array_sum($weights),
+    count($weights),
+    $profile,
+    count($empty),
+    implode(', ', $empty),
+));
+
+if ($planOnly) {
+    exit(0);
+}
+
+echo implode("\n", $plan[$shard]), "\n";

--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -23,6 +23,13 @@ on:
   schedule:
     - cron: "0 1 * * 1"
 
+# A newer push to the same pull request or branch supersedes the run that is still going: the
+# older run would only report on a commit nobody looks at any more. The event name is part of the
+# group so that a release or the weekly schedule is never cancelled by a push on the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 env:
   APP_ENV: "test"
   CORESHOP_SKIP_DB_SETUP: "1"
@@ -51,16 +58,16 @@ jobs:
     continue-on-error: ${{ matrix.allow-failure }}
 
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - php: 8.3
-            pimcore: ^12.3
-            dependencies: highest
-            allow-failure: false
-          - php: 8.4
-            pimcore: ^12.3
-            dependencies: highest
-            allow-failure: false
+        php: [ 8.3, 8.4 ]
+        pimcore: [ ^12.3 ]
+        dependencies: [ highest ]
+        allow-failure: [ false ]
+        # The suites are spread over the shards by scenario count. More shards only help while no
+        # single suite is longer than an even share, and the cart suite alone holds a good quarter of all domain scenarios — it is the
+        # floor. Keep this list and the `--shards` argument of the Behat step in sync.
+        shard: [ 1, 2, 3, 4 ]
 
     services:
       database:
@@ -81,7 +88,7 @@ jobs:
         ports:
           - 9200:9200
 
-    name: "${{ matrix.pimcore }}, PHP ${{ matrix.php }}, Deps ${{ matrix.dependencies }}"
+    name: "${{ matrix.pimcore }}, PHP ${{ matrix.php }}, Deps ${{ matrix.dependencies }}, Shard ${{ matrix.shard }}/4"
 
     steps:
       - uses: actions/checkout@v7
@@ -159,4 +166,26 @@ jobs:
           bin/console coreshop:install
 
       - name: Run Behat
-        run: vendor/bin/behat --strict --no-interaction -vvv -f progress --config behat.yml.dist -p default
+        run: |
+          suites=$(php .github/bin/behat-shard.php --profile=default --shard=${{ matrix.shard }} --shards=4)
+
+          if [ -z "$suites" ]; then
+            echo "No suites assigned to this shard."
+
+            exit 0
+          fi
+
+          # Behat takes a single --suite, so a shard runs its suites one after the other. Each of
+          # them runs even when an earlier one failed: stopping at the first failure would hide
+          # the rest of the shard's scenarios behind another round trip.
+          status=0
+
+          for suite in $suites; do
+            echo "::group::behat --suite=$suite"
+
+            vendor/bin/behat --strict --no-interaction -vvv -f progress --config behat.yml.dist -p default --suite "$suite" || status=1
+
+            echo "::endgroup::"
+          done
+
+          exit $status

--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -76,7 +76,13 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        # Installing the Pimcore class definitions issues hundreds of CREATE/ALTER TABLE
+        # statements, and every one of them waits on an fsync. The test database lives and dies
+        # with the job, so it has no business touching the disk at all — a RAM disk takes the
+        # durability cost out of the DDL and out of the scenarios that write through it.
+        options: >-
+          --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+          --tmpfs /var/lib/mysql:rw,noexec,nosuid,size=2g
 
       opensearch:
         image: "opensearchproject/opensearch:2.11.1"

--- a/.github/workflows/behat_ui.yml
+++ b/.github/workflows/behat_ui.yml
@@ -77,7 +77,13 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        # Installing the Pimcore class definitions issues hundreds of CREATE/ALTER TABLE
+        # statements, and every one of them waits on an fsync. The test database lives and dies
+        # with the job, so it has no business touching the disk at all — a RAM disk takes the
+        # durability cost out of the DDL and out of the scenarios that write through it.
+        options: >-
+          --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+          --tmpfs /var/lib/mysql:rw,noexec,nosuid,size=2g
 
       opensearch:
         image: "opensearchproject/opensearch:2.11.1"

--- a/.github/workflows/behat_ui.yml
+++ b/.github/workflows/behat_ui.yml
@@ -23,6 +23,13 @@ on:
   schedule:
     - cron: "0 1 * * 1"
 
+# A newer push to the same pull request or branch supersedes the run that is still going: the
+# older run would only report on a commit nobody looks at any more. The event name is part of the
+# group so that a release or the weekly schedule is never cancelled by a push on the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 env:
   APP_ENV: "test"
   CORESHOP_SKIP_DB_SETUP: "1"
@@ -52,16 +59,16 @@ jobs:
     continue-on-error: ${{ matrix.allow-failure }}
 
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - php: 8.3
-            pimcore: ^12.3
-            dependencies: highest
-            allow-failure: false
-          - php: 8.4
-            pimcore: ^12.3
-            dependencies: highest
-            allow-failure: false
+        php: [ 8.3, 8.4 ]
+        pimcore: [ ^12.3 ]
+        dependencies: [ highest ]
+        allow-failure: [ false ]
+        # The suites are spread over the shards by scenario count. More shards only help while no
+        # single suite is longer than an even share, and the cart suite alone holds close to half of the UI scenarios — it is the
+        # floor. Keep this list and the `--shards` argument of the Behat step in sync.
+        shard: [ 1, 2, 3, 4 ]
 
     services:
       database:
@@ -82,7 +89,7 @@ jobs:
         ports:
           - 9200:9200
 
-    name: "${{ matrix.pimcore }}, PHP ${{ matrix.php }}, Deps ${{ matrix.dependencies }}"
+    name: "${{ matrix.pimcore }}, PHP ${{ matrix.php }}, Deps ${{ matrix.dependencies }}, Shard ${{ matrix.shard }}/4"
 
     steps:
       - uses: actions/checkout@v7
@@ -172,13 +179,36 @@ jobs:
         run: symfony server:start --port=9080 --dir=public --daemon --no-tls
 
       - name: Run Behat
-        run: vendor/bin/behat --strict --no-interaction -vvv -f progress --config behat.yml.dist -p ui
+        run: |
+          suites=$(php .github/bin/behat-shard.php --profile=ui --shard=${{ matrix.shard }} --shards=4)
+
+          if [ -z "$suites" ]; then
+            echo "No suites assigned to this shard."
+
+            exit 0
+          fi
+
+          # Behat takes a single --suite, so a shard runs its suites one after the other. Each of
+          # them runs even when an earlier one failed: stopping at the first failure would hide
+          # the rest of the shard's scenarios behind another round trip.
+          status=0
+
+          for suite in $suites; do
+            echo "::group::behat --suite=$suite"
+
+            vendor/bin/behat --strict --no-interaction -vvv -f progress --config behat.yml.dist -p ui --suite "$suite" || status=1
+
+            echo "::endgroup::"
+          done
+
+          exit $status
 
       - name: Upload Logs
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: "Logs (PHP ${{ matrix.php }}, Symfony ${{ matrix.pimcore }})"
+          # Artifact names have to be unique within a run, so the shard belongs in here.
+          name: "Logs (PHP ${{ matrix.php }}, Pimcore ${{ matrix.pimcore }}, Shard ${{ matrix.shard }})"
           path: |
             var/log/
             etc/build/

--- a/.github/workflows/packages_bundles.yml
+++ b/.github/workflows/packages_bundles.yml
@@ -15,6 +15,12 @@ on:
   schedule:
     - cron: "0 1 * * 1"
 
+# A newer push to the same pull request or branch supersedes the run that is still going; the
+# event name keeps a release or the weekly schedule from being cancelled by a push on the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 env:
   PIMCORE_SECRET: ${{ secrets.PIMCORE_SECRET }}
   PIMCORE_INSTALL_ENCRYPTION_SECRET: ${{ secrets.PIMCORE_SECRET }}
@@ -39,22 +45,39 @@ jobs:
 
       - name: "List Packages"
         id: create-list
-        run: echo "packages=$(find src/CoreShop/Bundle -mindepth 2 -maxdepth 2 -type f -name composer.json -exec dirname '{}' \; | sed -e 's/src\/CoreShop\///g' | sort | jq  --raw-input . | jq --slurp . | jq -c .)" >> $GITHUB_OUTPUT
+        # A job per package spends more time checking out the repository and setting up PHP than
+        # it spends on the package itself, and it puts one check per package on every pull
+        # request. The packages are handed out in chunks instead: the same work, a fraction of
+        # the setup, and a check list that can still be read.
+        run: |
+          chunks=$(find src/CoreShop/Bundle -mindepth 2 -maxdepth 2 -type f -name composer.json -exec dirname '{}' \; \
+            | sed -e 's/src\/CoreShop\///g' \
+            | sort \
+            | jq --raw-input . \
+            | jq --slurp --compact-output --argjson size "$CHUNK_SIZE" \
+              '[range(0; length; $size) as $i | {index: ($i / $size + 1 | floor), packages: (.[$i:$i + $size] | join(" "))}]')
+
+          echo "chunks=$chunks" >> "$GITHUB_OUTPUT"
+          echo "$chunks" | jq .
+        env:
+          # Chunks run in parallel, the packages within a chunk one after another. Larger chunks
+          # save setup time and shorten the check list; smaller ones use more runners at once.
+          CHUNK_SIZE: 8
 
     outputs:
-      packages: "${{ steps.create-list.outputs.packages }}"
+      chunks: "${{ steps.create-list.outputs.chunks }}"
 
   test-packages:
     needs: list
     runs-on: ubuntu-latest
-    name: "${{ matrix.package }}, PHP ${{ matrix.php }}, Pimcore ${{ matrix.pimcore }}, Deps ${{ matrix.dependencies }}"
+    name: "Chunk ${{ matrix.chunk.index }}, PHP ${{ matrix.php }}, Pimcore ${{ matrix.pimcore }}, Deps ${{ matrix.dependencies }}"
     strategy:
       fail-fast: false
       matrix:
         php: [ 8.3, 8.4 ]
         pimcore: [ ^12.3 ]
         dependencies: [ highest, lowest ]
-        package: "${{ fromJson(needs.list.outputs.packages) }}"
+        chunk: "${{ fromJson(needs.list.outputs.chunks) }}"
         exclude:
           - php: 8.4
             dependencies: lowest
@@ -79,37 +102,45 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-php-${{ matrix.php }}-package-${{ matrix.package }}-composer-${{ hashFiles(format('src/CoreShop/{0}/composer.json', matrix.package)) }}
+          key: ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.dependencies }}-packages-${{ hashFiles('src/CoreShop/Bundle/*/composer.json') }}
           restore-keys: |
-            ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.pimcore }}-package-${{ matrix.package }}-composer-
-            ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.pimcore }}-package-
+            ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.dependencies }}-packages-
+            ${{ runner.os }}-php-${{ matrix.php }}-
 
-      - name: Validate composer.json
-        run: composer validate --ansi --strict
-        working-directory: "src/CoreShop/${{ matrix.package }}"
-
-      - name: pimcore/pimcore
-        run: composer req pimcore/pimcore:${{ matrix.pimcore }} --no-interaction --no-scripts --no-update
-        env:
-          COMPOSER_ROOT_VERSION: dev-master
-        working-directory: "src/CoreShop/${{ matrix.package }}"
-
-      - if: matrix.dependencies == 'highest'
-        name: Install dependencies highest
-        run: composer update --no-progress --prefer-dist --optimize-autoloader
-        env:
-          COMPOSER_ROOT_VERSION: dev-master
-        working-directory: "src/CoreShop/${{ matrix.package }}"
-
-      - if: matrix.dependencies == 'lowest'
-        name: Install dependencies lowest
-        run: composer update --no-progress --prefer-dist --optimize-autoloader --prefer-lowest
-        env:
-          COMPOSER_ROOT_VERSION: dev-master
-        working-directory: "src/CoreShop/${{ matrix.package }}"
-
-      - name: STAN
+      - name: Validate, install and analyse
+        # Every package of the chunk is checked even when an earlier one failed, so one broken
+        # package does not hide the state of the rest behind another round trip.
         run: |
-          cp ../../../../phpstan-package.neon phpstan.neon
-          vendor/bin/phpstan analyse -c phpstan.neon . -l 3
-        working-directory: "src/CoreShop/${{ matrix.package }}"
+          status=0
+
+          for package in ${{ matrix.chunk.packages }}; do
+            echo "::group::$package"
+
+            (
+              set -e
+
+              cd "src/CoreShop/$package"
+
+              composer validate --ansi --strict
+              composer req pimcore/pimcore:${{ matrix.pimcore }} --no-interaction --no-scripts --no-update
+
+              if [ "${{ matrix.dependencies }}" = 'lowest' ]; then
+                composer update --no-progress --prefer-dist --optimize-autoloader --prefer-lowest
+              else
+                composer update --no-progress --prefer-dist --optimize-autoloader
+              fi
+
+              cp ../../../../phpstan-package.neon phpstan.neon
+              vendor/bin/phpstan analyse -c phpstan.neon . -l 3
+            ) || status=1
+
+            # Each package installs its own copy of Pimcore; a whole chunk of them at once does
+            # not fit on the runner.
+            rm -rf "src/CoreShop/$package/vendor"
+
+            echo "::endgroup::"
+          done
+
+          exit $status
+        env:
+          COMPOSER_ROOT_VERSION: dev-main

--- a/.github/workflows/packages_components.yml
+++ b/.github/workflows/packages_components.yml
@@ -14,6 +14,12 @@ on:
     types: [ created ]
   schedule:
     - cron: "0 1 * * 1"
+# A newer push to the same pull request or branch supersedes the run that is still going; the
+# event name keeps a release or the weekly schedule from being cancelled by a push on the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 env:
   PIMCORE_SECRET: ${{ secrets.PIMCORE_SECRET }}
   PIMCORE_INSTALL_ENCRYPTION_SECRET: ${{ secrets.PIMCORE_SECRET }}
@@ -39,23 +45,40 @@ jobs:
 
       - name: "List Packages"
         id: create-list
-        run: echo "packages=$(find src/CoreShop/Component -mindepth 2 -maxdepth 2 -type f -name composer.json -exec dirname '{}' \; | sed -e 's/src\/CoreShop\///g' | sort | jq  --raw-input . | jq --slurp . | jq -c .)" >> $GITHUB_OUTPUT
+        # A job per package spends more time checking out the repository and setting up PHP than
+        # it spends on the package itself, and it puts one check per package on every pull
+        # request. The packages are handed out in chunks instead: the same work, a fraction of
+        # the setup, and a check list that can still be read.
+        run: |
+          chunks=$(find src/CoreShop/Component -mindepth 2 -maxdepth 2 -type f -name composer.json -exec dirname '{}' \; \
+            | sed -e 's/src\/CoreShop\///g' \
+            | sort \
+            | jq --raw-input . \
+            | jq --slurp --compact-output --argjson size "$CHUNK_SIZE" \
+              '[range(0; length; $size) as $i | {index: ($i / $size + 1 | floor), packages: (.[$i:$i + $size] | join(" "))}]')
+
+          echo "chunks=$chunks" >> "$GITHUB_OUTPUT"
+          echo "$chunks" | jq .
+        env:
+          # Chunks run in parallel, the packages within a chunk one after another. Larger chunks
+          # save setup time and shorten the check list; smaller ones use more runners at once.
+          CHUNK_SIZE: 8
 
     outputs:
-      packages: "${{ steps.create-list.outputs.packages }}"
+      chunks: "${{ steps.create-list.outputs.chunks }}"
 
   test-packages:
     needs: list
     if: github.repository == 'coreshop/CoreShop'
     runs-on: ubuntu-latest
-    name: "${{ matrix.package }}, PHP ${{ matrix.php }}, Pimcore ${{ matrix.pimcore }}, Deps ${{ matrix.dependencies }}"
+    name: "Chunk ${{ matrix.chunk.index }}, PHP ${{ matrix.php }}, Pimcore ${{ matrix.pimcore }}, Deps ${{ matrix.dependencies }}"
     strategy:
       fail-fast: false
       matrix:
         php: [ 8.3, 8.4 ]
         pimcore: [ ^12.3 ]
         dependencies: [ highest, lowest ]
-        package: "${{ fromJson(needs.list.outputs.packages) }}"
+        chunk: "${{ fromJson(needs.list.outputs.chunks) }}"
         exclude:
           - php: 8.4
             dependencies: lowest
@@ -80,37 +103,45 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-php-${{ matrix.php }}-pimcore-${{ matrix.pimcore }}-package-${{ matrix.package }}-composer-${{ hashFiles(format('src/CoreShop/{0}/composer.json', matrix.package)) }}
+          key: ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.dependencies }}-packages-${{ hashFiles('src/CoreShop/Component/*/composer.json') }}
           restore-keys: |
-            ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.pimcore }}-package-${{ matrix.package }}-composer-
-            ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.pimcore }}-package-
+            ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.dependencies }}-packages-
+            ${{ runner.os }}-php-${{ matrix.php }}-
 
-      - name: Validate composer.json
-        run: composer validate --ansi --strict
-        working-directory: "src/CoreShop/${{ matrix.package }}"
-
-      - name: pimcore/pimcore
-        run: composer req pimcore/pimcore:${{ matrix.pimcore }} --no-interaction --no-scripts --no-update
-        env:
-          COMPOSER_ROOT_VERSION: dev-master
-        working-directory: "src/CoreShop/${{ matrix.package }}"
-
-      - if: matrix.dependencies == 'highest'
-        name: Install dependencies highest
-        run: composer update --no-progress --prefer-dist --optimize-autoloader
-        env:
-          COMPOSER_ROOT_VERSION: dev-master
-        working-directory: "src/CoreShop/${{ matrix.package }}"
-
-      - if: matrix.dependencies == 'lowest'
-        name: Install dependencies lowest
-        run: composer update --no-progress --prefer-dist --optimize-autoloader --prefer-lowest
-        env:
-          COMPOSER_ROOT_VERSION: dev-master
-        working-directory: "src/CoreShop/${{ matrix.package }}"
-
-      - name: STAN
+      - name: Validate, install and analyse
+        # Every package of the chunk is checked even when an earlier one failed, so one broken
+        # package does not hide the state of the rest behind another round trip.
         run: |
-          cp ../../../../phpstan-package.neon phpstan.neon
-          vendor/bin/phpstan analyse -c phpstan.neon . -l 3
-        working-directory: "src/CoreShop/${{ matrix.package }}"
+          status=0
+
+          for package in ${{ matrix.chunk.packages }}; do
+            echo "::group::$package"
+
+            (
+              set -e
+
+              cd "src/CoreShop/$package"
+
+              composer validate --ansi --strict
+              composer req pimcore/pimcore:${{ matrix.pimcore }} --no-interaction --no-scripts --no-update
+
+              if [ "${{ matrix.dependencies }}" = 'lowest' ]; then
+                composer update --no-progress --prefer-dist --optimize-autoloader --prefer-lowest
+              else
+                composer update --no-progress --prefer-dist --optimize-autoloader
+              fi
+
+              cp ../../../../phpstan-package.neon phpstan.neon
+              vendor/bin/phpstan analyse -c phpstan.neon . -l 3
+            ) || status=1
+
+            # Each package installs its own copy of Pimcore; a whole chunk of them at once does
+            # not fit on the runner.
+            rm -rf "src/CoreShop/$package/vendor"
+
+            echo "::endgroup::"
+          done
+
+          exit $status
+        env:
+          COMPOSER_ROOT_VERSION: dev-main

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -27,6 +27,13 @@ on:
   schedule:
     - cron: "0 1 * * 1"
 
+# A newer push to the same pull request or branch supersedes the run that is still going: the
+# older run would only report on a commit nobody looks at any more. The event name is part of the
+# group so that a release or the weekly schedule is never cancelled by a push on the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -66,7 +66,13 @@ jobs:
           MYSQL_DATABASE: coreshop_test
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        # Installing the Pimcore class definitions issues hundreds of CREATE/ALTER TABLE
+        # statements, and every one of them waits on an fsync. The test database lives and dies
+        # with the job, so it has no business touching the disk at all — a RAM disk takes the
+        # durability cost out of the DDL and out of the scenarios that write through it.
+        options: >-
+          --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+          --tmpfs /var/lib/mysql:rw,noexec,nosuid,size=2g
     name: "${{ matrix.pimcore }}, PHP ${{ matrix.php }}, Deps ${{ matrix.dependencies }}"
 
     steps:


### PR DESCRIPTION
A pull request currently waits about twenty minutes on CI, and almost all of
that is a single Behat process: `Run Behat` takes 460s in the domain job and
854s in the UI job, while everything around it — containers, PHP, Pimcore
install — adds up to roughly three minutes.

### Sharding

Behat suites can each run on their own via `--suite`, so they are the unit to
split by. Their sizes differ wildly, though — the cart suite alone holds 140
of the 522 domain scenarios — so a round-robin split would leave one runner
carrying the tail. `.github/bin/behat-shard.php` weights every suite by the
number of scenarios its tag filter matches and distributes them longest-first
onto the emptiest shard:

```
Shard 1/4 — 140 scenarios in 1 suite:  domain_cart
Shard 2/4 — 128 scenarios in 7 suites: domain_product, domain_order, …
Shard 3/4 — 127 scenarios in 6 suites: domain_shipping, domain_tracking, …
Shard 4/4 — 127 scenarios in 8 suites: domain_payment_provider, domain_index, …
```

The scenario count approximates the runtime rather than measuring it, which is
close enough to keep the shards within a percent of each other and needs no
timing data carried between runs.

It also drops the suites a profile matches nothing in. All suites live in the
`default` profile, so a `-p default` run today walks the 32 UI suites and pays
a kernel boot for each without running a scenario. The skipped suites are
listed in the log, because a suite turning up there unexpectedly would be one
whose scenarios nobody runs.

The cart suite is the floor: at 140 of 522 scenarios it is longer than an even
quarter, so a fifth shard would not help. Going below it means splitting that
suite by feature file, which is a separate change.

### Package matrices

`Packages Bundles` ran 114 jobs of well under a minute each, every one paying
~40s of checkout and PHP setup, and put one check per package on the pull
request. Packages are now handed out in chunks of eight — 15 jobs instead of
114, and with `Packages Components` the check list drops from about 200 entries
to under 30. Each package's `vendor/` is removed after its analysis, since a
whole chunk of Pimcore installations does not fit on a runner.

### Concurrency

None of the five workflows had a concurrency group, so a second push to a
branch left the superseded run competing for runners. The event name is part
of the group, so a release or the weekly schedule is never cancelled by a push
that happens to share its ref.

### Verification

The suite weights were cross-checked against an independent implementation and
agree suite for suite; the four shards together cover exactly the set of suites
a full run covers, without overlap, for both the `default` and `ui` profiles;
the feature-file parser was compared against every one of the 315 feature files
without a discrepancy. The chunking was run against the real package list — 38
bundles into 5 chunks, 28 components into 4, no package lost. `actionlint` is
clean apart from pre-existing SC2086 notices on untouched lines.

The numbers this actually delivers will show up on this pull request's own
checks, which is the point of opening it against 5.1 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)