### PR TITLE
[Release] 2026.2.1

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Application/Version.php
+++ b/src/CoreShop/Bundle/CoreBundle/Application/Version.php
@@ -23,7 +23,7 @@ final class Version
 
     public const string MINOR_VERSION = '2';
 
-    public const string RELEASE_VERSION = '0';
+    public const string RELEASE_VERSION = '1';
 
     public const string EXTRA_VERSION = '';
 


### PR DESCRIPTION
Patch release of the 2026.x line.

- Telemetry ping and license check, now shipped as its own bundle `coreshop/telemetry-bundle` (#3214, #3218 via upmerge #3223), required by `coreshop/enterprise-subscription-bundle`.
- CI: Behat shards no longer break on PHP 8.5 deprecations (#3225).

`Version::RELEASE_VERSION` → `1`; the `## 2026.2.1` changelog section already exists. After the merge: tag `2026.2.1` on the resulting build commit and publish the GitHub release with generated notes, as for 2026.2.0.