### PR TITLE
[CI] Split only the active lines and refresh the gitsplit cache every run

### DIFF
--- a/.github/workflows/gitsplit.yml
+++ b/.github/workflows/gitsplit.yml
@@ -1,18 +1,14 @@
 name: Monorepo split
 on:
     workflow_dispatch: ~
+    # Only the lines that still receive commits. 2.x–4.0 are final and already live in
+    # the split repositories, so re-splitting them costs an hour for nothing.
     push:
         branches:
-            - next
-            - 2.0
-            - 2.1
-            - 2.2
-            - 3.0
-            - 3.1
-            - 4.0
             - 4.1
             - 5.0
             - 5.1
+            - 2026.x
         paths:
             - 'src/CoreShop/Bundle/**'
             - 'src/CoreShop/Component/**'
@@ -35,7 +31,14 @@ jobs:
                 uses: actions/cache@v6
                 with:
                     path: cache
-                    key: gitsplit-cache
+                    # A cache is only ever saved under a key that does not exist yet, so a static
+                    # key froze the split state at its first save and every eviction meant a full
+                    # rebuild (~70 min). Keying per run saves a fresh snapshot every time; the
+                    # prefix restore key picks up the newest one, from any branch (caches saved on
+                    # the default branch are visible everywhere).
+                    key: gitsplit-cache-${{ github.run_id }}
+                    restore-keys: |
+                        gitsplit-cache-
             -
                 name: Split repositories
                 uses: docker://jderusse/gitsplit:latest

--- a/.gitsplit.yml
+++ b/.gitsplit.yml
@@ -1,10 +1,11 @@
 cache_url: 'file://cache'
 project_url: 'https://@github.com/coreshop/CoreShop.git'
+# Only the lines that still receive commits are split. 2.x–4.0 and their tags are final and
+# already live in the split repositories; listing them here only makes a cache miss re-split
+# history nobody changes.
 origins:
-    - ^next$
-    - ^\d+\.\d+$
-    - ^\d+\.\d+\.\d+$
-    - '^\d+\.\d+\.\d+(?:-?(?:alpha|beta|rc)\.?\d*)?$'
+    - ^(4\.1|5\.0|5\.1|2026\.x)$
+    - '^(4\.1|5\.\d+|2026\.\d+)\.\d+(?:-?(?:alpha|beta|rc)\.?\d*)?$'
 splits:
     - { prefix: src/CoreShop/Component/Address, target: 'https://${GH_TOKEN}@github.com/coreshop/Address.git' }
     - { prefix: src/CoreShop/Bundle/AddressBundle, target: 'https://${GH_TOKEN}@github.com/coreshop/AddressBundle.git' }


### PR DESCRIPTION
Fixes #3221

- `.github/workflows/gitsplit.yml`: cache key `gitsplit-cache-${{ github.run_id }}` with `restore-keys: gitsplit-cache-`, so every run saves a fresh snapshot and the next one restores the newest (a static key is saved once and never again; an eviction then meant a ~70 min full rebuild). Push trigger limited to `4.1`, `5.0`, `5.1`, `2026.x`.
- `.gitsplit.yml`: origins limited to those branches and to the tags `4.1.*`, `5.*`, `2026.*` (pre-release suffixes included). 2.x–4.0 are final and already live in the split repositories.

Expected effect: cache hits stay at ~2 min; a miss re-splits only the active lines instead of the whole history. The first run after the merge starts from the current cache snapshot (or a miss) and saves the new per-run key.

Both files are per-branch: `5.0` and `2026.x` get the same change through the upmerge chain (the 2026.x file already lists `2026.x` instead of `next`); `4.1` would need a backport if its split should benefit too.

`actionlint` only reports the pre-existing SC2086 info on the untouched clone line.