### PR TITLE
[CI] Point the upmerge artifact pathspec at the build-dist archives

### DIFF
--- a/.github/workflows/upmerge.yaml
+++ b/.github/workflows/upmerge.yaml
@@ -54,7 +54,7 @@ jobs:
           # ever passes to git, which is what bounds that resolution to build artifacts.
           # The trailing `/*` is load-bearing: a git pathspec containing a wildcard is matched
           # against the whole path, so without it nothing under the directory matches at all.
-          ARTIFACTS='src/CoreShop/Bundle/*/Resources/public/studio/*'
+          ARTIFACTS='src/CoreShop/Bundle/*/Resources/build-dist/*'
 
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'


### PR DESCRIPTION
The automatic upmerge on 2026.x aborted with `pathspec 'src/CoreShop/Bundle/*/Resources/public/studio/*' did not match any file(s) known to git` (run 33904717789): since #3205 the Studio builds live in `Resources/build-dist/build-<id>.zip`. The artifact pathspec (and the comment) now point there. Today's upmerge was done by hand in #3228.