### PR TITLE
[Docs] Point the demo links at the CoreShop 2026 demo

### DIFF
--- a/docs/00_Introduction.md
+++ b/docs/00_Introduction.md
@@ -25,7 +25,7 @@ Our documentation is organized into easy-to-navigate sections, each tailored to 
 
 ## Explore CoreShop in Action
 
-- **Live Demo**: Experience CoreShop firsthand and use our [CoreShop Demo](https://demo4.coreshop.org) as a blueprint
+- **Live Demo**: Experience CoreShop firsthand and use our [CoreShop Demo](https://demo2026.coreshop.org) as a blueprint
   for your implementations.
 
 For more information about Pimcore itself, visit [pimcore.com](https://pimcore.com).

--- a/docs/00_Introduction.md
+++ b/docs/00_Introduction.md
@@ -25,7 +25,7 @@ Our documentation is organized into easy-to-navigate sections, each tailored to 
 
 ## Explore CoreShop in Action
 
-- **Live Demo**: Experience CoreShop firsthand and use our [CoreShop Demo](https://demo2026.coreshop.org) as a blueprint
+- **Live Demo**: Experience CoreShop firsthand and use our [CoreShop Demo](https://demo2026.coreshop.dev) as a blueprint
   for your implementations.
 
 For more information about Pimcore itself, visit [pimcore.com](https://pimcore.com).

--- a/docs/01_Getting_Started/03_Demo.md
+++ b/docs/01_Getting_Started/03_Demo.md
@@ -8,7 +8,7 @@ business owner, or eCommerce enthusiast, our demos offer a valuable glimpse into
 ## Frontend Demo
 
 :::info
-[https://demo2026.coreshop.org](https://demo2026.coreshop.org)
+[https://demo2026.coreshop.dev](https://demo2026.coreshop.dev)
 :::
 
 ## Backend Demo
@@ -16,7 +16,7 @@ business owner, or eCommerce enthusiast, our demos offer a valuable glimpse into
 CoreShop 2026 runs on Pimcore Studio; there is no classic admin anymore.
 
 :::info
-[https://demo2026.coreshop.org/pimcore-studio](https://demo2026.coreshop.org/pimcore-studio)
+[https://demo2026.coreshop.dev/pimcore-studio](https://demo2026.coreshop.dev/pimcore-studio)
 
 Username: admin  / Password: coreshop
 :::

--- a/docs/01_Getting_Started/03_Demo.md
+++ b/docs/01_Getting_Started/03_Demo.md
@@ -8,19 +8,21 @@ business owner, or eCommerce enthusiast, our demos offer a valuable glimpse into
 ## Frontend Demo
 
 :::info
-[https://demo4.coreshop.org](https://demo4.coreshop.org)
+[https://demo2026.coreshop.org](https://demo2026.coreshop.org)
 :::
 
 ## Backend Demo
 
+CoreShop 2026 runs on Pimcore Studio; there is no classic admin anymore.
+
 :::info
-[https://demo4.coreshop.org/admin](https://demo4.coreshop.org/admin)
+[https://demo2026.coreshop.org/pimcore-studio](https://demo2026.coreshop.org/pimcore-studio)
 
 Username: admin  / Password: coreshop
 :::
 
+## Run it yourself
 
-:::tip
-You can also setup this demo locally by running `bin/console coreshop:install:demo`
-:::
+The demo is a public project on GitHub: [coreshop/demo2026](https://github.com/coreshop/demo2026). Clone it and start it
+with Docker Compose, or install the demo data into your own project with `bin/console coreshop:install:demo`.
 


### PR DESCRIPTION
Closes #3232

## Change

- `docs/00_Introduction.md`: "Live Demo" links https://demo2026.coreshop.org.
- `docs/01_Getting_Started/03_Demo.md`: frontend link → https://demo2026.coreshop.org; backend section now points at the Studio login https://demo2026.coreshop.org/pimcore-studio (CoreShop 2026 has no classic admin) and keeps the admin/coreshop credentials; new "Run it yourself" section linking the public source repository https://github.com/coreshop/demo2026 and the `coreshop:install:demo` command.

No other `demo4`/`demo3`/`ofcors.cloud`/`coreshop.dev` references exist in `docs/` or `README.md` on this line.

## Test

Markdown only; links verified to resolve: demo2026.coreshop.org (Studio) and the GitHub repository.