### PR TITLE
[Release] 5.1.1

### DIFF
--- a/src/CoreShop/Bundle/CoreBundle/Application/Version.php
+++ b/src/CoreShop/Bundle/CoreBundle/Application/Version.php
@@ -23,7 +23,7 @@ final class Version
 
     public const string MINOR_VERSION = '1';
 
-    public const string RELEASE_VERSION = '0';
+    public const string RELEASE_VERSION = '1';
 
     public const string EXTRA_VERSION = '';
 


### PR DESCRIPTION
Patch release of the 5.1 line.

- Telemetry ping and license check, shipped as its own bundle `coreshop/telemetry-bundle` (#3215, #3220), required by `coreshop/enterprise-subscription-bundle` on its 2025.x line.

`Version::RELEASE_VERSION` → `1`; the `## 5.1.1` changelog section already exists. After the merge: tag `5.1.1` on the resulting build commit and publish the GitHub release with generated notes, as for 5.1.0.