### PR TITLE
[CI] Keep PHP deprecations out of the Behat shard suite list

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -180,7 +180,7 @@ jobs:
 
       - name: Run Behat
         run: |
-          suites=$(php .github/bin/behat-shard.php --shard=${{ matrix.shard }} --shards=4)
+          suites=$(php -d display_errors=stderr .github/bin/behat-shard.php --shard=${{ matrix.shard }} --shards=4)
 
           if [ -z "$suites" ]; then
             echo "No suites assigned to this shard."

--- a/.github/workflows/behat_ui.yml
+++ b/.github/workflows/behat_ui.yml
@@ -193,7 +193,7 @@ jobs:
 
       - name: Run Behat
         run: |
-          suites=$(php .github/bin/behat-shard.php --profile=ui --shard=${{ matrix.shard }} --shards=4)
+          suites=$(php -d display_errors=stderr .github/bin/behat-shard.php --profile=ui --shard=${{ matrix.shard }} --shards=4)
 
           if [ -z "$suites" ]; then
             echo "No suites assigned to this shard."


### PR DESCRIPTION
Closes #3224

## Change

`behat.yml` and `behat_ui.yml` invoke the shard script with `php -d display_errors=stderr`, so a deprecation printed by vendor code (react/promise on PHP 8.5) no longer lands in `$suites`. Nothing else changes; the script itself is untouched.

## Test

Reproduced from the logs of #3223 / #3219 (PHP 8.5 shards: `Case`, `statements`, `a`, … "suite is not found"); PHP 8.4 shards were already green. This PR's own PHP 8.5 shards are the verification.